### PR TITLE
fix: prevent orphaned KymaEnvironmentBinding bindings 

### DIFF
--- a/internal/controller/kymaenvironmentbinding/kymaenvironmentbinding.go
+++ b/internal/controller/kymaenvironmentbinding/kymaenvironmentbinding.go
@@ -8,7 +8,9 @@ import (
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/pkg/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
@@ -37,6 +39,9 @@ const (
 	errStatusUpdate              = "while updating status"
 	errDelete                    = "while deleting bindings"
 	errDeleteInstances           = "while deleting instances"
+	errRollbackBinding           = "while rolling back binding after status update failure"
+
+	statusUpdateMaxRetries = 5
 )
 
 // A connector is expected to produce an ExternalClient when its Connect method
@@ -63,6 +68,36 @@ type external struct {
 // Since we dont need this, we only have it to fullfil the interface.
 func (c *external) Disconnect(ctx context.Context) error {
 	return nil
+}
+
+// updateStatusWithRetry writes desiredBindings to the CR status, retrying up to statusUpdateMaxRetries
+// times on conflict errors. On each attempt the CR is re-fetched to get the latest resourceVersion.
+// Non-conflict errors are returned immediately. If all retries are exhausted the last error is returned.
+func (c *external) updateStatusWithRetry(ctx context.Context, cr *v1alpha1.KymaEnvironmentBinding, desiredBindings []v1alpha1.Binding) error {
+	var lastErr error
+	for i := 0; i < statusUpdateMaxRetries; i++ {
+		if i > 0 {
+			select {
+			case <-time.After(time.Duration(100*(1<<uint(i-1))) * time.Millisecond):
+			case <-ctx.Done():
+				return errors.Wrap(ctx.Err(), errStatusUpdate)
+			}
+		}
+
+		if err := c.kube.Get(ctx, types.NamespacedName{Name: cr.Name, Namespace: cr.Namespace}, cr); err != nil {
+			return errors.Wrap(err, errStatusUpdate)
+		}
+		cr.Status.AtProvider.Bindings = desiredBindings
+
+		lastErr = c.kube.Status().Update(ctx, cr)
+		if lastErr == nil {
+			return nil
+		}
+		if !kerrors.IsConflict(lastErr) {
+			return errors.Wrap(lastErr, errStatusUpdate)
+		}
+	}
+	return errors.Wrap(lastErr, errStatusUpdate)
 }
 
 func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) {
@@ -194,9 +229,6 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 		ExpiresAt: metav1.NewTime(clientBinding.Metadata.ExpiresAt.UTC()),
 	}
 
-	// Add new binding to status
-	cr.Status.AtProvider.Bindings = append(cr.Status.AtProvider.Bindings, newBinding)
-	// Prepare connection details
 	connectionDetails := managed.ConnectionDetails{
 		"binding_id": []byte(newBinding.Id),
 		"expires_at": []byte(newBinding.ExpiresAt.UTC().String()),
@@ -204,9 +236,23 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 		"kubeconfig": []byte(clientBinding.Credentials.Kubeconfig),
 	}
 
+	// Re-fetch cr and write status with retry to handle optimistic concurrency conflicts.
+	// updateStatusWithRetry is self-contained: it re-fetches on every attempt.
+	desiredBindings := append(cr.Status.AtProvider.Bindings, newBinding)
+
+	if err := c.updateStatusWithRetry(ctx, cr, desiredBindings); err != nil {
+		// Status update failed after all retries. Roll back the binding on the provisioning API
+		// to prevent it from becoming orphaned and consuming one of the 10-binding slots.
+		rollbackErr := c.client.DeleteInstances(ctx, []v1alpha1.Binding{newBinding}, cr.Spec.KymaEnvironmentId)
+		if rollbackErr != nil {
+			return managed.ExternalCreation{}, errors.Errorf("%s; %s: %s", err, errRollbackBinding, rollbackErr)
+		}
+		return managed.ExternalCreation{}, err
+	}
+
 	return managed.ExternalCreation{
 		ConnectionDetails: connectionDetails,
-	}, errors.Wrap(c.kube.Status().Update(ctx, cr), errStatusUpdate)
+	}, nil
 }
 
 func (c *external) Update(ctx context.Context, mg resource.Managed) (managed.ExternalUpdate, error) {

--- a/internal/controller/kymaenvironmentbinding/kymaenvironmentbinding_test.go
+++ b/internal/controller/kymaenvironmentbinding/kymaenvironmentbinding_test.go
@@ -1003,6 +1003,14 @@ func Test_external_Delete(t *testing.T) {
 func Test_external_Create(t *testing.T) {
 	conflictErr := kerrors.NewConflict(schema.GroupResource{}, "test", errors.New("conflict"))
 
+	defaultBinding := &kymaenvironmentbinding.Binding{
+		Metadata:    &kymaenvironmentbinding.Metadata{Id: "new-id", ExpiresAt: timeNow.Add(time.Hour * 2)},
+		Credentials: &kymaenvironmentbinding.Credentials{Kubeconfig: "kubeconfig-data"},
+	}
+	defaultCreateFn := func(ctx context.Context, _ string, _ int) (*kymaenvironmentbinding.Binding, error) {
+		return defaultBinding, nil
+	}
+
 	type wantResult struct {
 		err               bool
 		errContains       string
@@ -1174,14 +1182,7 @@ func Test_external_Create(t *testing.T) {
 					},
 				},
 			},
-			client: &fakeClient{
-				createInstanceFunc: func(ctx context.Context, kymaInstanceId string, ttl int) (*kymaenvironmentbinding.Binding, error) {
-					return &kymaenvironmentbinding.Binding{
-						Metadata:    &kymaenvironmentbinding.Metadata{Id: "new-id", ExpiresAt: timeNow.Add(time.Hour * 2)},
-						Credentials: &kymaenvironmentbinding.Credentials{Kubeconfig: "kubeconfig-data"},
-					}, nil
-				},
-			},
+			client:          &fakeClient{createInstanceFunc: defaultCreateFn},
 			statusUpdateFns: []test.MockSubResourceUpdateFn{test.NewMockSubResourceUpdateFn(nil)},
 			getFn:           test.NewMockGetFn(nil),
 			want: wantResult{
@@ -1203,14 +1204,7 @@ func Test_external_Create(t *testing.T) {
 					},
 				},
 			},
-			client: &fakeClient{
-				createInstanceFunc: func(ctx context.Context, kymaInstanceId string, ttl int) (*kymaenvironmentbinding.Binding, error) {
-					return &kymaenvironmentbinding.Binding{
-						Metadata:    &kymaenvironmentbinding.Metadata{Id: "new-id", ExpiresAt: timeNow.Add(time.Hour * 2)},
-						Credentials: &kymaenvironmentbinding.Credentials{Kubeconfig: "kubeconfig-data"},
-					}, nil
-				},
-			},
+			client: &fakeClient{createInstanceFunc: defaultCreateFn},
 			statusUpdateFns: []test.MockSubResourceUpdateFn{
 				test.NewMockSubResourceUpdateFn(conflictErr),
 				test.NewMockSubResourceUpdateFn(nil),
@@ -1235,14 +1229,7 @@ func Test_external_Create(t *testing.T) {
 					},
 				},
 			},
-			client: &fakeClient{
-				createInstanceFunc: func(ctx context.Context, kymaInstanceId string, ttl int) (*kymaenvironmentbinding.Binding, error) {
-					return &kymaenvironmentbinding.Binding{
-						Metadata:    &kymaenvironmentbinding.Metadata{Id: "new-id", ExpiresAt: timeNow.Add(time.Hour * 2)},
-						Credentials: &kymaenvironmentbinding.Credentials{Kubeconfig: "kubeconfig-data"},
-					}, nil
-				},
-			},
+			client: &fakeClient{createInstanceFunc: defaultCreateFn},
 			statusUpdateFns: []test.MockSubResourceUpdateFn{
 				test.NewMockSubResourceUpdateFn(conflictErr),
 				test.NewMockSubResourceUpdateFn(conflictErr),
@@ -1265,14 +1252,7 @@ func Test_external_Create(t *testing.T) {
 					},
 				},
 			},
