### PR TITLE
fix: ResourceUsage error during its removal

### DIFF
--- a/internal/controller/account/resourceusage/reconciler.go
+++ b/internal/controller/account/resourceusage/reconciler.go
@@ -33,11 +33,6 @@ const (
 	errUpdateStatus = "cannot update ResourceUsage status"
 )
 
-// Event reasons.
-const (
-	reasonAccount event.Reason = "UsageAccounting"
-)
-
 // Condition types and reasons.
 const (
 	TypeTerminating xpv1.ConditionType   = "Terminating"
@@ -138,11 +133,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{}, errors.Wrap(resource.IgnoreNotFound(err), errGetPC)
 	}
 
-	log = log.WithValues(
-		"uid", ru.GetUID(),
-		"version", ru.GetResourceVersion(),
-		"name", ru.GetName(),
-	)
 	// check if target is still in place (on delete)
 	target, err := r.tracker.ResolveTarget(ctx, *ru)
 	if resource.IgnoreNotFound(err) != nil {

--- a/internal/controller/account/resourceusage/reconciler_test.go
+++ b/internal/controller/account/resourceusage/reconciler_test.go
@@ -107,6 +107,8 @@ func TestReconciler(t *testing.T) {
 					Client: &test.MockClient{
 						MockGet:          test.NewMockGetFn(nil, GetDeletedResourceUsageAndTarget),
 						MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
+						MockUpdate:       test.NewMockUpdateFn(nil),
+						MockDelete:       test.NewMockDeleteFn(nil),
 					},
 					Scheme: fake.SchemeWith(&v1alpha1.ResourceUsage{}, &v1alpha1.ResourceUsageList{}),
 				},


### PR DESCRIPTION
This PR fixes the problem with excessive logging bug described in #79 
Normally switching off logging would do the trick, but the functionality of deleting ResourceUsage finalizer was not working completely.
The code inserted ensure that when ResourceUsage is marked as deleted, its underlying finalizer and k8s resource is also deleted.