### PR TITLE
fix(entitlement): avoid transient quota zero when deleting one of multiple entitlement CRs

### DIFF
--- a/internal/clients/entitlement/entitlement.go
+++ b/internal/clients/entitlement/entitlement.go
@@ -87,8 +87,12 @@ func (c EntitlementsClient) DeleteInstance(ctx context.Context, cr *v1alpha1.Ent
 	}
 
 	if isNumericQuota {
-		amount := 0
-		cr.Status.AtProvider.Required.Amount = &amount
+		// Only zero out if no other entitlements remain. If survivors exist,
+		// Required.Amount already holds the correct merged value from GenerateObservation.
+		if relatedEntitlements == nil || *relatedEntitlements == 0 {
+			amount := 0
+			cr.Status.AtProvider.Required.Amount = &amount
+		}
 	} else {
 		enabled := false
 		cr.Status.AtProvider.Required.Enable = &enabled


### PR DESCRIPTION
## Summary

- When deleting a numeric entitlement CR, `DeleteInstance` was unconditionally setting `Required.Amount` to 0 before calling `UpdateInstance`, even when `MergeRelatedEntitlements` had already computed the correct remaining quota from surviving CRs
- This caused a transient window where the BTP quota was set to 0, relying on surviving CRs to self-heal via their reconcile loop
- Fix: only zero the amount when no other entitlement CRs remain for the same subaccount/service/plan (`EntitlementsCount == 0`)

## Root Cause

In `DeleteInstance`, `GenerateObservation` is called before `DeleteInstance` with a filter that excludes the being-deleted CR — so `Required.Amount` already holds the correct merged value from surviving entitlements. The unconditional `amount := 0` override was discarding that correct value.

## Behaviour Change

| Scenario | Before | After |
|---|---|---|
| Delete last entitlement for a plan | BTP set to 0 ✓ | BTP set to 0 ✓ |
| Delete one of N entitlements for a plan | BTP transiently set to 0, self-healed by survivors | BTP set directly to correct remaining amount ✓ |