### PR TITLE
fix: cannot create CF-ENV

### DIFF
--- a/btp/cisclient.go
+++ b/btp/cisclient.go
@@ -323,12 +323,20 @@ func (c *Client) CreateCloudFoundryOrg(
 func (c *Client) CreateCloudFoundryOrgIfNotExists(
 	ctx context.Context, instanceName string, serviceAccountEmail string, resourceUID string,
 	landscape string,
-) error {
-	environmentId, err := c.getEnvironmentId(ctx, instanceName, CloudFoundryEnvironmentType())
-	if environmentId == "" {
-		err = c.CreateCloudFoundryOrg(ctx, instanceName, serviceAccountEmail, resourceUID, landscape)
+) (*CloudFoundryOrg, error) {
+	org, err := c.GetCloudFoundryOrg(ctx, instanceName)
+	if err != nil {
+		return nil, err
 	}
-	return err
+	if org == nil || org.Id == "" {
+		err = c.CreateCloudFoundryOrg(ctx, instanceName, serviceAccountEmail, resourceUID, landscape)
+		if err != nil {
+			return nil, err
+		}
+		return c.GetCloudFoundryOrg(ctx, instanceName)
+	}
+
+	return org, err
 }
 
 func (c *Client) DeleteEnvironmentById(ctx context.Context, environmentId string) error {


### PR DESCRIPTION
This PR fixes the bug which occurred after the merge of #111:
- could not create cf-env anymore because of `nil pointer dereference` in `createClientWithType` method

### Before
Used `atProvider` to initiate the client, but during create this will not be existing (at least for initial creation of resource)

### After
Using `org` data directly from the created instance, not from `status`
