### PR TITLE
docs: add review suggestions from previous backoff controller flags PR 

### DIFF
--- a/apis/generate.go
+++ b/apis/generate.go
@@ -36,8 +36,8 @@ limitations under the License.
 // Run Upjet generator
 //go:generate go run ../cmd/generator/main.go ..
 
-// Inject custom ratelimiter settings on top of generated controllers
-//go:generate ../hack/helpers/ctrl_inject_ratelimiter.sh
+// Inject custom backoff settings on top of generated controllers
+//go:generate ../hack/helpers/ctrl_inject_backoff.sh
 
 // Run e2e test generator
 //go:generate go run ../test/e2e/generator/main.go ..

--- a/docs/user-stories/setup/configure-controller-flags.mdx
+++ b/docs/user-stories/setup/configure-controller-flags.mdx
@@ -13,10 +13,10 @@ These flags are passed as arguments to the provider's container process and can 
 |---|---|---|
 | `--sync` / `-s` | `1h` | How often **all** resources are re-checked for drift from the desired state (full sync interval). |
 | `--poll` | `1m` | How often **individual** resources are checked for drift from the desired state. |
-| `--max-reconcile-rate` | `3` | Global maximum number of resources reconciled per second. |
+| `--max-reconcile-rate` | `3` | Global maximum number of resources reconciled concurrently (parallel reconcile goroutines) |
 | `--backoff-base` | `1s` | Base duration for exponential backoff when a reconcile fails. The wait time after the first failure. |
 | `--backoff-max` | `60s` | Maximum duration for exponential backoff. The wait time will never exceed this value, regardless of how many failures have occurred. |
-| `--leader-election` / `-l` | `false` | Enable leader election for the controller manager. Can also be set via the `LEADER_ELECTION` environment variable. |
+| `--leader-election` / `-l` | `false` | Enable leader election for the controller manager. Used to ensure only one instance of the controller is active at a time while allowing multiple replicas to run simultaneously for failover. Can also be set via the `LEADER_ELECTION` environment variable. |
 | `--debug` / `-d` | `false` | Run with debug logging. |
 
 ### Exponential Backoff Details
@@ -30,6 +30,10 @@ The `--backoff-base` and `--backoff-max` flags control how the provider handles 
 Tuning these values is useful when:
 - The BTP API is rate-limiting your requests (increase `--backoff-base` and `--backoff-max`)
 - You want faster recovery from transient errors in a low-traffic environment (decrease `--backoff-base`)
+
+:::tip
+Avoid setting `--backoff-max` to a value that coincides with your `--poll` or `--sync` interval, as this can cause a burst of reconcile requests all firing at the same time. For example, if `--poll=1m`, prefer `--backoff-max=50s` or `--backoff-max=90s` rather than `60s`.
+:::
 
 ## Configure Flags via a `DeploymentRuntimeConfig`
 
@@ -60,7 +64,7 @@ The following example configures a slower poll interval and a more conservative 
                     - --poll=5m
                     - --max-reconcile-rate=5
                     - --backoff-base=5s
-                    - --backoff-max=120s
+                    - --backoff-max=90s
     ```
 
 2. Reference the `DeploymentRuntimeConfig` from your `Provider` resource:

--- a/hack/helpers/ctrl_inject_backoff.sh
+++ b/hack/helpers/ctrl_inject_backoff.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# This script injects using a custom ratelimiter for backoff into upjet based controllers
+# This script injects using custom backoff settings into upjet based controllers
 # since the controller generation is part of upjet we can't do that while generating,
 # so we amend this code afterwards
 set -euo pipefail


### PR DESCRIPTION
## Summary

Follow-up to #578 implementing the review feedback that wasn't addressed before merging:

- Rename `ctrl_inject_ratelimiter.sh` → `ctrl_inject_backoff.sh` (less confusing naming)
- Clarify `--max-reconcile-rate` description: it limits concurrent reconcile goroutines, not requests per second
- Expand `--leader-election` description to explain the single-active-instance + failover behavior
- Add tip warning against aligning `--backoff-max` with `--poll`/`--sync` intervals to avoid burst requests
- Fix example YAML: change `--backoff-max=120s` → `90s` so it doesn't coincide with `--poll=5m` or `--sync=2h`

---

_This PR was created with the help of [Claude Code](https://claude.ai/code)._
