### PR TITLE
fix: e2e-long helm install

### DIFF
--- a/.github/workflows/cron_long_e2e_test.yaml
+++ b/.github/workflows/cron_long_e2e_test.yaml
@@ -33,9 +33,9 @@ jobs:
 
       - name: Install Helm
         run: |
-          curl https://baltocdn.com/helm/signing.asc | sudo gpg --dearmor -o /usr/share/keyrings/helm.gpg
+          curl -fsSL https://packages.buildkite.com/helm-linux/helm-debian/gpgkey | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
           sudo apt-get install apt-transport-https --yes
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+          echo "deb [signed-by=/usr/share/keyrings/helm.gpg] https://packages.buildkite.com/helm-linux/helm-debian/any/ any main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
           sudo apt-get update
           sudo apt-get install -y helm
 


### PR DESCRIPTION
Also apply fix https://github.com/SAP/crossplane-provider-btp/pull/304 also to e2e-long tests.