### PR TITLE
docs: add link to CRD explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - Cloud Management
 - Environments
 
+Have a look on all available CRDs in the [API reference](https://doc.crds.dev/github.com/SAP/crossplane-provider-btp@v1.0.0).
 Check the documentation for more detailed information on available capabilities for different kinds.
 
 ## Roadmap

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## About this project
 
-`crossplane-provider-btp` is a [Crossplane](https://crossplane.io/) Provider that handles the orchestration of account related resources on [SAP Business Technology Platform](https://www.sap.com/products/technology-platform.html):
+`crossplane-provider-btp` is a [Crossplane](https://crossplane.io/) provider that handles the orchestration of account related resources on [SAP Business Technology Platform](https://www.sap.com/products/technology-platform.html):
 
 - Subaccount
 - User Management


### PR DESCRIPTION
This PR adds a link to the CRD explorer from https://doc.crds.dev/, so that users can browse all available CRDs via: https://doc.crds.dev/github.com/SAP/crossplane-provider-btp@v1.0.0.