### PR TITLE
test: verify external-name in ServiceManager Tf client

### DIFF
--- a/internal/clients/servicemanager/service_manager_tf_client_test.go
+++ b/internal/clients/servicemanager/service_manager_tf_client_test.go
@@ -108,7 +108,7 @@ func TestConnectResources(t *testing.T) {
 				bindingSpec: v1alpha1.SubaccountServiceBindingParameters{
 					SubaccountID:      internal.Ptr("subaccountId"),
 					Name:              internal.Ptr("another-custom-name"),
-					ServiceInstanceID: internal.Ptr("instanceID/bindingID"),
+					ServiceInstanceID: internal.Ptr("instanceID"),
 				},
 			},
 		},

--- a/internal/clients/servicemanager/service_manager_tf_client_test.go
+++ b/internal/clients/servicemanager/service_manager_tf_client_test.go
@@ -160,13 +160,13 @@ func TestConnectResources(t *testing.T) {
 				}
 				tfClient := resources.(*TfClient)
 				if diff := cmp.Diff(tc.want.instanceExternalName, meta.GetExternalName(tfClient.sInstance)); diff != "" {
-					t.Errorf("\ne.ConnectResources() binding spec: -want, +got:\n%s\n", diff)
+					t.Errorf("\ne.ConnectResources() instance externalName: -want, +got:\n%s\n", diff)
 				}
 				if diff := cmp.Diff(tc.want.instanceSpec, tfClient.sInstance.Spec.ForProvider); diff != "" {
 					t.Errorf("\ne.ConnectResources() instance spec: -want, +got:\n%s\n", diff)
 				}
 				if diff := cmp.Diff(tc.want.bindingExternalName, meta.GetExternalName(tfClient.sBinding)); diff != "" {
-					t.Errorf("\ne.ConnectResources() binding spec: -want, +got:\n%s\n", diff)
+					t.Errorf("\ne.ConnectResources() binding externalName: -want, +got:\n%s\n", diff)
 				}
 				if diff := cmp.Diff(tc.want.bindingSpec, tfClient.sBinding.Spec.ForProvider); diff != "" {
 					t.Errorf("\ne.ConnectResources() binding spec: -want, +got:\n%s\n", diff)


### PR DESCRIPTION
This PR adds
- check of diff in external-names to TestConnectResources of service_manager_tf_client_test.go. 
- a test case checking the split of ServiceManager external-name when mapping native CR to Tf ones.

Closes #317 