### PR TITLE
fix: add pollInterval to controller template

### DIFF
--- a/hack/helpers/controller/KIND_LOWER/KIND_LOWER.go.tmpl
+++ b/hack/helpers/controller/KIND_LOWER/KIND_LOWER.go.tmpl
@@ -53,6 +53,7 @@ func Setup(mgr ctrl.Manager, o controller.Options) error {
 			usage:        resource.NewProviderConfigUsageTracker(mgr.GetClient(), &apisv1alpha1.ProviderConfigUsage{}),
 			newServiceFn: newNoOpService}),
 		managed.WithLogger(o.Logger.WithValues("controller", name)),
+		managed.WithPollInterval(o.PollInterval),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithConnectionPublishers(cps...))
 


### PR DESCRIPTION
## Changes
Added `managed.WithPollInterval(o.PollInterval)` to the controller template file.

## Background
While all existing controllers already have pollInterval configuration, the template file (`hack/helpers/controller/KIND_LOWER/KIND_LOWER.go.tmpl`) used to generate new controllers was missing it. This PR ensures future generated controllers will include the poll interval configuration.

## Impact
- No changes to existing controllers
- Future generated controllers will be consistent with current ones
- Aligns template with established patterns

## Risk
None - this only affects the template for future code generation.