### PR TITLE
fix: legacy label format parsing for connection details

### DIFF
--- a/internal/clients/cfenvironment/client.go
+++ b/internal/clients/cfenvironment/client.go
@@ -90,7 +90,7 @@ func GetConnectionDetails(instance *provisioningclient.BusinessEnvironmentInstan
 	if instance == nil {
 		return managed.ConnectionDetails{}, nil
 	}
-	var cflabels cfEnvironmentLabels
+	cflabels := make(map[string]string)
 	var label string
 	if instance.Labels != nil {
 		label = *instance.Labels
@@ -102,21 +102,23 @@ func GetConnectionDetails(instance *provisioningclient.BusinessEnvironmentInstan
 		v1alpha1.ResourceRaw: []byte(label),
 	}
 
-	if cflabels.OrgName != nil {
-		details[v1alpha1.ResourceOrgName] = []byte(*cflabels.OrgName)
+	if orgName, ok := cflabels["Org Name"]; ok {
+		details[v1alpha1.ResourceOrgName] = []byte(orgName)
 	}
-	if cflabels.OrgId != nil {
-		details[v1alpha1.ResourceOrgId] = []byte(*cflabels.OrgId)
+
+	for _, orgIdKey := range []string{"Org ID:", "Org ID"} {
+		if orgID, ok := cflabels[orgIdKey]; ok {
+			details[v1alpha1.ResourceOrgId] = []byte(orgID)
+			break
+		}
 	}
-	if cflabels.ApiEndpoint != nil {
-		details[v1alpha1.ResourceAPIEndpoint] = []byte(*cflabels.ApiEndpoint)
+
+	for _, apiEndpointKey := range []string{"API Endpoint:", "API Endpoint"} {
+		if apiEndpoint, ok := cflabels[apiEndpointKey]; ok {
+			details[v1alpha1.ResourceAPIEndpoint] = []byte(apiEndpoint)
+			break
+		}
 	}
 
 	return details, nil
-}
-
-type cfEnvironmentLabels struct {
-	ApiEndpoint *string `json:"API Endpoint,omitempty"`
-	OrgName     *string `json:"Org Name,omitempty"`
-	OrgId       *string `json:"Org ID,omitempty"`
 }


### PR DESCRIPTION
This PR fixes the parsing of legacy labels formats for CloudFoundryEnvironment when creating the connection details.

The parsing of legacy labels when creating a new CloudFoundryOrg was fixed in #426.