### PR TITLE
feat: `KymaModule` external-name compliance

### DIFF
--- a/internal/clients/kymamodule/module.go
+++ b/internal/clients/kymamodule/module.go
@@ -6,6 +6,7 @@ import (
 
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
 	"github.com/pkg/errors"
 	"github.com/sap/crossplane-provider-btp/apis/environment/v1alpha1"
 
@@ -68,7 +69,7 @@ func (c *KymaModuleClient) ObserveModule(ctx context.Context, moduleCr *v1alpha1
 	// Reason: we use one managed resource per module while kyma bundles it all in one cr.
 	// To resolve this many to one mapping, for every one of our module managed resource, we query the same kyma cr and find the correct name in it.
 	for _, module := range kyma.Status.Modules {
-		if module.Name == moduleCr.Spec.ForProvider.Name {
+		if module.Name == meta.GetExternalName(moduleCr) {
 			moduleCr.Status.AtProvider = module
 			return &module, nil
 		}


### PR DESCRIPTION
This PR ensures external-name compliance for the `KymaModule` resource. 

- fixes https://github.com/SAP/crossplane-provider-btp/issues/320