### PR TITLE
fix: CloudFoundryEnvironment legacy label format parsing

### DIFF
--- a/btp/cisclient.go
+++ b/btp/cisclient.go
@@ -586,14 +586,13 @@ func NewCloudFoundryOrgByLabel(rawLabels string) (*CloudFoundryOrg, error) {
 	}
 
 	oldOrgId, oldOrgIdExists := labels["Org ID:"]
-	oldOrgName, oldOrgNameExist := labels["Org Name:"]
 	oldApiEndpoint, oldApiEndpointExist := labels["API Endpoint:"]
 
-	if oldOrgIdExists || oldOrgNameExist || oldApiEndpointExist {
+	if oldOrgIdExists || oldApiEndpointExist {
 		//labels are in the old format
 		return &CloudFoundryOrg{
 			Id:          oldOrgId,
-			Name:        oldOrgName,
+			Name:        labels["Org Name"],
 			ApiEndpoint: oldApiEndpoint,
 		}, nil
 	}

--- a/btp/cisclient_test.go
+++ b/btp/cisclient_test.go
@@ -233,7 +233,7 @@ func TestCloudFoundryOrgByLabel(t *testing.T) {
 		{
 			name: "Old Format",
 			args: args{
-				labels: `{"Org ID:":"id", "Org Name:":"test-name", "API Endpoint:":"api-endpoint"}`,
+				labels: `{"Org ID:":"id", "Org Name":"test-name", "API Endpoint:":"api-endpoint"}`,
 			},
 			want: &CloudFoundryOrg{
 				Id:          "id",


### PR DESCRIPTION
A Cloud Foundry environment created long in the past have a different format of the Labels field:
```
// old format
labels={"Org ID:":"id", "Org Name":"test-name", "API Endpoint:":"api-endpoint"}
// new format
labels={"Org ID":"id", "Org Name":"test-name", "API Endpoint":"api-endpoint"}
```
The difference is the `:` in the end of the json key. This fix will handle both formats.

**NOTE** the missing `:` for `Org Name` in the old format, as this old format didnt include this.