-			client: &fakeClient{
-				createInstanceFunc: func(ctx context.Context, kymaInstanceId string, ttl int) (*kymaenvironmentbinding.Binding, error) {
-					return &kymaenvironmentbinding.Binding{
-						Metadata:    &kymaenvironmentbinding.Metadata{Id: "new-id", ExpiresAt: timeNow.Add(time.Hour * 2)},
-						Credentials: &kymaenvironmentbinding.Credentials{Kubeconfig: "kubeconfig-data"},
-					}, nil
-				},
-			},
+			client: &fakeClient{createInstanceFunc: defaultCreateFn},
 			statusUpdateFns: []test.MockSubResourceUpdateFn{
 				test.NewMockSubResourceUpdateFn(conflictErr),
 				test.NewMockSubResourceUpdateFn(conflictErr),

--- a/internal/controller/kymaenvironmentbinding/kymaenvironmentbinding_test.go
+++ b/internal/controller/kymaenvironmentbinding/kymaenvironmentbinding_test.go
@@ -1001,16 +1001,26 @@ func Test_external_Delete(t *testing.T) {
 }
 
 func Test_external_Create(t *testing.T) {
+	conflictErr := kerrors.NewConflict(schema.GroupResource{}, "test", errors.New("conflict"))
+
+	type wantResult struct {
+		err               bool
+		errContains       string
+		rollbackCalled    bool
+		connectionDetails managed.ConnectionDetails
+	}
 	type args struct {
 		ctx context.Context
 		mg  resource.Managed
 	}
 	tests := []struct {
-		name    string
-		args    args
-		client  *fakeClient
-		want    managed.ExternalCreation
-		wantErr bool
+		name            string
+		args            args
+		client          *fakeClient
+		statusUpdateFns []test.MockSubResourceUpdateFn
+		getFn           test.MockGetFn
+		rollbackErr     error
+		want            wantResult
 	}{
 		{
 			name: "not a KymaEnvironmentBinding",
@@ -1018,9 +1028,9 @@ func Test_external_Create(t *testing.T) {
 				ctx: context.Background(),
 				mg:  &v1alpha1.KymaEnvironment{},
 			},
-			client:  &fakeClient{},
-			want:    managed.ExternalCreation{},
-			wantErr: true,
+			client:          &fakeClient{},
+			statusUpdateFns: []test.MockSubResourceUpdateFn{},
+			want:            wantResult{err: true},
 		},
 		{
 			name: "create new binding when no valid bindings exist",
@@ -1050,23 +1060,18 @@ func Test_external_Create(t *testing.T) {
 			client: &fakeClient{
 				createInstanceFunc: func(ctx context.Context, kymaInstanceId string, ttl int) (*kymaenvironmentbinding.Binding, error) {
 					return &kymaenvironmentbinding.Binding{
-						Metadata: &kymaenvironmentbinding.Metadata{
-							Id:        "new-binding-id",
-							ExpiresAt: timeNow.Add(time.Hour * 2),
-						},
-						Credentials: &kymaenvironmentbinding.Credentials{
-							Kubeconfig: "new-binding-secret",
-						},
+						Metadata:    &kymaenvironmentbinding.Metadata{Id: "new-binding-id", ExpiresAt: timeNow.Add(time.Hour * 2)},
+						Credentials: &kymaenvironmentbinding.Credentials{Kubeconfig: "new-binding-secret"},
 					}, nil
 				},
 			},
-			want: managed.ExternalCreation{
-				ConnectionDetails: managed.ConnectionDetails{
+			statusUpdateFns: []test.MockSubResourceUpdateFn{test.NewMockSubResourceUpdateFn(nil)},
+			want: wantResult{
+				connectionDetails: managed.ConnectionDetails{
 					"binding_id": []byte("new-binding-id"),
 					"kubeconfig": []byte("new-binding-secret"),
 				},
 			},
-			wantErr: false,
 		},
 		{
 			name: "reuse existing valid binding",
@@ -1096,23 +1101,18 @@ func Test_external_Create(t *testing.T) {
 			client: &fakeClient{
 				createInstanceFunc: func(ctx context.Context, kymaInstanceId string, ttl int) (*kymaenvironmentbinding.Binding, error) {
 					return &kymaenvironmentbinding.Binding{
-						Metadata: &kymaenvironmentbinding.Metadata{
-							Id:        "valid-id",
-							ExpiresAt: timeNow.Add(time.Hour * 2),
-						},
-						Credentials: &kymaenvironmentbinding.Credentials{
-							Kubeconfig: "valid-id",
-						},
+						Metadata:    &kymaenvironmentbinding.Metadata{Id: "valid-id", ExpiresAt: timeNow.Add(time.Hour * 2)},
+						Credentials: &kymaenvironmentbinding.Credentials{Kubeconfig: "valid-id"},
 					}, nil
 				},
 			},
-			want: managed.ExternalCreation{
-				ConnectionDetails: managed.ConnectionDetails{
+			statusUpdateFns: []test.MockSubResourceUpdateFn{test.NewMockSubResourceUpdateFn(nil)},
+			want: wantResult{
+				connectionDetails: managed.ConnectionDetails{
 					"binding_id": []byte("valid-id"),
 					"kubeconfig": []byte("valid-id"),
 				},
 			},
-			wantErr: false,
 		},
 		{
 			name: "service returns error during creation",
@@ -1126,9 +1126,7 @@ func Test_external_Create(t *testing.T) {
 						},
 					},
 					Status: v1alpha1.KymaEnvironmentBindingStatus{
-						AtProvider: v1alpha1.KymaEnvironmentBindingObservation{
-							Bindings: []v1alpha1.Binding{},
-						},
+						AtProvider: v1alpha1.KymaEnvironmentBindingObservation{Bindings: []v1alpha1.Binding{}},
 					},
 				},
 			},
@@ -1137,8 +1135,8 @@ func Test_external_Create(t *testing.T) {
 					return nil, errors.New("service error")
 				},
 			},
-			want:    managed.ExternalCreation{},
-			wantErr: true,
+			statusUpdateFns: []test.MockSubResourceUpdateFn{},
+			want:            wantResult{err: true},
 		},
 		{
 			name: "service returns error for invalid instance",
@@ -1152,9 +1150,7 @@ func Test_external_Create(t *testing.T) {
 						},
 					},
 					Status: v1alpha1.KymaEnvironmentBindingStatus{
-						AtProvider: v1alpha1.KymaEnvironmentBindingObservation{
-							Bindings: []v1alpha1.Binding{},
-						},
+						AtProvider: v1alpha1.KymaEnvironmentBindingObservation{Bindings: []v1alpha1.Binding{}},
 					},
 				},
 			},
@@ -1163,24 +1159,175 @@ func Test_external_Create(t *testing.T) {
 					return nil, errors.New("invalid instance")
 				},
 			},
-			want:    managed.ExternalCreation{},
-			wantErr: true,
+			statusUpdateFns: []test.MockSubResourceUpdateFn{},
+			want:            wantResult{err: true},
+		},
+		{
+			name: "status write succeeds after re-fetch",
+			args: args{
+				ctx: context.Background(),
+				mg: &v1alpha1.KymaEnvironmentBinding{
+					ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+					Spec:       v1alpha1.KymaEnvironmentBindingSpec{KymaEnvironmentId: "kyma-id"},
+					Status: v1alpha1.KymaEnvironmentBindingStatus{
+						AtProvider: v1alpha1.KymaEnvironmentBindingObservation{Bindings: []v1alpha1.Binding{}},
+					},
+				},
+			},
+			client: &fakeClient{
+				createInstanceFunc: func(ctx context.Context, kymaInstanceId string, ttl int) (*kymaenvironmentbinding.Binding, error) {
+					return &kymaenvironmentbinding.Binding{
+						Metadata:    &kymaenvironmentbinding.Metadata{Id: "new-id", ExpiresAt: timeNow.Add(time.Hour * 2)},
+						Credentials: &kymaenvironmentbinding.Credentials{Kubeconfig: "kubeconfig-data"},
+					}, nil
+				},
+			},
+			statusUpdateFns: []test.MockSubResourceUpdateFn{test.NewMockSubResourceUpdateFn(nil)},
+			getFn:           test.NewMockGetFn(nil),
+			want: wantResult{
+				connectionDetails: managed.ConnectionDetails{
+					"binding_id": []byte("new-id"),
+					"kubeconfig": []byte("kubeconfig-data"),
+				},
+			},
+		},
+		{
+			name: "status conflict resolved on retry",
+			args: args{
+				ctx: context.Background(),
+				mg: &v1alpha1.KymaEnvironmentBinding{
+					ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+					Spec:       v1alpha1.KymaEnvironmentBindingSpec{KymaEnvironmentId: "kyma-id"},
+					Status: v1alpha1.KymaEnvironmentBindingStatus{
+						AtProvider: v1alpha1.KymaEnvironmentBindingObservation{Bindings: []v1alpha1.Binding{}},
+					},
+				},
+			},
+			client: &fakeClient{
+				createInstanceFunc: func(ctx context.Context, kymaInstanceId string, ttl int) (*kymaenvironmentbinding.Binding, error) {
+					return &kymaenvironmentbinding.Binding{
+						Metadata:    &kymaenvironmentbinding.Metadata{Id: "new-id", ExpiresAt: timeNow.Add(time.Hour * 2)},
+						Credentials: &kymaenvironmentbinding.Credentials{Kubeconfig: "kubeconfig-data"},
+					}, nil
+				},
+			},
+			statusUpdateFns: []test.MockSubResourceUpdateFn{
+				test.NewMockSubResourceUpdateFn(conflictErr),
+				test.NewMockSubResourceUpdateFn(nil),
+			},
+			getFn: test.NewMockGetFn(nil),
+			want: wantResult{
+				connectionDetails: managed.ConnectionDetails{
+					"binding_id": []byte("new-id"),
+					"kubeconfig": []byte("kubeconfig-data"),
+				},
+			},
+		},
+		{
+			name: "all retries exhausted triggers rollback",
+			args: args{
+				ctx: context.Background(),
+				mg: &v1alpha1.KymaEnvironmentBinding{
+					ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+					Spec:       v1alpha1.KymaEnvironmentBindingSpec{KymaEnvironmentId: "kyma-id"},
+					Status: v1alpha1.KymaEnvironmentBindingStatus{
+						AtProvider: v1alpha1.KymaEnvironmentBindingObservation{Bindings: []v1alpha1.Binding{}},
+					},
+				},
+			},
+			client: &fakeClient{
+				createInstanceFunc: func(ctx context.Context, kymaInstanceId string, ttl int) (*kymaenvironmentbinding.Binding, error) {
+					return &kymaenvironmentbinding.Binding{
+						Metadata:    &kymaenvironmentbinding.Metadata{Id: "new-id", ExpiresAt: timeNow.Add(time.Hour * 2)},
+						Credentials: &kymaenvironmentbinding.Credentials{Kubeconfig: "kubeconfig-data"},
+					}, nil
+				},
+			},
+			statusUpdateFns: []test.MockSubResourceUpdateFn{
+				test.NewMockSubResourceUpdateFn(conflictErr),
+				test.NewMockSubResourceUpdateFn(conflictErr),
+				test.NewMockSubResourceUpdateFn(conflictErr),
+				test.NewMockSubResourceUpdateFn(conflictErr),
+				test.NewMockSubResourceUpdateFn(conflictErr),
+			},
+			getFn: test.NewMockGetFn(nil),
+			want:  wantResult{err: true, rollbackCalled: true},
+		},
+		{
+			name: "all retries exhausted and rollback also fails",
+			args: args{
+				ctx: context.Background(),
+				mg: &v1alpha1.KymaEnvironmentBinding{
+					ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+					Spec:       v1alpha1.KymaEnvironmentBindingSpec{KymaEnvironmentId: "kyma-id"},
+					Status: v1alpha1.KymaEnvironmentBindingStatus{
+						AtProvider: v1alpha1.KymaEnvironmentBindingObservation{Bindings: []v1alpha1.Binding{}},
+					},
+				},
+			},
+			client: &fakeClient{
+				createInstanceFunc: func(ctx context.Context, kymaInstanceId string, ttl int) (*kymaenvironmentbinding.Binding, error) {
+					return &kymaenvironmentbinding.Binding{
+						Metadata:    &kymaenvironmentbinding.Metadata{Id: "new-id", ExpiresAt: timeNow.Add(time.Hour * 2)},
+						Credentials: &kymaenvironmentbinding.Credentials{Kubeconfig: "kubeconfig-data"},
+					}, nil
+				},
+			},
+			statusUpdateFns: []test.MockSubResourceUpdateFn{
+				test.NewMockSubResourceUpdateFn(conflictErr),
+				test.NewMockSubResourceUpdateFn(conflictErr),
+				test.NewMockSubResourceUpdateFn(conflictErr),
+				test.NewMockSubResourceUpdateFn(conflictErr),
+				test.NewMockSubResourceUpdateFn(conflictErr),
+			},
+			getFn:       test.NewMockGetFn(nil),
+			rollbackErr: errors.New("rollback failed"),
+			want:        wantResult{err: true, rollbackCalled: true, errContains: errRollbackBinding},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := &external{kube: test.NewMockClient(), client: tt.client}
+			rollbackCalled := false
+			callIdx := 0
+
+			kube := &test.MockClient{
+				MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					if tt.getFn != nil {
+						return tt.getFn(ctx, key, obj)
+					}
+					return nil
+				},
+				MockStatusUpdate: func(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+					fn := tt.statusUpdateFns[callIdx]
+					callIdx++
+					return fn(ctx, obj, opts...)
+				},
+			}
+			fc := &fakeClient{
+				createInstanceFunc: tt.client.createInstanceFunc,
+				deleteInstanceFunc: func(ctx context.Context, bindings []v1alpha1.Binding, kymaInstanceId string) error {
+					rollbackCalled = true
+					return tt.rollbackErr
+				},
+			}
+
+			c := &external{kube: kube, client: fc}
 			got, err := c.Create(tt.args.ctx, tt.args.mg)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Create() error = %v, wantErr %v", err, tt.wantErr)
+			if (err != nil) != tt.want.err {
+				t.Errorf("Create() error = %v, want.err %v", err, tt.want.err)
 				return
 			}
-			if diff := cmp.Diff(tt.want, got,
+			if rollbackCalled != tt.want.rollbackCalled {
+				t.Errorf("Create() rollbackCalled = %v, want %v", rollbackCalled, tt.want.rollbackCalled)
+			}
+			if tt.want.errContains != "" && !strings.Contains(err.Error(), tt.want.errContains) {
+				t.Errorf("expected error containing %q, got %v", tt.want.errContains, err)
+			}
+			if diff := cmp.Diff(tt.want.connectionDetails, got.ConnectionDetails,
 				cmp.FilterPath(func(p cmp.Path) bool {
 					return p.Last().String() == "[\"created_at\"]" || p.Last().String() == "[\"expires_at\"]"
-				}, cmp.Ignore()),
-				cmp.AllowUnexported(managed.ExternalCreation{})); diff != "" {
-				t.Errorf("Create() mismatch (-want +got):\n%s", diff)
+				}, cmp.Ignore())); diff != "" {
+				t.Errorf("Create() connectionDetails mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -1376,141 +1523,3 @@ func Test_external_updateStatusWithRetry(t *testing.T) {
 	}
 }
 
