### PR TITLE
chore: add do-not-merge label checker

### DIFF
--- a/.github/workflows/do-not-merge-block.yaml
+++ b/.github/workflows/do-not-merge-block.yaml
@@ -1,0 +1,15 @@
+name: "Do Not Merge Label Blocker"
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened]
+
+jobs:
+  do-not-merge-block:
+    if: contains(github.event.pull_request.labels.*.name, 'do-not-merge')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if 'do-not-merge' label is present
+        run: |
+          echo "The 'do-not-merge' label is present. Remove to succeed the job."
+          exit 1


### PR DESCRIPTION
This adds a workflow that fails if the do-not-merge label is present on a PR. 
Once this status check is included in the branch protection set for main, this failure effectively prevents merging.