### PR TITLE
fix: add e2e-test-success job for matrix status reporting

### DIFF
--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -167,3 +167,23 @@ jobs:
           BTP_TECHNICAL_USER: ${{ secrets.BTP_TECHNICAL_USER }}
           CLI_SERVER_URL: ${{ secrets.CLI_SERVER_URL }}
           GLOBAL_ACCOUNT: ${{ secrets.GLOBAL_ACCOUNT }}
+
+  # required for test matrix status reporting. Ignores cleanup-e2e job failure/success.
+  e2e-test-success:
+    runs-on: ubuntu-latest
+    needs: 
+      - prepare-matrix
+      - e2e-test
+    timeout-minutes: 1
+    if: always()
+    steps:
+      - name: Fail for failed prepare-matrix job
+        if: |
+          needs.prepare-matrix.result == 'failure' || 
+          needs.prepare-matrix.result == 'cancelled'
+        run: exit 1
+      - name: Fail for failed matrix jobs
+        if: |
+          needs.e2e-test.result == 'failure' || 
+          needs.e2e-test.result == 'cancelled'
+        run: exit 1


### PR DESCRIPTION
With the change on parallel matrix testing for e2e, we need a collection job to be used for the status reporting to be met to be able to merge a PR. This follows a common pattern like in [renovate](https://github.com/renovatebot/renovate/actions/runs/19458533518/workflow#L501) to check the result of matrix tests.