-func Test_external_Create_statusRetryAndRollback(t *testing.T) {
-	conflictErr := kerrors.NewConflict(schema.GroupResource{}, "test", errors.New("conflict"))
-
-	newBinding := &kymaenvironmentbinding.Binding{
-		Metadata: &kymaenvironmentbinding.Metadata{
-			Id:        "new-id",
-			ExpiresAt: timeNow.Add(time.Hour * 2),
-		},
-		Credentials: &kymaenvironmentbinding.Credentials{
-			Kubeconfig: "kubeconfig-data",
-		},
-	}
-
-	tests := []struct {
-		name                  string
-		statusUpdateFns       []test.MockSubResourceUpdateFn
-		getFn                 test.MockGetFn
-		rollbackErr           error
-		wantErr               bool
-		wantRollbackCalled    bool
-		wantConnectionDetails bool
-		wantErrContains       string
-	}{
-		{
-			name: "status write succeeds after re-fetch",
-			statusUpdateFns: []test.MockSubResourceUpdateFn{
-				test.NewMockSubResourceUpdateFn(nil),
-			},
-			getFn:                 test.NewMockGetFn(nil),
-			wantErr:               false,
-			wantRollbackCalled:    false,
-			wantConnectionDetails: true,
-		},
-		{
-			name: "status conflict resolved on retry",
-			statusUpdateFns: []test.MockSubResourceUpdateFn{
-				test.NewMockSubResourceUpdateFn(conflictErr),
-				test.NewMockSubResourceUpdateFn(nil),
-			},
-			getFn:                 test.NewMockGetFn(nil),
-			wantErr:               false,
-			wantRollbackCalled:    false,
-			wantConnectionDetails: true,
-		},
-		{
-			name: "all retries exhausted triggers rollback",
-			statusUpdateFns: []test.MockSubResourceUpdateFn{
-				test.NewMockSubResourceUpdateFn(conflictErr),
-				test.NewMockSubResourceUpdateFn(conflictErr),
-				test.NewMockSubResourceUpdateFn(conflictErr),
-				test.NewMockSubResourceUpdateFn(conflictErr),
-				test.NewMockSubResourceUpdateFn(conflictErr),
-			},
-			getFn:                 test.NewMockGetFn(nil),
-			wantErr:               true,
-			wantRollbackCalled:    true,
-			wantConnectionDetails: false,
-		},
-		{
-			name: "all retries exhausted and rollback also fails",
-			statusUpdateFns: []test.MockSubResourceUpdateFn{
-				test.NewMockSubResourceUpdateFn(conflictErr),
-				test.NewMockSubResourceUpdateFn(conflictErr),
-				test.NewMockSubResourceUpdateFn(conflictErr),
-				test.NewMockSubResourceUpdateFn(conflictErr),
-				test.NewMockSubResourceUpdateFn(conflictErr),
-			},
-			getFn:                 test.NewMockGetFn(nil),
-			rollbackErr:           errors.New("rollback failed"),
-			wantErr:               true,
-			wantRollbackCalled:    true,
-			wantConnectionDetails: false,
-			wantErrContains:       errRollbackBinding,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			rollbackCalled := false
-			callIdx := 0
-
-			kube := &test.MockClient{
-				MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
-					if tt.getFn != nil {
-						return tt.getFn(ctx, key, obj)
-					}
-					return nil
-				},
-				MockStatusUpdate: func(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
-					fn := tt.statusUpdateFns[callIdx]
-					callIdx++
-					return fn(ctx, obj, opts...)
-				},
-			}
-
-			fc := &fakeClient{
-				createInstanceFunc: func(ctx context.Context, kymaInstanceId string, ttl int) (*kymaenvironmentbinding.Binding, error) {
-					return newBinding, nil
-				},
-				deleteInstanceFunc: func(ctx context.Context, bindings []v1alpha1.Binding, kymaInstanceId string) error {
-					rollbackCalled = true
-					return tt.rollbackErr
-				},
-			}
-
-			c := &external{kube: kube, client: fc}
-			mg := &v1alpha1.KymaEnvironmentBinding{
-				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
-				Spec: v1alpha1.KymaEnvironmentBindingSpec{
-					KymaEnvironmentId: "kyma-id",
-				},
-				Status: v1alpha1.KymaEnvironmentBindingStatus{
-					AtProvider: v1alpha1.KymaEnvironmentBindingObservation{
-						Bindings: []v1alpha1.Binding{},
-					},
-				},
-			}
-
-			got, err := c.Create(context.Background(), mg)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Create() error = %v, wantErr %v", err, tt.wantErr)
-			}
-			if rollbackCalled != tt.wantRollbackCalled {
-				t.Errorf("Create() rollbackCalled = %v, want %v", rollbackCalled, tt.wantRollbackCalled)
-			}
-			if tt.wantConnectionDetails && len(got.ConnectionDetails) == 0 {
-				t.Errorf("Create() expected connection details, got none")
-			}
-			if !tt.wantConnectionDetails && len(got.ConnectionDetails) > 0 {
-				t.Errorf("Create() expected no connection details on failure, got %v", got.ConnectionDetails)
-			}
-			if tt.wantErrContains != "" && err != nil {
-				if !strings.Contains(err.Error(), tt.wantErrContains) {
-					t.Errorf("expected error containing %q, got %v", tt.wantErrContains, err)
-				}
-			}
-		})
-	}
-}

