### PR TITLE
fix: remove error event for subaccount deletion

### DIFF
--- a/internal/controller/account/subaccount/subaccount.go
+++ b/internal/controller/account/subaccount/subaccount.go
@@ -290,6 +290,11 @@ func deleteBTPSubaccount(
 	}
 
 	deletionState := response.State
+
+	if deletionState == subaccountStateDeleting {
+		return nil
+	}
+
 	return errors.New(fmt.Sprintf("Deletion Pending: Current status: %s", deletionState))
 }
 


### PR DESCRIPTION
Resolves #155 

If the state of the Subaccount is already `DELETING` after the API call, then no error event will be created.