### PR TITLE
chore: Update git submodule `build` url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "build"]
 	path = build
-	url = https://github.com/upbound/build
+	url = https://github.com/crossplane/build

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ KIND_NODE_IMAGE_TAG ?= v1.30.2
 # Setup Images
 DOCKER_REGISTRY ?= crossplane
 IMAGES = $(PROJECT_NAME) $(PROJECT_NAME)-controller
--include build/makelib/image.mk
+-include build/makelib/imagelight.mk
 
 export UUT_CONFIG = $(BUILD_REGISTRY)/$(subst crossplane-,crossplane/,$(PROJECT_NAME)):$(VERSION)
 export UUT_CONTROLLER = $(BUILD_REGISTRY)/$(subst crossplane-,crossplane/,$(PROJECT_NAME))-controller:$(VERSION)

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,8 @@ GO_SUBDIRS += cmd internal apis
 GO111MODULE = on
 -include build/makelib/golang.mk
 
+export GO_LINT_ARGS	?= --timeout 5m
+
 # kind-related versions
 KIND_VERSION ?= v0.23.0
 KIND_NODE_IMAGE_TAG ?= v1.30.2

--- a/cluster/images/crossplane-provider-btp-controller/Makefile
+++ b/cluster/images/crossplane-provider-btp-controller/Makefile
@@ -8,7 +8,7 @@ include ../../../build/makelib/common.mk
 # ====================================================================================
 #  Options
 IMAGE = $(BUILD_REGISTRY)/crossplane/provider-btp-controller
-include ../../../build/makelib/image.mk
+include ../../../build/makelib/imagelight.mk
 
 # ====================================================================================
 img.build:

--- a/cluster/images/crossplane-provider-btp/Makefile
+++ b/cluster/images/crossplane-provider-btp/Makefile
@@ -9,7 +9,7 @@ include ../../../build/makelib/common.mk
 DOCKER_REGISTRY ?= crossplane
 IMAGE = $(BUILD_REGISTRY)/crossplane/provider-btp
 OSBASEIMAGE = scratch
-include ../../../build/makelib/image.mk
+include ../../../build/makelib/imagelight.mk
 
 # ====================================================================================
 # Targets


### PR DESCRIPTION
The https://github.com/upbound/build repo has been archived and the author recommends to switch to https://github.com/crossplane/build. 

I used the provided commands to update the submodule url and sync it's contents.

```bash
git submodule set-url -- build https://github.com/crossplane/build
git submodule sync
cd build
git checkout main
git pull
```

However it seemed to work for you even without the update