--- a/internal/controller/kymaenvironmentbinding/kymaenvironmentbinding_test.go
+++ b/internal/controller/kymaenvironmentbinding/kymaenvironmentbinding_test.go
@@ -854,48 +854,38 @@ func Test_external_Observe(t *testing.T) {
 }
 
 func Test_external_Delete(t *testing.T) {
-	type args struct {
-		ctx context.Context
-		mg  resource.Managed
-	}
 	tests := []struct {
 		name    string
-		args    args
+		mg      resource.Managed
 		client  *fakeClient
 		wantErr bool
 	}{
 		{
-			name: "not a KymaEnvironmentBinding",
-			args: args{
-				ctx: context.Background(),
-				mg:  &v1alpha1.KymaEnvironment{},
-			},
+			name:    "not a KymaEnvironmentBinding",
+			mg:      &v1alpha1.KymaEnvironment{},
 			client:  &fakeClient{},
 			wantErr: true,
 		},
 		{
 			name: "successful deletion with multiple bindings",
-			args: args{
-				ctx: context.Background(),
-				mg: &v1alpha1.KymaEnvironmentBinding{
-					Spec: v1alpha1.KymaEnvironmentBindingSpec{
-						KymaEnvironmentId: "test-instance",
-					},
-					Status: v1alpha1.KymaEnvironmentBindingStatus{
-						AtProvider: v1alpha1.KymaEnvironmentBindingObservation{
-							Bindings: []v1alpha1.Binding{
-								{
-									Id:        "id1",
-									IsActive:  true,
-									CreatedAt: metav1.NewTime(timeNow.Add(time.Hour * -1)),
-									ExpiresAt: metav1.NewTime(timeNow.Add(time.Hour * 2)),
-								},
-								{
-									Id:        "id2",
-									IsActive:  false,
-									CreatedAt: metav1.NewTime(timeNow.Add(time.Hour * -2)),
-									ExpiresAt: metav1.NewTime(timeNow.Add(time.Hour * 1)),
-								},
+			mg: &v1alpha1.KymaEnvironmentBinding{
+				Spec: v1alpha1.KymaEnvironmentBindingSpec{
+					KymaEnvironmentId: "test-instance",
+				},
+				Status: v1alpha1.KymaEnvironmentBindingStatus{
+					AtProvider: v1alpha1.KymaEnvironmentBindingObservation{
+						Bindings: []v1alpha1.Binding{
+							{
+								Id:        "id1",
+								IsActive:  true,
+								CreatedAt: metav1.NewTime(timeNow.Add(time.Hour * -1)),
+								ExpiresAt: metav1.NewTime(timeNow.Add(time.Hour * 2)),
+							},
+							{
+								Id:        "id2",
+								IsActive:  false,
+								CreatedAt: metav1.NewTime(timeNow.Add(time.Hour * -2)),
+								ExpiresAt: metav1.NewTime(timeNow.Add(time.Hour * 1)),
 							},
 						},
 					},
@@ -910,21 +900,18 @@ func Test_external_Delete(t *testing.T) {
 		},
 		{
 			name: "service returns error during deletion",
-			args: args{
-				ctx: context.Background(),
-				mg: &v1alpha1.KymaEnvironmentBinding{
-					Spec: v1alpha1.KymaEnvironmentBindingSpec{
-						KymaEnvironmentId: "error-instance",
-					},
-					Status: v1alpha1.KymaEnvironmentBindingStatus{
-						AtProvider: v1alpha1.KymaEnvironmentBindingObservation{
-							Bindings: []v1alpha1.Binding{
-								{
-									Id:        "id1",
-									IsActive:  true,
-									CreatedAt: metav1.NewTime(timeNow.Add(time.Hour * -1)),
-									ExpiresAt: metav1.NewTime(timeNow.Add(time.Hour * 2)),
-								},
+			mg: &v1alpha1.KymaEnvironmentBinding{
+				Spec: v1alpha1.KymaEnvironmentBindingSpec{
+					KymaEnvironmentId: "error-instance",
+				},
+				Status: v1alpha1.KymaEnvironmentBindingStatus{
+					AtProvider: v1alpha1.KymaEnvironmentBindingObservation{
+						Bindings: []v1alpha1.Binding{
+							{
+								Id:        "id1",
+								IsActive:  true,
+								CreatedAt: metav1.NewTime(timeNow.Add(time.Hour * -1)),
+								ExpiresAt: metav1.NewTime(timeNow.Add(time.Hour * 2)),
 							},
 						},
 					},
@@ -939,21 +926,18 @@ func Test_external_Delete(t *testing.T) {
 		},
 		{
 			name: "service returns error for non-existent binding",
-			args: args{
-				ctx: context.Background(),
-				mg: &v1alpha1.KymaEnvironmentBinding{
-					Spec: v1alpha1.KymaEnvironmentBindingSpec{
-						KymaEnvironmentId: "non-existent-instance",
-					},
-					Status: v1alpha1.KymaEnvironmentBindingStatus{
-						AtProvider: v1alpha1.KymaEnvironmentBindingObservation{
-							Bindings: []v1alpha1.Binding{
-								{
-									Id:        "non-existent-id",
-									IsActive:  true,
-									CreatedAt: metav1.NewTime(timeNow.Add(time.Hour * -1)),
-									ExpiresAt: metav1.NewTime(timeNow.Add(time.Hour * 2)),
-								},
+			mg: &v1alpha1.KymaEnvironmentBinding{
+				Spec: v1alpha1.KymaEnvironmentBindingSpec{
+					KymaEnvironmentId: "non-existent-instance",
+				},
+				Status: v1alpha1.KymaEnvironmentBindingStatus{
+					AtProvider: v1alpha1.KymaEnvironmentBindingObservation{
+						Bindings: []v1alpha1.Binding{
+							{
+								Id:        "non-existent-id",
+								IsActive:  true,
+								CreatedAt: metav1.NewTime(timeNow.Add(time.Hour * -1)),
+								ExpiresAt: metav1.NewTime(timeNow.Add(time.Hour * 2)),
 							},
 						},
 					},
@@ -968,16 +952,13 @@ func Test_external_Delete(t *testing.T) {
 		},
 		{
 			name: "successful deletion with no bindings",
-			args: args{
-				ctx: context.Background(),
-				mg: &v1alpha1.KymaEnvironmentBinding{
-					Spec: v1alpha1.KymaEnvironmentBindingSpec{
-						KymaEnvironmentId: "test-instance",
-					},
-					Status: v1alpha1.KymaEnvironmentBindingStatus{
-						AtProvider: v1alpha1.KymaEnvironmentBindingObservation{
-							Bindings: []v1alpha1.Binding{},
-						},
+			mg: &v1alpha1.KymaEnvironmentBinding{
+				Spec: v1alpha1.KymaEnvironmentBindingSpec{
+					KymaEnvironmentId: "test-instance",
+				},
+				Status: v1alpha1.KymaEnvironmentBindingStatus{
+					AtProvider: v1alpha1.KymaEnvironmentBindingObservation{
+						Bindings: []v1alpha1.Binding{},
 					},
 				},
 			},
@@ -992,7 +973,7 @@ func Test_external_Delete(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &external{kube: test.NewMockClient(), client: tt.client, tracker: tracking.NewDefaultReferenceResolverTracker(test.NewMockClient())}
-			_, err := c.Delete(tt.args.ctx, tt.args.mg)
+			_, err := c.Delete(context.Background(), tt.mg)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Delete() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -1017,13 +998,9 @@ func Test_external_Create(t *testing.T) {
 		rollbackCalled    bool
 		connectionDetails managed.ConnectionDetails
 	}
-	type args struct {
-		ctx context.Context
-		mg  resource.Managed
-	}
 	tests := []struct {
 		name            string
-		args            args
+		mg              resource.Managed
 		client          *fakeClient
 		statusUpdateFns []test.MockSubResourceUpdateFn
 		getFn           test.MockGetFn
@@ -1031,35 +1008,29 @@ func Test_external_Create(t *testing.T) {
 		want            wantResult
 	}{
 		{
-			name: "not a KymaEnvironmentBinding",
-			args: args{
-				ctx: context.Background(),
-				mg:  &v1alpha1.KymaEnvironment{},
-			},
+			name:            "not a KymaEnvironmentBinding",
+			mg:              &v1alpha1.KymaEnvironment{},
 			client:          &fakeClient{},
 			statusUpdateFns: []test.MockSubResourceUpdateFn{},
 			want:            wantResult{err: true},
 		},
 		{
 			name: "create new binding when no valid bindings exist",
-			args: args{
-				ctx: context.Background(),
-				mg: &v1alpha1.KymaEnvironmentBinding{
-					Spec: v1alpha1.KymaEnvironmentBindingSpec{
-						KymaEnvironmentId: "test-instance",
-						ForProvider: v1alpha1.KymaEnvironmentBindingParameters{
-							RotationInterval: metav1.Duration{Duration: time.Hour * 1},
-						},
+			mg: &v1alpha1.KymaEnvironmentBinding{
+				Spec: v1alpha1.KymaEnvironmentBindingSpec{
+					KymaEnvironmentId: "test-instance",
+					ForProvider: v1alpha1.KymaEnvironmentBindingParameters{
+						RotationInterval: metav1.Duration{Duration: time.Hour * 1},
 					},
-					Status: v1alpha1.KymaEnvironmentBindingStatus{
-						AtProvider: v1alpha1.KymaEnvironmentBindingObservation{
-							Bindings: []v1alpha1.Binding{
-								{
-									Id:        "id",
-									IsActive:  true,
-									CreatedAt: metav1.NewTime(timeNow.Add(time.Hour * -1)),
-									ExpiresAt: metav1.NewTime(timeNow.Add(time.Minute * 10 * -1)),
-								},
+				},
+				Status: v1alpha1.KymaEnvironmentBindingStatus{
+					AtProvider: v1alpha1.KymaEnvironmentBindingObservation{
+						Bindings: []v1alpha1.Binding{
+							{
+								Id:        "id",
+								IsActive:  true,
+								CreatedAt: metav1.NewTime(timeNow.Add(time.Hour * -1)),
+								ExpiresAt: metav1.NewTime(timeNow.Add(time.Minute * 10 * -1)),
 							},
 						},
 					},
@@ -1083,24 +1054,21 @@ func Test_external_Create(t *testing.T) {
 		},
 		{
 			name: "reuse existing valid binding",
-			args: args{
-				ctx: context.Background(),
-				mg: &v1alpha1.KymaEnvironmentBinding{
-					Spec: v1alpha1.KymaEnvironmentBindingSpec{
-						KymaEnvironmentId: "test-instance",
-						ForProvider: v1alpha1.KymaEnvironmentBindingParameters{
-							RotationInterval: metav1.Duration{Duration: time.Hour * 2},
-						},
+			mg: &v1alpha1.KymaEnvironmentBinding{
+				Spec: v1alpha1.KymaEnvironmentBindingSpec{
+					KymaEnvironmentId: "test-instance",
+					ForProvider: v1alpha1.KymaEnvironmentBindingParameters{
+						RotationInterval: metav1.Duration{Duration: time.Hour * 2},
 					},
-					Status: v1alpha1.KymaEnvironmentBindingStatus{
-						AtProvider: v1alpha1.KymaEnvironmentBindingObservation{
-							Bindings: []v1alpha1.Binding{
-								{
-									Id:        "valid-id",
-									IsActive:  true,
-									CreatedAt: metav1.NewTime(timeNow.Add(time.Hour * -1)),
-									ExpiresAt: metav1.NewTime(timeNow.Add(time.Hour * 2)),
-								},
+				},
+				Status: v1alpha1.KymaEnvironmentBindingStatus{
+					AtProvider: v1alpha1.KymaEnvironmentBindingObservation{
+						Bindings: []v1alpha1.Binding{
+							{
+								Id:        "valid-id",
+								IsActive:  true,
+								CreatedAt: metav1.NewTime(timeNow.Add(time.Hour * -1)),
+								ExpiresAt: metav1.NewTime(timeNow.Add(time.Hour * 2)),
 							},
 						},
 					},
@@ -1124,18 +1092,15 @@ func Test_external_Create(t *testing.T) {
 		},
 		{
 			name: "service returns error during creation",
-			args: args{
-				ctx: context.Background(),
-				mg: &v1alpha1.KymaEnvironmentBinding{
-					Spec: v1alpha1.KymaEnvironmentBindingSpec{
-						KymaEnvironmentId: "error-instance",
-						ForProvider: v1alpha1.KymaEnvironmentBindingParameters{
-							RotationInterval: metav1.Duration{Duration: time.Hour * 1},
-						},
+			mg: &v1alpha1.KymaEnvironmentBinding{
+				Spec: v1alpha1.KymaEnvironmentBindingSpec{
+					KymaEnvironmentId: "error-instance",
+					ForProvider: v1alpha1.KymaEnvironmentBindingParameters{
+						RotationInterval: metav1.Duration{Duration: time.Hour * 1},
 					},
-					Status: v1alpha1.KymaEnvironmentBindingStatus{
-						AtProvider: v1alpha1.KymaEnvironmentBindingObservation{Bindings: []v1alpha1.Binding{}},
-					},
+				},
+				Status: v1alpha1.KymaEnvironmentBindingStatus{
+					AtProvider: v1alpha1.KymaEnvironmentBindingObservation{Bindings: []v1alpha1.Binding{}},
 				},
 			},
 			client: &fakeClient{
@@ -1148,18 +1113,15 @@ func Test_external_Create(t *testing.T) {
 		},
 		{
 			name: "service returns error for invalid instance",
-			args: args{
-				ctx: context.Background(),
-				mg: &v1alpha1.KymaEnvironmentBinding{
-					Spec: v1alpha1.KymaEnvironmentBindingSpec{
-						KymaEnvironmentId: "invalid-instance",
-						ForProvider: v1alpha1.KymaEnvironmentBindingParameters{
-							RotationInterval: metav1.Duration{Duration: time.Hour * 1},
-						},
+			mg: &v1alpha1.KymaEnvironmentBinding{
+				Spec: v1alpha1.KymaEnvironmentBindingSpec{
+					KymaEnvironmentId: "invalid-instance",
+					ForProvider: v1alpha1.KymaEnvironmentBindingParameters{
+						RotationInterval: metav1.Duration{Duration: time.Hour * 1},
 					},
-					Status: v1alpha1.KymaEnvironmentBindingStatus{
-						AtProvider: v1alpha1.KymaEnvironmentBindingObservation{Bindings: []v1alpha1.Binding{}},
-					},
+				},
+				Status: v1alpha1.KymaEnvironmentBindingStatus{
+					AtProvider: v1alpha1.KymaEnvironmentBindingObservation{Bindings: []v1alpha1.Binding{}},
 				},
 			},
 			client: &fakeClient{
@@ -1172,14 +1134,11 @@ func Test_external_Create(t *testing.T) {
 		},
 		{
 			name: "status write succeeds after re-fetch",
-			args: args{
-				ctx: context.Background(),
-				mg: &v1alpha1.KymaEnvironmentBinding{
-					ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
-					Spec:       v1alpha1.KymaEnvironmentBindingSpec{KymaEnvironmentId: "kyma-id"},
-					Status: v1alpha1.KymaEnvironmentBindingStatus{
-						AtProvider: v1alpha1.KymaEnvironmentBindingObservation{Bindings: []v1alpha1.Binding{}},
-					},
+			mg: &v1alpha1.KymaEnvironmentBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec:       v1alpha1.KymaEnvironmentBindingSpec{KymaEnvironmentId: "kyma-id"},
+				Status: v1alpha1.KymaEnvironmentBindingStatus{
+					AtProvider: v1alpha1.KymaEnvironmentBindingObservation{Bindings: []v1alpha1.Binding{}},
 				},
 			},
 			client:          &fakeClient{createInstanceFunc: defaultCreateFn},
@@ -1194,14 +1153,11 @@ func Test_external_Create(t *testing.T) {
 		},
 		{
 			name: "status conflict resolved on retry",
-			args: args{
-				ctx: context.Background(),
-				mg: &v1alpha1.KymaEnvironmentBinding{
-					ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
-					Spec:       v1alpha1.KymaEnvironmentBindingSpec{KymaEnvironmentId: "kyma-id"},
-					Status: v1alpha1.KymaEnvironmentBindingStatus{
-						AtProvider: v1alpha1.KymaEnvironmentBindingObservation{Bindings: []v1alpha1.Binding{}},
-					},
+			mg: &v1alpha1.KymaEnvironmentBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec:       v1alpha1.KymaEnvironmentBindingSpec{KymaEnvironmentId: "kyma-id"},
+				Status: v1alpha1.KymaEnvironmentBindingStatus{
+					AtProvider: v1alpha1.KymaEnvironmentBindingObservation{Bindings: []v1alpha1.Binding{}},
 				},
 			},
 			client: &fakeClient{createInstanceFunc: defaultCreateFn},
@@ -1219,14 +1175,11 @@ func Test_external_Create(t *testing.T) {
 		},
 		{
 			name: "all retries exhausted triggers rollback",
-			args: args{
-				ctx: context.Background(),
-				mg: &v1alpha1.KymaEnvironmentBinding{
-					ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
-					Spec:       v1alpha1.KymaEnvironmentBindingSpec{KymaEnvironmentId: "kyma-id"},
-					Status: v1alpha1.KymaEnvironmentBindingStatus{
-						AtProvider: v1alpha1.KymaEnvironmentBindingObservation{Bindings: []v1alpha1.Binding{}},
-					},
+			mg: &v1alpha1.KymaEnvironmentBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec:       v1alpha1.KymaEnvironmentBindingSpec{KymaEnvironmentId: "kyma-id"},
+				Status: v1alpha1.KymaEnvironmentBindingStatus{
+					AtProvider: v1alpha1.KymaEnvironmentBindingObservation{Bindings: []v1alpha1.Binding{}},
 				},
 			},
 			client: &fakeClient{createInstanceFunc: defaultCreateFn},
@@ -1242,14 +1195,11 @@ func Test_external_Create(t *testing.T) {
 		},
 		{
 			name: "all retries exhausted and rollback also fails",
-			args: args{
-				ctx: context.Background(),
-				mg: &v1alpha1.KymaEnvironmentBinding{
-					ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
-					Spec:       v1alpha1.KymaEnvironmentBindingSpec{KymaEnvironmentId: "kyma-id"},
-					Status: v1alpha1.KymaEnvironmentBindingStatus{
-						AtProvider: v1alpha1.KymaEnvironmentBindingObservation{Bindings: []v1alpha1.Binding{}},
-					},
+			mg: &v1alpha1.KymaEnvironmentBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec:       v1alpha1.KymaEnvironmentBindingSpec{KymaEnvironmentId: "kyma-id"},
+				Status: v1alpha1.KymaEnvironmentBindingStatus{
+					AtProvider: v1alpha1.KymaEnvironmentBindingObservation{Bindings: []v1alpha1.Binding{}},
 				},
 			},
 			client: &fakeClient{createInstanceFunc: defaultCreateFn},
@@ -1292,7 +1242,7 @@ func Test_external_Create(t *testing.T) {
 			}
 
 			c := &external{kube: kube, client: fc}
-			got, err := c.Create(tt.args.ctx, tt.args.mg)
+			got, err := c.Create(context.Background(), tt.mg)
 			if (err != nil) != tt.want.err {
 				t.Errorf("Create() error = %v, want.err %v", err, tt.want.err)
 				return
@@ -1314,34 +1264,24 @@ func Test_external_Create(t *testing.T) {
 }
 
 func Test_external_Update(t *testing.T) {
-	type args struct {
-		ctx context.Context
-		mg  resource.Managed
-	}
 	tests := []struct {
 		name    string
-		args    args
+		mg      resource.Managed
 		client  *fakeClient
 		want    managed.ExternalUpdate
 		wantErr bool
 	}{
 		{
-			name: "not a KymaEnvironmentBinding",
-			args: args{
-				ctx: context.Background(),
-				mg:  &v1alpha1.KymaEnvironment{},
-			},
+			name:    "not a KymaEnvironmentBinding",
+			mg:      &v1alpha1.KymaEnvironment{},
 			want:    managed.ExternalUpdate{},
 			wantErr: true,
 		},
 		{
 			name: "update not implemented",
-			args: args{
-				ctx: context.Background(),
-				mg: &v1alpha1.KymaEnvironmentBinding{
-					Spec: v1alpha1.KymaEnvironmentBindingSpec{
-						KymaEnvironmentId: "test-instance",
-					},
+			mg: &v1alpha1.KymaEnvironmentBinding{
+				Spec: v1alpha1.KymaEnvironmentBindingSpec{
+					KymaEnvironmentId: "test-instance",
 				},
 			},
 			want:    managed.ExternalUpdate{},
@@ -1351,7 +1291,7 @@ func Test_external_Update(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &external{kube: test.NewMockClient(), client: tt.client}
-			got, err := c.Update(tt.args.ctx, tt.args.mg)
+			got, err := c.Update(context.Background(), tt.mg)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Update() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/internal/controller/kymaenvironmentbinding/kymaenvironmentbinding_test.go
+++ b/internal/controller/kymaenvironmentbinding/kymaenvironmentbinding_test.go
@@ -3,6 +3,7 @@ package kymaenvironmentbinding
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -11,7 +12,10 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 	"github.com/google/go-cmp/cmp"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/sap/crossplane-provider-btp/apis/environment/v1alpha1"
 	"github.com/sap/crossplane-provider-btp/internal/clients/kymaenvironmentbinding"
@@ -1264,3 +1268,249 @@ func (f fakeClient) DeleteInstances(ctx context.Context, bindings []v1alpha1.Bin
 }
 
 var _ kymaenvironmentbinding.Client = &fakeClient{}
+
+func Test_external_updateStatusWithRetry(t *testing.T) {
+	conflictErr := kerrors.NewConflict(schema.GroupResource{}, "test", errors.New("conflict"))
+
+	tests := []struct {
+		name            string
+		statusUpdateFns []test.MockSubResourceUpdateFn
+		getFn           test.MockGetFn
+		cancelCtx       bool
+		wantErr         bool
+		wantErrContains string
+	}{
+		{
+			name: "success on first attempt",
+			statusUpdateFns: []test.MockSubResourceUpdateFn{
+				test.NewMockSubResourceUpdateFn(nil),
+			},
+			wantErr: false,
+		},
+		{
+			name: "conflict on first attempt, success on retry after re-fetch",
+			statusUpdateFns: []test.MockSubResourceUpdateFn{
+				test.NewMockSubResourceUpdateFn(conflictErr),
+				test.NewMockSubResourceUpdateFn(nil),
+			},
+			getFn:   test.NewMockGetFn(nil),
+			wantErr: false,
+		},
+		{
+			name: "non-conflict error returns immediately without retrying",
+			statusUpdateFns: []test.MockSubResourceUpdateFn{
+				test.NewMockSubResourceUpdateFn(errors.New("some other error")),
+			},
+			wantErr:         true,
+			wantErrContains: "some other error",
+		},
+		{
+			name: "conflict exhausts all retries",
+			statusUpdateFns: []test.MockSubResourceUpdateFn{
+				test.NewMockSubResourceUpdateFn(conflictErr),
+				test.NewMockSubResourceUpdateFn(conflictErr),
+				test.NewMockSubResourceUpdateFn(conflictErr),
+				test.NewMockSubResourceUpdateFn(conflictErr),
+				test.NewMockSubResourceUpdateFn(conflictErr),
+			},
+			getFn:           test.NewMockGetFn(nil),
+			wantErr:         true,
+			wantErrContains: errStatusUpdate,
+		},
+		{
+			name: "re-fetch fails returns immediately",
+			statusUpdateFns: []test.MockSubResourceUpdateFn{
+				test.NewMockSubResourceUpdateFn(conflictErr),
+			},
+			getFn:           test.NewMockGetFn(errors.New("get failed")),
+			wantErr:         true,
+			wantErrContains: "get failed",
+		},
+		{
+			name: "context cancelled during backoff returns immediately",
+			statusUpdateFns: []test.MockSubResourceUpdateFn{
+				test.NewMockSubResourceUpdateFn(conflictErr),
+			},
+			getFn:           test.NewMockGetFn(nil),
+			cancelCtx:       true,
+			wantErr:         true,
+			wantErrContains: errStatusUpdate,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			callIdx := 0
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			kube := &test.MockClient{
+				MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					if tt.cancelCtx {
+						cancel()
+					}
+					if tt.getFn != nil {
+						return tt.getFn(ctx, key, obj)
+					}
+					return nil
+				},
+				MockStatusUpdate: func(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+					fn := tt.statusUpdateFns[callIdx]
+					callIdx++
+					return fn(ctx, obj, opts...)
+				},
+			}
+			c := &external{kube: kube}
+			cr := &v1alpha1.KymaEnvironmentBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+			}
+			desiredBindings := []v1alpha1.Binding{{Id: "id1", IsActive: true}}
+			err := c.updateStatusWithRetry(ctx, cr, desiredBindings)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("updateStatusWithRetry() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErrContains != "" && err != nil {
+				if !strings.Contains(err.Error(), tt.wantErrContains) {
+					t.Errorf("expected error containing %q, got %v", tt.wantErrContains, err)
+				}
+			}
+		})
+	}
+}
+
+func Test_external_Create_statusRetryAndRollback(t *testing.T) {
+	conflictErr := kerrors.NewConflict(schema.GroupResource{}, "test", errors.New("conflict"))
+
+	newBinding := &kymaenvironmentbinding.Binding{
+		Metadata: &kymaenvironmentbinding.Metadata{
+			Id:        "new-id",
+			ExpiresAt: timeNow.Add(time.Hour * 2),
+		},
+		Credentials: &kymaenvironmentbinding.Credentials{
+			Kubeconfig: "kubeconfig-data",
+		},
+	}
+
+	tests := []struct {
+		name                  string
+		statusUpdateFns       []test.MockSubResourceUpdateFn
+		getFn                 test.MockGetFn
+		rollbackErr           error
+		wantErr               bool
+		wantRollbackCalled    bool
+		wantConnectionDetails bool
+		wantErrContains       string
+	}{
+		{
+			name: "status write succeeds after re-fetch",
+			statusUpdateFns: []test.MockSubResourceUpdateFn{
+				test.NewMockSubResourceUpdateFn(nil),
+			},
+			getFn:                 test.NewMockGetFn(nil),
+			wantErr:               false,
+			wantRollbackCalled:    false,
+			wantConnectionDetails: true,
+		},
+		{
+			name: "status conflict resolved on retry",
+			statusUpdateFns: []test.MockSubResourceUpdateFn{
+				test.NewMockSubResourceUpdateFn(conflictErr),
+				test.NewMockSubResourceUpdateFn(nil),
+			},
+			getFn:                 test.NewMockGetFn(nil),
+			wantErr:               false,
+			wantRollbackCalled:    false,
+			wantConnectionDetails: true,
+		},
+		{
+			name: "all retries exhausted triggers rollback",
+			statusUpdateFns: []test.MockSubResourceUpdateFn{
+				test.NewMockSubResourceUpdateFn(conflictErr),
+				test.NewMockSubResourceUpdateFn(conflictErr),
+				test.NewMockSubResourceUpdateFn(conflictErr),
+				test.NewMockSubResourceUpdateFn(conflictErr),
+				test.NewMockSubResourceUpdateFn(conflictErr),
+			},
+			getFn:                 test.NewMockGetFn(nil),
+			wantErr:               true,
+			wantRollbackCalled:    true,
+			wantConnectionDetails: false,
+		},
+		{
+			name: "all retries exhausted and rollback also fails",
+			statusUpdateFns: []test.MockSubResourceUpdateFn{
+				test.NewMockSubResourceUpdateFn(conflictErr),
+				test.NewMockSubResourceUpdateFn(conflictErr),
+				test.NewMockSubResourceUpdateFn(conflictErr),
+				test.NewMockSubResourceUpdateFn(conflictErr),
+				test.NewMockSubResourceUpdateFn(conflictErr),
+			},
+			getFn:                 test.NewMockGetFn(nil),
+			rollbackErr:           errors.New("rollback failed"),
+			wantErr:               true,
+			wantRollbackCalled:    true,
+			wantConnectionDetails: false,
+			wantErrContains:       errRollbackBinding,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rollbackCalled := false
+			callIdx := 0
+
+			kube := &test.MockClient{
+				MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					if tt.getFn != nil {
+						return tt.getFn(ctx, key, obj)
+					}
+					return nil
+				},
+				MockStatusUpdate: func(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+					fn := tt.statusUpdateFns[callIdx]
+					callIdx++
+					return fn(ctx, obj, opts...)
+				},
+			}
+
+			fc := &fakeClient{
+				createInstanceFunc: func(ctx context.Context, kymaInstanceId string, ttl int) (*kymaenvironmentbinding.Binding, error) {
+					return newBinding, nil
+				},
+				deleteInstanceFunc: func(ctx context.Context, bindings []v1alpha1.Binding, kymaInstanceId string) error {
+					rollbackCalled = true
+					return tt.rollbackErr
+				},
+			}
+
+			c := &external{kube: kube, client: fc}
+			mg := &v1alpha1.KymaEnvironmentBinding{
+				ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "default"},
+				Spec: v1alpha1.KymaEnvironmentBindingSpec{
+					KymaEnvironmentId: "kyma-id",
+				},
+				Status: v1alpha1.KymaEnvironmentBindingStatus{
+					AtProvider: v1alpha1.KymaEnvironmentBindingObservation{
+						Bindings: []v1alpha1.Binding{},
+					},
+				},
+			}
+
+			got, err := c.Create(context.Background(), mg)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Create() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if rollbackCalled != tt.wantRollbackCalled {
+				t.Errorf("Create() rollbackCalled = %v, want %v", rollbackCalled, tt.wantRollbackCalled)
+			}
+			if tt.wantConnectionDetails && len(got.ConnectionDetails) == 0 {
+				t.Errorf("Create() expected connection details, got none")
+			}
+			if !tt.wantConnectionDetails && len(got.ConnectionDetails) > 0 {
+				t.Errorf("Create() expected no connection details on failure, got %v", got.ConnectionDetails)
+			}
+			if tt.wantErrContains != "" && err != nil {
+				if !strings.Contains(err.Error(), tt.wantErrContains) {
+					t.Errorf("expected error containing %q, got %v", tt.wantErrContains, err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Problem 

After upgrading from Crossplane 1.19.1 to 1.20.5, KymaEnviromentBinding resources repeatedly created bindings until hitting the 10-binding API limit, leaving all resources in failed state.

When Create() succesfully provisions a binding via the api but fails to write the binding id back to CR status, the binding becomes orphaned. It's invisible to the controller but still consuming a slot. On the next reconcile the controller sees empty status, sets ResourceExists=false, and fires Create() again. This repeats untill the quota is exhausted.

## Root cause: 

In crossplane v1.19, `SetConditions(ReconcileSuccess()) `on an already-successful resource was a no-op. `Condition.Equal()` didn't compare ObservedGeneration, so the condition wasn't replaced and no real watch event was emitted. In v1.20 the new ObservedGenerationPropagationManager stamps a fresh ObservedGeneration on every condition, and `Equal() `now includes that field, so every reconcile produces a genuine status write and a corresponding watch event.

The extra watch traffic causes the informer cache to lag the API server's resourceVersion more frequently. Between Observe and Create, the reconciler performs three metadata/status writes (finalizer, ExternalCreatePending anotation, observe-phase status) each bumping the resourceVersion. When `Create()` then attempts it's own `Status().Update()` using the stale in-memory object, the API server returns a 409 Conflict and the binding ID is never persisted.


The original `Create()` did not retry or handle this conflict:

```go
cr.Status.AtProvider.Bindings = append(cr.Status.AtProvider.Bindings, newBinding)
return managed.ExternalCreation{...}, errors.Wrap(c.kube.Status().Update(ctx, cr), errStatusUpdate)
```

When the status write failed, the binding ID was never persisted to the CR. The next
`Observe()` saw no bindings in status, returned `ResourceExists: false`, and `Create()` was
called agian... creating another orphaned binding on the provisioning API. This repeated until
the 10-binding limit was hit.

# Fix:
- updateStatusWithRetry: re-fetches the CR on every attempt (including the first) to get the latest resourceVersion, retries up to 5 times on 409 conflict errors with exponential backoff , respects context cancellation, and returns immediately on non-conflict errors
- If all retries are exhausted, rolls back the provisioning API binding via DeleteInstances to prevent it from becoming an orphaned slot
- Adds unit tests covering: success on first attempt, conflict resolved on retry, retries exhausted with rollback, retries exhausted with rollback failure, re-fetch failure, and context cancellation during backoff