### PR TITLE
fix(workflow): remove duplicated env key in e2e test workflow

### DIFF
--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -10,9 +10,6 @@
 
 name: E2E Test
 
-env:
-  GO_VERSION: '1.25'
-
 on:
   workflow_dispatch:
   workflow_call:
@@ -55,6 +52,7 @@ permissions:
 env:
   # hardcoded BTP CLI version
   btp_cli_version: 2.90.2
+  GO_VERSION: '1.25'
 
 jobs:
   prepare-matrix:


### PR DESCRIPTION
In the change to go 1.25, we accidentally introduced a change in the e2e workflow file that breaks the github actions.
This fixes the env key in the workflow file.