### PR TITLE
fix: pass IDP origin to CF API login

### DIFF
--- a/internal/clients/cfenvironment/cfenvironment.go
+++ b/internal/clients/cfenvironment/cfenvironment.go
@@ -107,7 +107,7 @@ func (c CloudFoundryOrganization) createClient(environment *provisioningclient.B
 
 	cloudFoundryClient, err := newOrganizationClient(
 		org.Name, org.ApiEndpoint, org.Id, c.btp.Credential.UserCredential.Username,
-		c.btp.Credential.UserCredential.Password,
+		c.btp.Credential.UserCredential.Password, c.btp.Credential.UserCredential.Idp,
 	)
 	return cloudFoundryClient, err
 }
@@ -118,7 +118,7 @@ func (c CloudFoundryOrganization) createClientWithType(org *btp.CloudFoundryOrg)
 ) {
 	cloudFoundryClient, err := newOrganizationClient(
 		org.Name, org.ApiEndpoint, org.Id, c.btp.Credential.UserCredential.Username,
-		c.btp.Credential.UserCredential.Password,
+		c.btp.Credential.UserCredential.Password, c.btp.Credential.UserCredential.Idp,
 	)
 	return cloudFoundryClient, err
 }
@@ -200,10 +200,14 @@ func (o organizationClient) getManagerUsernames(ctx context.Context) ([]v1alpha1
 	return managers, nil
 }
 
-func newOrganizationClient(organizationName string, url string, orgId string, username string, password string) (
+func newOrganizationClient(organizationName string, url string, orgId string, username string, password string, origin string) (
 	*organizationClient, error,
 ) {
-	cfv3config, err := config.New(url, config.UserPassword(username, password))
+	configOpts := []config.Option{config.UserPassword(username, password)}
+	if origin != "" {
+		configOpts = append(configOpts, config.Origin(origin))
+	}
+	cfv3config, err := config.New(url, configOpts...)
 
 	if organizationName == "" {
 		return nil, fmt.Errorf("missing or empty organization name")

--- a/internal/clients/cfenvironment/cfenvironment_test.go
+++ b/internal/clients/cfenvironment/cfenvironment_test.go
@@ -40,6 +40,68 @@ func toUserSlice(ss []string) []v1alpha1.User {
 	return us
 }
 
+func TestNewOrganizationClient_Validation(t *testing.T) {
+	tests := []struct {
+		name    string
+		orgName string
+		url     string
+		orgId   string
+		user    string
+		pass    string
+		origin  string
+		wantErr bool
+	}{
+		{
+			name:    "missing org name returns error",
+			orgName: "",
+			url:     "https://api.cf.example.com",
+			orgId:   "org-guid",
+			user:    "user",
+			pass:    "pass",
+			origin:  "",
+			wantErr: true,
+		},
+		{
+			name:    "missing orgGuid returns error",
+			orgName: "my-org",
+			url:     "https://api.cf.example.com",
+			orgId:   "",
+			user:    "user",
+			pass:    "pass",
+			origin:  "",
+			wantErr: true,
+		},
+		{
+			name:    "empty origin is accepted",
+			orgName: "my-org",
+			url:     "https://api.cf.example.com",
+			orgId:   "org-guid",
+			user:    "user",
+			pass:    "pass",
+			origin:  "",
+			wantErr: true, // will fail on CF API connect, but not on validation
+		},
+		{
+			name:    "non-empty origin is accepted",
+			orgName: "my-org",
+			url:     "https://api.cf.example.com",
+			orgId:   "org-guid",
+			user:    "user",
+			pass:    "pass",
+			origin:  "custom-idp",
+			wantErr: true, // will fail on CF API connect, but not on validation
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := newOrganizationClient(tt.orgName, tt.url, tt.orgId, tt.user, tt.pass, tt.origin)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("newOrganizationClient() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestCloudFoundryOrganization_getEnvironmentByNameAndOrg(t *testing.T) {
 	getBtpClient := func(instanceName string) btp.Client {
 		return btp.Client{


### PR DESCRIPTION
## Summary

- `newOrganizationClient()` now accepts an `origin` parameter and conditionally passes it to `config.Origin()` in the go-cfclient configuration
- `createClient()` and `createClientWithType()` forward `UserCredential.Idp` from provider credentials
- Fixes CF API login returning `invalid_grant` when a custom identity provider is configured

Closes #506

## Changes

- **`internal/clients/cfenvironment/cfenvironment.go`**: Add `origin string` parameter to `newOrganizationClient()`, use `config.Option` slice with conditional `config.Origin()` append. Pass `c.btp.Credential.UserCredential.Idp` in both `createClient()` and `createClientWithType()`.
- **`internal/clients/cfenvironment/cfenvironment_test.go`**: Add `TestNewOrganizationClient_Validation` table-driven test covering missing org name, missing orgGuid, empty origin, and non-empty origin cases.

## Test plan

- [ ] Existing unit tests pass (`go test ./internal/clients/cfenvironment/...`)
- [ ] New `TestNewOrganizationClient_Validation` test passes
- [ ] Manual verification: CF login with custom IDP no longer returns `invalid_grant`

🤖 Generated with [Claude Code](https://claude.com/claude-code)