### PR TITLE
chore: add tests for subaccount connect method

### DIFF
--- a/internal/controller/account/subaccount/subaccount_test.go
+++ b/internal/controller/account/subaccount/subaccount_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sap/crossplane-provider-btp/internal/testutils"
 	trackingtest "github.com/sap/crossplane-provider-btp/internal/tracking/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	client "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/sap/crossplane-provider-btp/btp"
 )
@@ -719,6 +720,186 @@ func TestCreate(t *testing.T) {
 				t.Errorf("\n%s\ne.Create(...): -want cr, +got cr:\n%s\n", tc.reason, diff)
 			}
 
+		})
+	}
+}
+
+func TestConnect(t *testing.T) {
+	type args struct {
+		cr              resource.Managed
+		kubeObjects     []client.Object
+		serviceFnErr    error
+		serviceFnReturn *btp.Client
+	}
+	type newServiceArgs struct {
+		cisCreds []byte
+		saCreds  []byte
+	}
+	type want struct {
+		err            error
+		newServiceArgs newServiceArgs
+	}
+
+	tests := map[string]struct {
+		args args
+		want want
+	}{
+		"NilResource": {
+			args: args{
+				cr:          nil,
+				kubeObjects: []client.Object{},
+			},
+			want: want{
+				err: errors.New(errNotSubaccount),
+			},
+		},
+		"NoProviderConfig": {
+			args: args{
+				cr:          NewSubaccount("unittest-sa", WithProviderConfig(xpv1.Reference{Name: "unittest-pc"})),
+				kubeObjects: []client.Object{},
+			},
+			want: want{
+				err: errors.New("cannot get ProviderConfig"),
+			},
+		},
+		"NoCISCredentials": {
+			args: args{
+				cr: &v1alpha1.Subaccount{
+					Spec: v1alpha1.SubaccountSpec{
+						ResourceSpec: xpv1.ResourceSpec{
+							ProviderConfigReference: &xpv1.Reference{
+								Name: "pc-reference",
+							}},
+					},
+				},
+				kubeObjects: []client.Object{
+					testutils.NewProviderConfig("pc-reference", "cis-provider-secret", "sa-provider-secret"),
+				},
+			},
+			want: want{
+				err: errors.New("cannot get CIS credentials"),
+			},
+		},
+		"NoSACredentials": {
+			args: args{
+				cr: &v1alpha1.Subaccount{
+					Spec: v1alpha1.SubaccountSpec{
+						ResourceSpec: xpv1.ResourceSpec{
+							ProviderConfigReference: &xpv1.Reference{
+								Name: "pc-reference",
+							}},
+					},
+				},
+				kubeObjects: []client.Object{
+					testutils.NewProviderConfig("pc-reference", "cis-provider-secret", "sa-provider-secret"),
+					testutils.NewSecret("cis-provider-secret", nil),
+				},
+			},
+			want: want{
+				err: errors.New("cannot get Service Account credentials"),
+			},
+		},
+		"EmptyCISSecret": {
+			args: args{
+				cr: &v1alpha1.Subaccount{
+					Spec: v1alpha1.SubaccountSpec{
+						ResourceSpec: xpv1.ResourceSpec{
+							ProviderConfigReference: &xpv1.Reference{
+								Name: "pc-reference",
+							}},
+					},
+				},
+				kubeObjects: []client.Object{
+					testutils.NewProviderConfig("pc-reference", "cis-provider-secret", "sa-provider-secret"),
+					testutils.NewSecret("cis-provider-secret", nil),
+					testutils.NewSecret("sa-provider-secret", nil),
+				},
+			},
+			want: want{
+				err: errors.New("CF Secret is empty or nil, please check config & secrets referenced in provider config"),
+			},
+		},
+		"NewServiceFnError": {
+			args: args{
+				cr: &v1alpha1.Subaccount{
+					Spec: v1alpha1.SubaccountSpec{
+						ResourceSpec: xpv1.ResourceSpec{
+							ProviderConfigReference: &xpv1.Reference{
+								Name: "pc-reference",
+							}},
+					},
+				},
+				kubeObjects: []client.Object{
+					testutils.NewProviderConfig("pc-reference", "cis-provider-secret", "sa-provider-secret"),
+					testutils.NewSecret("cis-provider-secret", map[string][]byte{"data": []byte("someCISCreds")}),
+					testutils.NewSecret("sa-provider-secret", map[string][]byte{"credentials": []byte("someSACreds")}),
+				},
+				serviceFnReturn: &btp.Client{},
+				serviceFnErr:    errors.New("serviceFnError"),
+			},
+			want: want{
+				newServiceArgs: newServiceArgs{
+					cisCreds: []byte("someCISCreds"),
+					saCreds:  []byte("someSACreds"),
+				},
+				err: errors.New("serviceFnError"),
+			},
+		},
+		"ConnectSuccess": {
+			args: args{
+				cr: &v1alpha1.Subaccount{
+					Spec: v1alpha1.SubaccountSpec{
+						ResourceSpec: xpv1.ResourceSpec{
+							ProviderConfigReference: &xpv1.Reference{
+								Name: "pc-reference",
+							}},
+					},
+				},
+				kubeObjects: []client.Object{
+					testutils.NewProviderConfig("pc-reference", "cis-provider-secret", "sa-provider-secret"),
+					testutils.NewSecret("cis-provider-secret", map[string][]byte{"data": []byte("someCISCreds")}),
+					testutils.NewSecret("sa-provider-secret", map[string][]byte{"credentials": []byte("someSACreds")}),
+				},
+				serviceFnReturn: &btp.Client{},
+			},
+			want: want{
+				newServiceArgs: newServiceArgs{
+					cisCreds: []byte("someCISCreds"),
+					saCreds:  []byte("someSACreds"),
+				},
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			kube := testutils.NewFakeKubeClientBuilder().
+				AddResources(tc.args.kubeObjects...).
+				Build()
+			ctrl := connector{
+				kube:            &kube,
+				usage:           trackingtest.NoOpReferenceResolverTracker{},
+				resourcetracker: trackingtest.NoOpReferenceResolverTracker{},
+				newServiceFn: func(cisSecretData []byte, serviceAccountSecretData []byte) (*btp.Client, error) {
+					if tc.want.newServiceArgs.cisCreds != nil && string(tc.want.newServiceArgs.cisCreds) != string(serviceAccountSecretData) {
+						t.Errorf("Passed CIS Creds to newServiceFN do not match; Passed: %v, Expected: %v", cisSecretData, tc.want.newServiceArgs.cisCreds)
+					}
+					if tc.want.newServiceArgs.saCreds != nil && string(tc.want.newServiceArgs.saCreds) != string(serviceAccountSecretData) {
+						t.Errorf("Passed SA Creds to newServiceFN do not match; Passed: %v, Expected: %v", cisSecretData, tc.want.newServiceArgs.saCreds)
+					}
+					return tc.args.serviceFnReturn, tc.args.serviceFnErr
+				},
+			}
+			connect, err := ctrl.Connect(context.Background(), tc.args.cr)
+
+			if contained := testutils.ContainsError(err, tc.want.err); !contained {
+				t.Errorf("\ne.Connect(...): error \"%v\" not part of \"%v\"", err, tc.want.err)
+			}
+			if tc.want.err == nil {
+				if connect == nil {
+					t.Errorf("Expected connector to be != nil")
+				}
+			}
 		})
 	}
 }

