### PR TITLE
fix(deps): renovate runs go mod tidy after updating

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,10 +3,19 @@
   "extends": [
     "config:recommended"
   ],
+  "postUpdateOptions": [
+    "gomodTidy"
+  ],
   "customManagers": [
     {
-      "fileMatch": ["(^|/)Makefile$", "(^|/)Dockerfile$", "(^|/)config.yml$"],
-      "matchStrings": ["(export|ARG|--build-arg=) *TERRAFORM_PROVIDER_VERSION *[:|\\?]?= *(?<currentValue>\\d+\\.\\d+\\.\\d+)"],
+      "fileMatch": [
+        "(^|/)Makefile$",
+        "(^|/)Dockerfile$",
+        "(^|/)config.yml$"
+      ],
+      "matchStrings": [
+        "(export|ARG|--build-arg=) *TERRAFORM_PROVIDER_VERSION *[:|\\?]?= *(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
       "datasourceTemplate": "terraform-provider",
       "versioningTemplate": "hashicorp",
       "depNameTemplate": "SAP/btp"


### PR DESCRIPTION
I noticed several Renovate PRs in which `make reviewable` failed because it runs `go mod tidy` while renovate doesnt run it. 
So i added this option, hopefully making it easier to upgrade dependencies without manual intervention.