### PR TITLE
fix: Fix faulty erorr message for the BTP config provider

### DIFF
--- a/internal/controller/account/directory/directory_test.go
+++ b/internal/controller/account/directory/directory_test.go
@@ -118,7 +118,7 @@ func TestConnect(t *testing.T) {
 				},
 			},
 			want: want{
-				err: errors.New("CF Secret is empty or nil, please check config & secrets referenced in provider config"),
+				err: errors.New("CIS Secret is empty or nil, please check config & secrets referenced in provider config"),
 			},
 		},
 		"NewServiceFnError": {

--- a/internal/controller/account/subaccount/subaccount_test.go
+++ b/internal/controller/account/subaccount/subaccount_test.go
@@ -1060,7 +1060,7 @@ func TestConnect(t *testing.T) {
 				},
 			},
 			want: want{
-				err: errors.New("CF Secret is empty or nil, please check config & secrets referenced in provider config"),
+				err: errors.New("CIS Secret is empty or nil, please check config & secrets referenced in provider config"),
 			},
 		},
 		"NewServiceFnError": {

--- a/internal/controller/providerconfig/config.go
+++ b/internal/controller/providerconfig/config.go
@@ -29,7 +29,6 @@ const (
 	errNewClient          = "cannot create new Service"
 	errCisSecretEmpty     = "CIS Secret is empty or nil, please check config & secrets referenced in provider config"
 	errCisSecretCorrupted = "CIS Secret does not match expected format"
-	errCFSecretEmpty      = "CF Secret is empty or nil, please check config & secrets referenced in provider config"
 )
 
 // Setup adds a controller that reconciles ProviderConfigs by accounting for
@@ -95,7 +94,7 @@ func CreateClient(
 		return nil, errors.Wrap(err, errGetCFCreds)
 	}
 	if ServiceAccountSecretData == nil {
-		return nil, errors.New(errCFSecretEmpty)
+		return nil, errors.New(errCisSecretEmpty)
 
 	}
 


### PR DESCRIPTION
Fix error message for the empty secret. 
Remove unused error message. 