### PR TITLE
feat(e2e-long) test filter: trigger run of single tests

### DIFF
--- a/.github/workflows/cron_long_e2e_test.yaml
+++ b/.github/workflows/cron_long_e2e_test.yaml
@@ -4,6 +4,10 @@ name: Long E2E Test
 
 on:
   workflow_dispatch:
+    inputs:
+      testFilter:
+        description: 'testFilter string that will be passed to make e2e-long testFilter=functionNameOfTest.'
+        required: false
   schedule:
     - cron: '10 1 * * 1-5'  # every weekday at 1:10 AM
 
@@ -53,7 +57,11 @@ jobs:
       - name: Run long e2e test
         timeout-minutes: 180
         run: |
-          make test-e2e-long
+          if [ -n "${{ github.event.inputs.testFilter }}" ]; then
+            make test-e2e-long testFilter=${{ github.event.inputs.testFilter }};
+          else
+            make test-e2e-long;
+          fi
         env:
           BUILD_ID: ${{ env.BUILD_ID }}
           CIS_CENTRAL_BINDING: ${{ secrets.CIS_CENTRAL_BINDING }}

--- a/Makefile
+++ b/Makefile
@@ -242,12 +242,12 @@ test-e2e: $(KIND) $(HELM3) build generate-test-crs
 	@UUT_CONFIG=$(BUILD_REGISTRY)/$(subst crossplane-,crossplane/,$(PROJECT_NAME)):$(VERSION) UUT_CONTROLLER=$(BUILD_REGISTRY)/$(subst crossplane-,crossplane/,$(PROJECT_NAME))-controller:$(VERSION) go test $(PROJECT_REPO)/test/... -tags=e2e -short -count=1 -timeout 30m
 	@$(OK) e2e tests passed
 
-
+#run single test-e2e-long test with <make e2e testFilter=functionNameOfTest>
 test-e2e-long: $(KIND) $(HELM3) build generate-test-crs
 	@$(INFO) running integration tests
 	@echo UUT_CONFIG=$$UUT_CONFIG
 	@echo UUT_CONTROLLER=$$UUT_CONTROLLER
-	go test -v  $(PROJECT_REPO)/test/... -tags=e2e -count=1 -test.v -timeout 240m
+	go test -v  $(PROJECT_REPO)/test/... -tags=e2e -count=1 -test.v -run '$(testFilter)' -timeout 240m
 	@$(OK) integration tests passed
 
 #run single e2e test with <make e2e testFilter=functionNameOfTest>

--- a/Makefile
+++ b/Makefile
@@ -249,6 +249,12 @@ test-e2e-long: $(KIND) $(HELM3) build generate-test-crs
 	@echo UUT_CONTROLLER=$$UUT_CONTROLLER
 	go test -v  $(PROJECT_REPO)/test/... -tags=e2e -count=1 -test.v -run '$(testFilter)' -timeout 240m 2>&1 | tee test-output.log
 	@$(OK) integration tests passed
+	@echo "===========Test Summary==========="
+	@grep -E "PASS|FAIL" test-output.log
+	@case `tail -n 1 test-output.log` in \
+     		*FAIL*) echo "❌ Error: Test failed"; exit 1 ;; \
+     		*) echo "✅ All tests passed"; $(OK) integration tests passed ;; \
+     esac
 
 #run single e2e test with <make e2e testFilter=functionNameOfTest>
 .PHONY: test-acceptance

--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,7 @@ test-e2e-long: $(KIND) $(HELM3) build generate-test-crs
 	@$(INFO) running integration tests
 	@echo UUT_CONFIG=$$UUT_CONFIG
 	@echo UUT_CONTROLLER=$$UUT_CONTROLLER
-	go test -v  $(PROJECT_REPO)/test/... -tags=e2e -count=1 -test.v -run '$(testFilter)' -timeout 240m
+	go test -v  $(PROJECT_REPO)/test/... -tags=e2e -count=1 -test.v -run '$(testFilter)' -timeout 240m 2>&1 | tee test-output.log
 	@$(OK) integration tests passed
 
 #run single e2e test with <make e2e testFilter=functionNameOfTest>


### PR DESCRIPTION
Our short tests allow to specify the `go test -run` parameter to define testFilter and then only run this test.
For the e2e-long, this is also helpful, especially when working with external systems that take many minutes.

When we now trigger a manual Long E2E Test, we have an input in the gh action that is passed to the `go test -run` parameter. Also I added the test summary from the short tests to the long tests.

Sample Test Run with this parameter runs only TestDirectory here (works): https://github.com/SAP/crossplane-provider-btp/actions/runs/16961721013