### PR TITLE
Fail test on timeout error

### DIFF
--- a/test/e2e/cloudfoundry_env_test.go
+++ b/test/e2e/cloudfoundry_env_test.go
@@ -32,7 +32,9 @@ func TestCloudFoundryEnvironment(t *testing.T) {
 		Assess(
 			"Await resources to become synced",
 			func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-				resources.WaitForResourcesToBeSynced(ctx, cfg, manifestDir, wait.WithTimeout(time.Minute*25))
+				if err := resources.WaitForResourcesToBeSynced(ctx, cfg, manifestDir, wait.WithTimeout(time.Minute*25)); err != nil {
+					t.Fatal(err)
+				}
 				return ctx
 			},
 		).

--- a/test/e2e/kyma_env_test.go
+++ b/test/e2e/kyma_env_test.go
@@ -35,7 +35,9 @@ func TestKymaEnvironment(t *testing.T) {
 		Assess(
 			"Await resources to become synced",
 			func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-				resources.WaitForResourcesToBeSynced(ctx, cfg, manifestDir, wait.WithTimeout(time.Minute*25))
+				if err := resources.WaitForResourcesToBeSynced(ctx, cfg, manifestDir, wait.WithTimeout(time.Minute*25)); err != nil {
+					t.Fatal(err)
+				}
 				return ctx
 			},
 		).


### PR DESCRIPTION
Some tests do not properly use the methods for waiting for success states.
In this case the tests are succeeding even though the healthy state could not be determined until timeout. 

This came up in this PR: https://github.com/SAP/crossplane-provider-btp/actions/runs/13993401441/job/39182398901#step:9:598

This PR fixes that.