### PR TITLE
ci: fix target of long running e2e tests

### DIFF
--- a/.github/workflows/cron_long_e2e_test.yaml
+++ b/.github/workflows/cron_long_e2e_test.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Run long e2e test
         timeout-minutes: 120
         run: |
-          make e2e-long
+          make test-e2e-long
         env:
           BUILD_ID: ${{ env.BUILD_ID }}
           CIS_CENTRAL_BINDING: ${{ secrets.CIS_CENTRAL_BINDING }}


### PR DESCRIPTION
tests are currently failing, since the target used is not found.