--- a/internal/controller/account/subaccount/subaccount_test.go
+++ b/internal/controller/account/subaccount/subaccount_test.go
@@ -764,16 +764,9 @@ func TestConnect(t *testing.T) {
 		},
 		"NoCISCredentials": {
 			args: args{
-				cr: &v1alpha1.Subaccount{
-					Spec: v1alpha1.SubaccountSpec{
-						ResourceSpec: xpv1.ResourceSpec{
-							ProviderConfigReference: &xpv1.Reference{
-								Name: "pc-reference",
-							}},
-					},
-				},
+				cr: NewSubaccount("unittest-sa", WithProviderConfig(xpv1.Reference{Name: "unittest-pc"})),
 				kubeObjects: []client.Object{
-					testutils.NewProviderConfig("pc-reference", "cis-provider-secret", "sa-provider-secret"),
+					testutils.NewProviderConfig("unittest-pc", "cis-provider-secret", "sa-provider-secret"),
 				},
 			},
 			want: want{
@@ -782,16 +775,9 @@ func TestConnect(t *testing.T) {
 		},
 		"NoSACredentials": {
 			args: args{
-				cr: &v1alpha1.Subaccount{
-					Spec: v1alpha1.SubaccountSpec{
-						ResourceSpec: xpv1.ResourceSpec{
-							ProviderConfigReference: &xpv1.Reference{
-								Name: "pc-reference",
-							}},
-					},
-				},
+				cr: NewSubaccount("unittest-sa", WithProviderConfig(xpv1.Reference{Name: "unittest-pc"})),
 				kubeObjects: []client.Object{
-					testutils.NewProviderConfig("pc-reference", "cis-provider-secret", "sa-provider-secret"),
+					testutils.NewProviderConfig("unittest-pc", "cis-provider-secret", "sa-provider-secret"),
 					testutils.NewSecret("cis-provider-secret", nil),
 				},
 			},
@@ -801,16 +787,9 @@ func TestConnect(t *testing.T) {
 		},
 		"EmptyCISSecret": {
 			args: args{
-				cr: &v1alpha1.Subaccount{
-					Spec: v1alpha1.SubaccountSpec{
-						ResourceSpec: xpv1.ResourceSpec{
-							ProviderConfigReference: &xpv1.Reference{
-								Name: "pc-reference",
-							}},
-					},
-				},
+				cr: NewSubaccount("unittest-sa", WithProviderConfig(xpv1.Reference{Name: "unittest-pc"})),
 				kubeObjects: []client.Object{
-					testutils.NewProviderConfig("pc-reference", "cis-provider-secret", "sa-provider-secret"),
+					testutils.NewProviderConfig("unittest-pc", "cis-provider-secret", "sa-provider-secret"),
 					testutils.NewSecret("cis-provider-secret", nil),
 					testutils.NewSecret("sa-provider-secret", nil),
 				},
@@ -821,16 +800,9 @@ func TestConnect(t *testing.T) {
 		},
 		"NewServiceFnError": {
 			args: args{
-				cr: &v1alpha1.Subaccount{
-					Spec: v1alpha1.SubaccountSpec{
-						ResourceSpec: xpv1.ResourceSpec{
-							ProviderConfigReference: &xpv1.Reference{
-								Name: "pc-reference",
-							}},
-					},
-				},
+				cr: NewSubaccount("unittest-sa", WithProviderConfig(xpv1.Reference{Name: "unittest-pc"})),
 				kubeObjects: []client.Object{
-					testutils.NewProviderConfig("pc-reference", "cis-provider-secret", "sa-provider-secret"),
+					testutils.NewProviderConfig("unittest-pc", "cis-provider-secret", "sa-provider-secret"),
 					testutils.NewSecret("cis-provider-secret", map[string][]byte{"data": []byte("someCISCreds")}),
 					testutils.NewSecret("sa-provider-secret", map[string][]byte{"credentials": []byte("someSACreds")}),
 				},
@@ -847,16 +819,9 @@ func TestConnect(t *testing.T) {
 		},
 		"ConnectSuccess": {
 			args: args{
-				cr: &v1alpha1.Subaccount{
-					Spec: v1alpha1.SubaccountSpec{
-						ResourceSpec: xpv1.ResourceSpec{
-							ProviderConfigReference: &xpv1.Reference{
-								Name: "pc-reference",
-							}},
-					},
-				},
+				cr: NewSubaccount("unittest-sa", WithProviderConfig(xpv1.Reference{Name: "unittest-pc"})),
 				kubeObjects: []client.Object{
-					testutils.NewProviderConfig("pc-reference", "cis-provider-secret", "sa-provider-secret"),
+					testutils.NewProviderConfig("unittest-pc", "cis-provider-secret", "sa-provider-secret"),
 					testutils.NewSecret("cis-provider-secret", map[string][]byte{"data": []byte("someCISCreds")}),
 					testutils.NewSecret("sa-provider-secret", map[string][]byte{"credentials": []byte("someSACreds")}),
 				},

--- a/internal/controller/account/subaccount/subaccount_test.go
+++ b/internal/controller/account/subaccount/subaccount_test.go
@@ -881,7 +881,7 @@ func TestConnect(t *testing.T) {
 				usage:           trackingtest.NoOpReferenceResolverTracker{},
 				resourcetracker: trackingtest.NoOpReferenceResolverTracker{},
 				newServiceFn: func(cisSecretData []byte, serviceAccountSecretData []byte) (*btp.Client, error) {
-					if tc.want.newServiceArgs.cisCreds != nil && string(tc.want.newServiceArgs.cisCreds) != string(serviceAccountSecretData) {
+					if tc.want.newServiceArgs.cisCreds != nil && string(tc.want.newServiceArgs.cisCreds) != string(cisSecretData) {
 						t.Errorf("Passed CIS Creds to newServiceFN do not match; Passed: %v, Expected: %v", cisSecretData, tc.want.newServiceArgs.cisCreds)
 					}
 					if tc.want.newServiceArgs.saCreds != nil && string(tc.want.newServiceArgs.saCreds) != string(serviceAccountSecretData) {

--- a/internal/controller/account/subaccount/subaccount_test.go
+++ b/internal/controller/account/subaccount/subaccount_test.go
@@ -890,13 +890,13 @@ func TestConnect(t *testing.T) {
 					return tc.args.serviceFnReturn, tc.args.serviceFnErr
 				},
 			}
-			connect, err := ctrl.Connect(context.Background(), tc.args.cr)
+			client, err := ctrl.Connect(context.Background(), tc.args.cr)
 
 			if contained := testutils.ContainsError(err, tc.want.err); !contained {
 				t.Errorf("\ne.Connect(...): error \"%v\" not part of \"%v\"", err, tc.want.err)
 			}
 			if tc.want.err == nil {
-				if connect == nil {
+				if client == nil {
 					t.Errorf("Expected connector to be != nil")
 				}
 			}


### PR DESCRIPTION
Adds unit test for the Connect method for the Subaccount CR.

Resolves #83 (the unit test part), the refactor into Client and Controller is still pending.