### PR TITLE
Feat/custom user agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ NPROCS ?= 1
 GO_TEST_PARALLEL := $(shell echo $$(( $(NPROCS) / 2 )))
 GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/provider
 GO_LDFLAGS += -X $(GO_PROJECT)/internal/version.Version=$(VERSION)
+# this version will eventually be passed to the terraform provider
+GO_LDFLAGS += -X $(GO_PROJECT)/internal/version.ProviderVersion=$(VERSION)
+
 GO_SUBDIRS += cmd internal apis
 GO111MODULE = on
 -include build/makelib/golang.mk

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"
@@ -12,6 +13,7 @@ import (
 	"github.com/sap/crossplane-provider-btp/config"
 	"github.com/sap/crossplane-provider-btp/internal/clients/tfclient"
 	"github.com/sap/crossplane-provider-btp/internal/features"
+	"github.com/sap/crossplane-provider-btp/internal/version"
 	"gopkg.in/alecthomas/kingpin.v2"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -89,6 +91,9 @@ func main() {
 
 	cfg, err := ctrl.GetConfig()
 	kingpin.FatalIfError(err, "Cannot get API server rest config")
+
+	os.Setenv("BTP_APPEND_USER_AGENT", version.ProviderVersion)
+	bla := os.Getenv("BTP_APPEND_USER_AGENT") // ensure the env var is set
 
 	mgr, err := ctrl.NewManager(
 		ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -92,8 +92,9 @@ func main() {
 	cfg, err := ctrl.GetConfig()
 	kingpin.FatalIfError(err, "Cannot get API server rest config")
 
-	os.Setenv("BTP_APPEND_USER_AGENT", version.ProviderVersion)
-	bla := os.Getenv("BTP_APPEND_USER_AGENT") // ensure the env var is set
+	// Set custom user agent for terraform http calls via env variable
+	envErr := os.Setenv("BTP_APPEND_USER_AGENT", fmt.Sprintf("crossplane/%s", version.ProviderVersion))
+	kingpin.FatalIfError(envErr, "Cannot set environment variable BTP_APPEND_USER_AGENT")
 
 	mgr, err := ctrl.NewManager(
 		ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-var ProviderVersion string = "crossplane/dev"
+var ProviderVersion string = "dev"

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,3 @@
+package version
+
+var ProviderVersion string = "crossplane/dev"


### PR DESCRIPTION
Relates to #200 

Sets a custom user agent for tf http calls as described in [issue](https://github.com/SAP/terraform-provider-btp/issues/622).

**Format** 
`crossplane/<provider_version>` (<provider_version> defaults to "dev" when running in local)
**Format of whole user agent (as defined by tf provider)**
`terraform/<tf_version> terraform-provider-btp/<tf_provider_version> custom-user-agent/crossplane/<provider_version`
