### PR TITLE
fix: e2e test failing after crossplane v2 release

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -91,7 +91,7 @@ func SetupClusterWithCrossplane(namespace string) {
 	}
 	testenv.Setup(
 		envfuncs.CreateKindCluster(kindClusterName),
-		xpenvfuncs.Conditional(xpenvfuncs.InstallCrossplane(kindClusterName, xpenvfuncs.Registry(setup.DockerRegistry)), firstSetup),
+		xpenvfuncs.Conditional(xpenvfuncs.InstallCrossplane(kindClusterName, xpenvfuncs.Registry(setup.DockerRegistry), xpenvfuncs.Version("1.20.1")), firstSetup),
 		xpenvfuncs.Conditional(
 			xpenvfuncs.InstallCrossplaneProvider(
 				kindClusterName, xpenvfuncs.InstallCrossplaneProviderOptions{


### PR DESCRIPTION
Crossplane v2 has been released as stable a few days ago and it doesnt work with our current e2e test setup. 
For now, setting the version fix should get our e2e tests going again.

We have to update xp-testing and then revalidate again. This is done in #263 

It seems like v2 doesnt support the controlerconfig cr but maybe more (this cr is deprecated anyway). Further investigation should be done AFTER we use the latest xp-testing with the DeploymentRuntime Config to replace the deprecated controlerconfig.