### PR TITLE
test: test usage of external-name for cf environment lookup

### DIFF
--- a/internal/clients/cfenvironment/cfenvironment_test.go
+++ b/internal/clients/cfenvironment/cfenvironment_test.go
@@ -1,7 +1,18 @@
 package environments
 
 import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/pkg/errors"
 	"github.com/sap/crossplane-provider-btp/apis/environment/v1alpha1"
+	"github.com/sap/crossplane-provider-btp/btp"
+	"github.com/sap/crossplane-provider-btp/internal"
+	"github.com/sap/crossplane-provider-btp/internal/clients/fakes"
+	provisioningclient "github.com/sap/crossplane-provider-btp/internal/openapi_clients/btp-provisioning-service-api-go/pkg"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // crWithManagers returns a CloudFoundryEnvironment CR with the given managers.
@@ -27,4 +38,129 @@ func toUserSlice(ss []string) []v1alpha1.User {
 		us = append(us, v1alpha1.User{Username: s, Origin: "sap.ids"})
 	}
 	return us
+}
+
+func TestCloudFoundryOrganization_getEnvironmentByNameAndOrg(t *testing.T) {
+	getBtpClient := func(instanceName string) btp.Client {
+		return btp.Client{
+			Credential: &btp.Credentials{
+				UserCredential: &btp.UserCredential{Username: "username", Password: "password"},
+			},
+			ProvisioningServiceClient: &fakes.MockProvisioningServiceClient{
+				ApiResponse: &provisioningclient.BusinessEnvironmentInstancesResponseCollection{
+					EnvironmentInstances: []provisioningclient.BusinessEnvironmentInstanceResponseObject{
+						{
+							EnvironmentType: internal.Ptr("cloudfoundry"),
+							Parameters:      internal.Ptr(fmt.Sprintf("{\"instance_name\":\"%s\"}", instanceName)),
+							Id:              internal.Ptr("1234"),
+							Labels:          internal.Ptr("{\"Org Id\":\"1234\",\"Org Name\":\"name\",\"API Endpoint\":\"endpoint\"}"),
+						},
+					},
+				},
+			},
+		}
+	}
+
+	type fields struct {
+		btp btp.Client
+	}
+	type args struct {
+		ctx context.Context
+		cr  v1alpha1.CloudFoundryEnvironment
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *provisioningclient.BusinessEnvironmentInstanceResponseObject
+		wantErr bool
+	}{
+		{
+			name: "Error",
+			fields: fields{
+				btp: btp.Client{
+					Credential: &btp.Credentials{
+						UserCredential: &btp.UserCredential{Username: "username", Password: "password"},
+					},
+					ProvisioningServiceClient: &fakes.MockProvisioningServiceClient{
+						Err: errors.New("error"),
+					},
+				},
+			},
+			args: args{
+				cr: v1alpha1.CloudFoundryEnvironment{
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{"crossplane.io/external-name": "extName"},
+					},
+					Spec: v1alpha1.CfEnvironmentSpec{
+						ForProvider: v1alpha1.CfEnvironmentParameters{
+							OrgName: "org",
+						},
+					},
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Not found - no environment matching external-name",
+			fields: fields{
+				btp: getBtpClient("somethingElse"),
+			},
+			args: args{
+				cr: v1alpha1.CloudFoundryEnvironment{
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{"crossplane.io/external-name": "extName"},
+					},
+					Spec: v1alpha1.CfEnvironmentSpec{
+						ForProvider: v1alpha1.CfEnvironmentParameters{
+							OrgName: "org",
+						},
+					},
+				},
+			},
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name: "Success - match by external-name",
+			fields: fields{
+				btp: getBtpClient("extName"),
+			},
+			args: args{
+				cr: v1alpha1.CloudFoundryEnvironment{
+					ObjectMeta: v1.ObjectMeta{
+						Annotations: map[string]string{"crossplane.io/external-name": "extName"},
+					},
+					Spec: v1alpha1.CfEnvironmentSpec{
+						ForProvider: v1alpha1.CfEnvironmentParameters{
+							OrgName: "org",
+						},
+					},
+				},
+			},
+			want: &provisioningclient.BusinessEnvironmentInstanceResponseObject{
+				EnvironmentType: internal.Ptr("cloudfoundry"),
+				Parameters:      internal.Ptr("{\"instance_name\":\"extName\"}"),
+				Id:              internal.Ptr("1234"),
+				Labels:          internal.Ptr("{\"Org Id\":\"1234\",\"Org Name\":\"name\",\"API Endpoint\":\"endpoint\"}"),
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := CloudFoundryOrganization{
+				btp: tt.fields.btp,
+			}
+			got, err := c.getEnvironmentByNameAndOrg(tt.args.ctx, tt.args.cr)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getEnvironmentByNameAndOrg() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getEnvironmentByNameAndOrg() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/internal/clients/fakes/provisioningserviceclient_fake.go
+++ b/internal/clients/fakes/provisioningserviceclient_fake.go
@@ -1,4 +1,4 @@
-package environments
+package fakes
 
 import (
 	"context"
@@ -8,8 +8,8 @@ import (
 )
 
 type MockProvisioningServiceClient struct {
-	err         error
-	apiResponse *client.BusinessEnvironmentInstancesResponseCollection
+	Err         error
+	ApiResponse *client.BusinessEnvironmentInstancesResponseCollection
 }
 
 // CreateEnvironmentInstance implements openapi.EnvironmentsAPI.
@@ -139,7 +139,7 @@ func (m *MockProvisioningServiceClient) GetEnvironmentInstances(ctx context.Cont
 
 // GetEnvironmentInstancesExecute implements openapi.EnvironmentsAPI.
 func (m *MockProvisioningServiceClient) GetEnvironmentInstancesExecute(r client.ApiGetEnvironmentInstancesRequest) (*client.BusinessEnvironmentInstancesResponseCollection, *http.Response, error) {
-	return m.apiResponse, &http.Response{}, m.err
+	return m.ApiResponse, &http.Response{}, m.Err
 }
 
 // UpdateEnvironmentInstance implements openapi.EnvironmentsAPI.

--- a/internal/clients/kymaenvironment/kymaenvironment_test.go
+++ b/internal/clients/kymaenvironment/kymaenvironment_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sap/crossplane-provider-btp/apis/environment/v1alpha1"
 	"github.com/sap/crossplane-provider-btp/btp"
 	"github.com/sap/crossplane-provider-btp/internal"
+	"github.com/sap/crossplane-provider-btp/internal/clients/fakes"
 	client "github.com/sap/crossplane-provider-btp/internal/openapi_clients/btp-provisioning-service-api-go/pkg"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -17,7 +18,7 @@ import (
 func TestEnvironmentsApiHandler_GetEnvironments(t *testing.T) {
 	tests := []struct {
 		name                string
-		mockEnvironmentsApi *MockProvisioningServiceClient
+		mockEnvironmentsApi *fakes.MockProvisioningServiceClient
 		mockCr              v1alpha1.KymaEnvironment
 
 		wantErr        error
@@ -26,18 +27,18 @@ func TestEnvironmentsApiHandler_GetEnvironments(t *testing.T) {
 	}{
 		{
 			name: "APIerror",
-			mockEnvironmentsApi: &MockProvisioningServiceClient{
-				err:         errors.New("apiError"),
-				apiResponse: nil,
+			mockEnvironmentsApi: &fakes.MockProvisioningServiceClient{
+				Err:         errors.New("apiError"),
+				ApiResponse: nil,
 			},
 
 			wantErr: errors.New("apiError"),
 		},
 		{
 			name: "EmptyResponse",
-			mockEnvironmentsApi: &MockProvisioningServiceClient{
-				err:         nil,
-				apiResponse: &client.BusinessEnvironmentInstancesResponseCollection{},
+			mockEnvironmentsApi: &fakes.MockProvisioningServiceClient{
+				Err:         nil,
+				ApiResponse: &client.BusinessEnvironmentInstancesResponseCollection{},
 			},
 			wantErr:      nil,
 			wantResponse: nil,
@@ -49,9 +50,9 @@ func TestEnvironmentsApiHandler_GetEnvironments(t *testing.T) {
 					Annotations: map[string]string{"crossplane.io/external-name": "1234"},
 				},
 			},
-			mockEnvironmentsApi: &MockProvisioningServiceClient{
-				err: nil,
-				apiResponse: &client.BusinessEnvironmentInstancesResponseCollection{
+			mockEnvironmentsApi: &fakes.MockProvisioningServiceClient{
+				Err: nil,
+				ApiResponse: &client.BusinessEnvironmentInstancesResponseCollection{
 					EnvironmentInstances: []client.BusinessEnvironmentInstanceResponseObject{
 						{
 							Parameters: internal.Ptr("{\"name\":\"kyma\"}"),
@@ -75,9 +76,9 @@ func TestEnvironmentsApiHandler_GetEnvironments(t *testing.T) {
 					Annotations: map[string]string{"crossplane.io/external-name": "kyma"},
 				},
 			},
-			mockEnvironmentsApi: &MockProvisioningServiceClient{
-				err: nil,
-				apiResponse: &client.BusinessEnvironmentInstancesResponseCollection{
+			mockEnvironmentsApi: &fakes.MockProvisioningServiceClient{
+				Err: nil,
+				ApiResponse: &client.BusinessEnvironmentInstancesResponseCollection{
 					EnvironmentInstances: []client.BusinessEnvironmentInstanceResponseObject{
 						{
 							Parameters: internal.Ptr("{\"name\":\"kyma\"}"),


### PR DESCRIPTION
This PR adds tests making sure external-name is used to match cf environment in lookups.

- I had to refactor the `DescribeInstance` func slightly (split its implementation) to allow easier testing, as it not only read environments but also tried to connect to them in order to read managers. 
- This was split into two steps: 1) reading env 2) reading managers.
- Added tests for 1) including external-name

Closes #318