### PR TITLE
docs: show hint to use "" as planname for "default" values

### DIFF
--- a/apis/account/v1alpha1/subscription_types.go
+++ b/apis/account/v1alpha1/subscription_types.go
@@ -24,7 +24,7 @@ type SubscriptionParameters struct {
 	// AppName of the app to subscribe to
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="appName can't be updated once set"
 	AppName string `json:"appName"`
-	// PlanName to subscribe to
+	// PlanName to subscribe to, empty plannames are shown as "default" in cockpit, use "" instead
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="planName can't be updated once set"
 	PlanName string `json:"planName"`
 }

--- a/package/crds/account.btp.sap.crossplane.io_subscriptions.yaml
+++ b/package/crds/account.btp.sap.crossplane.io_subscriptions.yaml
@@ -163,7 +163,8 @@ spec:
                     - message: appName can't be updated once set
                       rule: self == oldSelf
                   planName:
-                    description: PlanName to subscribe to
+                    description: PlanName to subscribe to, empty plannames are shown
+                      as "default" in cockpit, use "" instead
                     type: string
                     x-kubernetes-validations:
                     - message: planName can't be updated once set


### PR DESCRIPTION
We found that a lot of subscription apps have an empty planname. 
Setting the planname as empty does work, however its confusing because in the cockpit they are left as "default" instead. 

This PR adds documentation to make that fact apparent to users.