### PR TITLE
fix: support per-user IDP origin in initialOrgManagers

### DIFF
--- a/apis/environment/v1alpha1/cfenvironment_types.go
+++ b/apis/environment/v1alpha1/cfenvironment_types.go
@@ -47,7 +47,7 @@ type CfEnvironmentParameters struct {
 	// Cannot be updated after creation --> initial creation only
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="OrgManagers can't be updated once set"
 	// +optional
-	Managers []string `json:"initialOrgManagers,omitempty"`
+	Managers []User `json:"initialOrgManagers,omitempty"`
 
 	// Landscape, region of the cloud foundry org, e.g. cf-eu12
 	// must be set, when cloud foundry name is set

--- a/apis/environment/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/environment/v1alpha1/zz_generated.deepcopy.go
@@ -68,7 +68,7 @@ func (in *CfEnvironmentParameters) DeepCopyInto(out *CfEnvironmentParameters) {
 	*out = *in
 	if in.Managers != nil {
 		in, out := &in.Managers, &out.Managers
-		*out = make([]string, len(*in))
+		*out = make([]User, len(*in))
 		copy(*out, *in)
 	}
 }

--- a/examples/sample/cf-environment.yaml
+++ b/examples/sample/cf-environment.yaml
@@ -8,7 +8,8 @@
 #    cloudManagementRef:
 #      name: cis-local
 #    initialOrgManagers:
-#      - <EMAIL>
+#      - username: <EMAIL>
+#        origin: sap.ids  # optional, defaults to sap.ids
 #    landscape: cf-eu10
 #  SubaccountRef:
 #    name: test-123455

--- a/internal/clients/cfenvironment/cfenvironment.go
+++ b/internal/clients/cfenvironment/cfenvironment.go
@@ -139,8 +139,12 @@ func (c CloudFoundryOrganization) CreateInstance(ctx context.Context, cr v1alpha
 		return "", errors.Wrap(err, instanceCreateFailed)
 	}
 
-	for _, managerEmail := range cr.Spec.ForProvider.Managers {
-		if err := cloudFoundryClient.addManager(ctx, managerEmail, defaultOrigin); err != nil {
+	for _, manager := range cr.Spec.ForProvider.Managers {
+		origin := manager.Origin
+		if origin == "" {
+			origin = defaultOrigin
+		}
+		if err := cloudFoundryClient.addManager(ctx, manager.Username, origin); err != nil {
 			return "", errors.Wrap(err, instanceCreateFailed)
 		}
 	}

--- a/internal/clients/cfenvironment/cfenvironment_test.go
+++ b/internal/clients/cfenvironment/cfenvironment_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 // crWithManagers returns a CloudFoundryEnvironment CR with the given managers.
-func _(specManagers []string, statusManagers []string) v1alpha1.CloudFoundryEnvironment {
+func _(specManagers []v1alpha1.User, statusManagers []string) v1alpha1.CloudFoundryEnvironment {
 	return v1alpha1.CloudFoundryEnvironment{
 		Spec: v1alpha1.CfEnvironmentSpec{
 			ForProvider: v1alpha1.CfEnvironmentParameters{

--- a/internal/controller/environment/cloudfoundry/cfenvironment_test.go
+++ b/internal/controller/environment/cloudfoundry/cfenvironment_test.go
@@ -95,7 +95,7 @@ func TestObserve(t *testing.T) {
 					return false
 				}},
 				cr: environment(withUID("1234"),
-					withData(v1alpha1.CfEnvironmentParameters{OrgName: "test-org", Managers: []string{aUser.Username}}),
+					withData(v1alpha1.CfEnvironmentParameters{OrgName: "test-org", Managers: []v1alpha1.User{aUser}}),
 					withStatus(v1alpha1.CfEnvironmentObservation{
 						EnvironmentObservation: v1alpha1.EnvironmentObservation{
 							State:  internal.Ptr("OK"),
@@ -112,7 +112,7 @@ func TestObserve(t *testing.T) {
 				},
 				err: nil,
 				cr: environment(withUID("1234"), withConditions(xpv1.Available()),
-					withData(v1alpha1.CfEnvironmentParameters{OrgName: "test-org", Managers: []string{aUser.Username}}),
+					withData(v1alpha1.CfEnvironmentParameters{OrgName: "test-org", Managers: []v1alpha1.User{aUser}}),
 					withStatus(v1alpha1.CfEnvironmentObservation{
 						EnvironmentObservation: v1alpha1.EnvironmentObservation{
 							State:  internal.Ptr("OK"),
@@ -134,7 +134,7 @@ func TestObserve(t *testing.T) {
 					return false
 				}},
 				cr: environment(withUID("1234"),
-					withData(v1alpha1.CfEnvironmentParameters{Managers: []string{aUser.Username}}),
+					withData(v1alpha1.CfEnvironmentParameters{Managers: []v1alpha1.User{aUser}}),
 					withStatus(v1alpha1.CfEnvironmentObservation{
 						EnvironmentObservation: v1alpha1.EnvironmentObservation{
 							State:  internal.Ptr("CREATING"),
@@ -151,7 +151,7 @@ func TestObserve(t *testing.T) {
 				},
 				err: nil,
 				cr: environment(withUID("1234"), withConditions(xpv1.Unavailable()),
-					withData(v1alpha1.CfEnvironmentParameters{Managers: []string{aUser.Username}}),
+					withData(v1alpha1.CfEnvironmentParameters{Managers: []v1alpha1.User{aUser}}),
 					withStatus(v1alpha1.CfEnvironmentObservation{
 						EnvironmentObservation: v1alpha1.EnvironmentObservation{
 							State:  internal.Ptr("CREATING"),

--- a/package/crds/environment.btp.sap.crossplane.io_cloudfoundryenvironments.yaml
+++ b/package/crds/environment.btp.sap.crossplane.io_cloudfoundryenvironments.yaml
@@ -163,7 +163,18 @@ spec:
                       A list of users (with username/email and origin) to assign as the Org Manager role.
                       Cannot be updated after creation --> initial creation only
                     items:
-                      type: string
+                      description: User identifies a user by username and origin
+                      properties:
+                        origin:
+                          default: sap.ids
+                          description: Origin picks the IDP
+                          type: string
+                        username:
+                          description: Username at the identity provider
+                          type: string
+                      required:
+                      - username
+                      type: object
                     type: array
                     x-kubernetes-validations:
                     - message: OrgManagers can't be updated once set


### PR DESCRIPTION
## Summary

- Change `CfEnvironmentParameters.Managers` from `[]string` to `[]User` so each initial org manager can specify their IDP origin
- When origin is empty, default to `sap.ids` for backward compatibility
- Update CRD schema from `string` items to `object{username, origin}` with `username` required and `origin` defaulting to `sap.ids`

Closes #505

## Changes

- **`apis/environment/v1alpha1/cfenvironment_types.go`**: `Managers []string` → `[]User`
- **`apis/environment/v1alpha1/zz_generated.deepcopy.go`**: `make([]string` → `make([]User`
- **`internal/clients/cfenvironment/cfenvironment.go`**: `CreateInstance` loop iterates `[]User`, reads `manager.Username` and `manager.Origin` per user
- **`internal/clients/cfenvironment/cfenvironment_test.go`**: Helper signature `[]string` → `[]User`
- **`internal/controller/environment/cloudfoundry/cfenvironment_test.go`**: Test data `[]string{aUser.Username}` → `[]v1alpha1.User{aUser}` (4 places)
- **`package/crds/...cloudfoundryenvironments.yaml`**: CRD schema items changed from `type: string` to `type: object` with `username`/`origin` properties
- **`examples/sample/cf-environment.yaml`**: Example updated to use structured `{username, origin}` format

## Test plan

- [ ] Existing unit tests pass (`go test ./internal/clients/cfenvironment/...` and `go test ./internal/controller/environment/cloudfoundry/...`)
- [ ] CRD validation accepts both `username`-only and `username`+`origin` entries
- [ ] Manual verification: creating a CF environment with per-user IDP origins works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)