### PR TITLE
[DRAFT] ci: fix add-to-backlog-project workflow

### DIFF
--- a/.github/workflows/add-to-backlog-project.yml
+++ b/.github/workflows/add-to-backlog-project.yml
@@ -10,4 +10,4 @@ env:
 
 jobs:
   call-reusable-workflow:
-    uses: openmcp-project/.github/workflows/addRefinedIssuesToBacklog.yml@main
+    uses: openmcp-project/.github/.github/workflows/addRefinedIssuesToBacklog.yml@main

--- a/.github/workflows/add-to-backlog-project.yml
+++ b/.github/workflows/add-to-backlog-project.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: "0 7 * * *"  # Runs at 07:00 UTC every day
   workflow_dispatch:  # Allows manual trigger
+  pull_request:  # Runs on PRs for debug purposes
 
 env:
   ACTIONS_STEP_DEBUG: true


### PR DESCRIPTION
This PR tries to fix #340, but is still a draft

Error:

<img width="720" height="409" alt="image" src="https://github.com/user-attachments/assets/94103951-904e-4bc5-b696-c9074785eb1b" />
