### PR TITLE
Fix: Continous updates on KymaEnvironment due to breaking provisioning API change 

### DIFF
--- a/internal/clients/kymaenvironment/kymaenvironment.go
+++ b/internal/clients/kymaenvironment/kymaenvironment.go
@@ -10,7 +10,6 @@ import (
 	provisioningclient "github.com/sap/crossplane-provider-btp/internal/openapi_clients/btp-provisioning-service-api-go/pkg"
 	"sigs.k8s.io/yaml"
 
-	v1alpha12 "github.com/sap/crossplane-provider-btp/apis/account/v1alpha1"
 	"github.com/sap/crossplane-provider-btp/apis/environment/v1alpha1"
 	"github.com/sap/crossplane-provider-btp/btp"
 )
@@ -129,6 +128,5 @@ func hasPrefix(buf []byte, prefix []byte) bool {
 
 func AddKymaDefaultParameters(parameters btp.InstanceParameters, instanceName string, resourceUID string) btp.InstanceParameters {
 	parameters[btp.KymaenvironmentParameterInstanceName] = instanceName
-	parameters[v1alpha12.SubaccountOperatorLabel] = resourceUID
 	return parameters
 }

--- a/internal/controller/environment/kyma/kymaenvironment_test.go
+++ b/internal/controller/environment/kyma/kymaenvironment_test.go
@@ -97,7 +97,7 @@ func TestObserve(t *testing.T) {
 						State:        internal.Ptr("OK"),
 						ModifiedDate: internal.Ptr(float32(2000000000000.000000)),
 						Labels:       internal.Ptr("}corrupted{"),
-						Parameters:   internal.Ptr("{\"orchestrate.cloud.sap/subaccount-operator\": \"1234\", \"name\":\"kyma\"}"),
+						Parameters:   internal.Ptr("{\"name\":\"kyma\"}"),
 					}, nil
 				}},
 				httpClient: mockedHttpClient("someKubeConfigContent"),
@@ -117,7 +117,7 @@ func TestObserve(t *testing.T) {
 				client: fake.MockClient{MockDescribeCluster: func(ctx context.Context, input *v1alpha1.KymaEnvironment) (*provisioningclient.EnvironmentInstanceResponseObject, error) {
 					return &provisioningclient.EnvironmentInstanceResponseObject{
 						State:      internal.Ptr("OK"),
-						Parameters: internal.Ptr("{\"orchestrate.cloud.sap/subaccount-operator\": \"1234\", \"name\":\"kyma\"}"),
+						Parameters: internal.Ptr("{\"name\":\"kyma\"}"),
 					}, nil
 				}},
 				cr: environment(withUID("1234")),
@@ -138,7 +138,7 @@ func TestObserve(t *testing.T) {
 						State:        internal.Ptr("OK"),
 						ModifiedDate: internal.Ptr(float32(2000000000000.000000)),
 						Labels:       internal.Ptr("{\"name\": \"kyma\", \"KubeconfigURL\": \"someUrl\"}"),
-						Parameters:   internal.Ptr("{\"orchestrate.cloud.sap/subaccount-operator\": \"1234\", \"name\":\"kyma\"}"),
+						Parameters:   internal.Ptr("{\"name\":\"kyma\"}"),
 					}, nil
 				}},
 				httpClient: mockedHttpClient(kubeConfigData),
@@ -167,7 +167,7 @@ func TestObserve(t *testing.T) {
 						State:        internal.Ptr("OK"),
 						ModifiedDate: internal.Ptr(float32(2000000000000.000000)),
 						Labels:       internal.Ptr("{\"name\": \"kyma\", \"KubeconfigURL\": \"someUrl\"}"),
-						Parameters:   internal.Ptr("{\"orchestrate.cloud.sap/subaccount-operator\": \"1234\", \"name\":\"kyma\"}"),
+						Parameters:   internal.Ptr("{\"name\":\"kyma\"}"),
 					}, nil
 				}},
 				httpClient: mockedHttpClient("someNotMatchingKubeConfigData"),


### PR DESCRIPTION
There was a change in the provisioning api, which leads to unknown parameters not being returned in a GET call. This lead to continous drift detection and therefor continous update calls to patch this specific operator label that we previously used.

This PR removes maintenance of that label. It has outgrown its use anyway, so removing that wasn't really a much of a question. 