### PR TITLE
feat: Import tests for `ServiceManager` und `CloudManagement`

### DIFF
--- a/test/e2e/cloudmanagement_test.go
+++ b/test/e2e/cloudmanagement_test.go
@@ -8,11 +8,13 @@ import (
 	"time"
 
 	"github.com/sap/crossplane-provider-btp/apis"
+	"github.com/sap/crossplane-provider-btp/apis/account/v1alpha1"
 	"github.com/sap/crossplane-provider-btp/apis/account/v1beta1"
 	"github.com/sap/crossplane-provider-btp/internal"
 	"sigs.k8s.io/e2e-framework/klient/wait"
 
 	"github.com/crossplane-contrib/xp-testing/pkg/resources"
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	res "sigs.k8s.io/e2e-framework/klient/k8s/resources"
@@ -24,6 +26,7 @@ var (
 	cisCreateName = "e2e-cis-created"
 	siName        = "e2e-si-created"
 	sbName        = "e2e-sb-created"
+	cmImportName  = "cm-import-test"
 )
 
 func TestCloudManagemen(t *testing.T) {
@@ -98,6 +101,130 @@ func TestCloudManagemen(t *testing.T) {
 	).Feature()
 
 	testenv.Test(t, crudFeatureSuite)
+}
+
+func TestCloudManagementImport(t *testing.T) {
+	importFeatureSuite := features.New("CloudManagement Import Flow").
+		Setup(
+			func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+				resources.ImportResources(ctx, t, cfg, "testdata/crs/cloudmanagement/env")
+				r, _ := res.New(cfg.Client().RESTConfig())
+				_ = apis.AddToScheme(r.GetScheme())
+
+				// Wait for the ServiceManager to be ready before creating CloudManagement
+				waitForResource(&v1beta1.ServiceManager{
+					ObjectMeta: metav1.ObjectMeta{Name: "e2e-sm-cis", Namespace: cfg.Namespace()},
+				}, cfg, t, wait.WithTimeout(15*time.Minute))
+
+				cm := &v1beta1.CloudManagement{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      cmImportName + "-create",
+						Namespace: cfg.Namespace(),
+					},
+					Spec: v1beta1.CloudManagementSpec{
+						ResourceSpec: xpv1.ResourceSpec{
+							ManagementPolicies: []xpv1.ManagementAction{
+								xpv1.ManagementActionObserve,
+								xpv1.ManagementActionCreate,
+								xpv1.ManagementActionUpdate,
+								xpv1.ManagementActionLateInitialize,
+							},
+							WriteConnectionSecretToReference: &xpv1.SecretReference{
+								Name:      cmImportName + "-create",
+								Namespace: cfg.Namespace(),
+							},
+						},
+						ForProvider: v1beta1.CloudManagementParameters{
+							ServiceManagerRef: &xpv1.Reference{Name: "e2e-sm-cis"},
+							SubaccountRef:     &xpv1.Reference{Name: "cis-sa-test"},
+						},
+					},
+				}
+
+				err := cfg.Client().Resources().Create(ctx, cm)
+				if err != nil {
+					t.Errorf("Failed to create CloudManagement for import preparation: %v", err)
+				}
+
+				waitForResource(cm, cfg, t, wait.WithTimeout(10*time.Minute))
+
+				createdCM := &v1beta1.CloudManagement{}
+				MustGetResource(t, cfg, cmImportName+"-create", nil, createdCM)
+
+				actualExternalName := createdCM.GetAnnotations()["crossplane.io/external-name"]
+				t.Logf("Using external name for import: %s", actualExternalName)
+
+				AwaitResourceDeletionOrFail(ctx, t, cfg, createdCM, wait.WithTimeout(time.Minute*2))
+
+				ctx = context.WithValue(ctx, "actualExternalName", actualExternalName)
+
+				return ctx
+			},
+		).
+		Assess(
+			"Check Imported CloudManagement gets healthy", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+				actualExternalName := ctx.Value("actualExternalName").(string)
+
+				cm := &v1beta1.CloudManagement{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      cmImportName,
+						Namespace: cfg.Namespace(),
+						Annotations: map[string]string{
+							"crossplane.io/external-name": actualExternalName,
+						},
+					},
+					Spec: v1beta1.CloudManagementSpec{
+						ResourceSpec: xpv1.ResourceSpec{
+							ManagementPolicies: []xpv1.ManagementAction{xpv1.ManagementActionObserve},
+							WriteConnectionSecretToReference: &xpv1.SecretReference{
+								Name:      cmImportName,
+								Namespace: cfg.Namespace(),
+							},
+						},
+						ForProvider: v1beta1.CloudManagementParameters{
+							ServiceManagerRef: &xpv1.Reference{Name: "e2e-sm-cis"},
+							SubaccountRef:     &xpv1.Reference{Name: "cis-sa-test"},
+						},
+					},
+				}
+
+				err := cfg.Client().Resources().Create(ctx, cm)
+				if err != nil {
+					t.Errorf("Failed to create import CloudManagement: %v", err)
+				}
+
+				waitForResource(cm, cfg, t)
+
+				importedCM := &v1beta1.CloudManagement{}
+				MustGetResource(t, cfg, cmImportName, nil, importedCM)
+
+				if importedCM.Status.AtProvider.Status != v1beta1.CisStatusBound {
+					t.Error("CloudManagement Status not as expected")
+				}
+
+				assertProperSecretWritten(t, ctx, cfg, importedCM)
+
+				return ctx
+			},
+		).Teardown(
+		func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			cm := &v1beta1.CloudManagement{}
+			MustGetResource(t, cfg, cmImportName, nil, cm)
+
+			// Allow resource to be deleted for teardown
+			cm.Spec.ResourceSpec.ManagementPolicies = []xpv1.ManagementAction{xpv1.ManagementActionDelete, xpv1.ManagementActionObserve}
+			if err := cfg.Client().Resources().Update(ctx, cm); err != nil {
+				t.Errorf("Failed to update CloudManagement deletion policy: %v", err)
+			}
+
+			AwaitResourceDeletionOrFail(ctx, t, cfg, cm, wait.WithTimeout(time.Minute*10))
+
+			DeleteResourcesIgnoreMissing(ctx, t, cfg, "cloudmanagement/env", wait.WithTimeout(time.Minute*15))
+			return ctx
+		},
+	).Feature()
+
+	testenv.Test(t, importFeatureSuite)
 }
 
 func assertProperSecretWritten(t *testing.T, ctx context.Context, cfg *envconf.Config, cm *v1beta1.CloudManagement) {

--- a/test/e2e/cloudmanagement_test.go
+++ b/test/e2e/cloudmanagement_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/sap/crossplane-provider-btp/apis"
-	"github.com/sap/crossplane-provider-btp/apis/account/v1alpha1"
 	"github.com/sap/crossplane-provider-btp/apis/account/v1beta1"
 	"github.com/sap/crossplane-provider-btp/internal"
 	"sigs.k8s.io/e2e-framework/klient/wait"

--- a/test/e2e/resource_utils.go
+++ b/test/e2e/resource_utils.go
@@ -111,7 +111,7 @@ func AwaitResourceDeletionOrFail(ctx context.Context, t *testing.T, cfg *envconf
 
 	err := res.Delete(ctx, object)
 	if err != nil {
-		t.Fatalf("Failed to delete object %s.", identifier(object))
+		t.Fatalf("Failed to delete object %s: %s.", identifier(object), err)
 	}
 
 	err = wait.For(conditions.New(res).ResourceDeleted(object), opts...)

--- a/test/e2e/servicemanager_test.go
+++ b/test/e2e/servicemanager_test.go
@@ -191,8 +191,7 @@ func TestServiceManagerImport(t *testing.T) {
 
 			// Allow resource to be deleted for teardown
 			sm.Spec.ResourceSpec.ManagementPolicies = []xpv1.ManagementAction{xpv1.ManagementActionDelete, xpv1.ManagementActionObserve}
-			err = cfg.Client().Resources().Update(ctx, sm)
-			if err != nil {
+			if err := cfg.Client().Resources().Update(ctx, sm); err != nil {
 				t.Errorf("Failed to update ServiceManager deletion policy: %v", err)
 			}
 

--- a/test/e2e/servicemanager_test.go
+++ b/test/e2e/servicemanager_test.go
@@ -120,18 +120,11 @@ func TestServiceManagerImport(t *testing.T) {
 				waitForResource(sm, cfg, t, wait.WithTimeout(7*time.Minute))
 
 				createdSM := &v1beta1.ServiceManager{}
-				err = cfg.Client().Resources().Get(ctx, smImportName+"-create", cfg.Namespace(), createdSM)
-				if err != nil {
-					t.Errorf("Failed to get created ServiceManager: %v", err)
-				}
+
+				MustGetResource(t, cfg, smImportName+"-create", nil, createdSM)
 
 				actualExternalName := createdSM.GetAnnotations()["crossplane.io/external-name"]
 				t.Logf("Using external name for import: %s", actualExternalName)
-
-				err = cfg.Client().Resources().Delete(ctx, createdSM)
-				if err != nil {
-					t.Errorf("Failed to delete ServiceManager: %v", err)
-				}
 
 				AwaitResourceDeletionOrFail(ctx, t, cfg, createdSM, wait.WithTimeout(time.Minute*2))
 
@@ -195,7 +188,7 @@ func TestServiceManagerImport(t *testing.T) {
 				t.Errorf("Failed to update ServiceManager deletion policy: %v", err)
 			}
 
-			resources.AwaitResourceDeletionOrFail(ctx, t, cfg, sm)
+			AwaitResourceDeletionOrFail(ctx, t, cfg, sm, wait.WithTimeout(time.Minute*5))
 
 			DeleteResourcesIgnoreMissing(ctx, t, cfg, "servicemanager/import/environment", wait.WithTimeout(time.Minute*15))
 			return ctx

--- a/test/e2e/testdata/crs/servicemanager/import/environment/subaccount.yaml
+++ b/test/e2e/testdata/crs/servicemanager/import/environment/subaccount.yaml
@@ -1,0 +1,15 @@
+apiVersion: account.btp.sap.crossplane.io/v1alpha1
+kind: Subaccount
+metadata:
+  namespace: default
+  name: sm-import-sa-test
+spec:
+  forProvider:
+    displayName: $BUILD_ID-e2e-test-sa-servicemanager-import
+    region: eu10
+    subdomain: $BUILD_ID-e2e-test-sa-servicemanager-import-sub
+    labels:
+      safe-to-delete: [ "yes" ]
+      BUILD_ID: [ "$BUILD_ID" ]
+    subaccountAdmins:
+      - $TECHNICAL_USER_EMAIL


### PR DESCRIPTION
Closes #215 by implementing import testing for `ServiceManager` and `CloudManagement` like described in the issue.