### PR TITLE
fix(subscription): omit plan name when empty in create payload

### DIFF
--- a/internal/clients/subscription/subscription.go
+++ b/internal/clients/subscription/subscription.go
@@ -174,10 +174,18 @@ func (s *SubscriptionTypeMapper) SyncStatus(get *SubscriptionGet, crStatus *v1al
 }
 
 func (s *SubscriptionTypeMapper) ConvertToCreatePayload(cr *v1alpha1.Subscription) SubscriptionPost {
+	// Passing { "planName": "" } to the SAP SaaS Provisioning Service API when subscribing creates a new entitled application instead of subscribing to the existing one.
+	// This leaves the existing one with "state": "NOT_SUBSCRIBED".
+	// Observe gets the existing one, tries to subscribe and receives a HTTP 409 Conflict because the subaccount is already subscribed to the application.
+	// We avoid this by omitting the planName when it's empty.
+	var planName *string
+	if cr.Spec.ForProvider.PlanName != "" {
+		planName = &cr.Spec.ForProvider.PlanName
+	}
 	return SubscriptionPost{
 		appName: cr.Spec.ForProvider.AppName,
 		CreateSubscriptionRequestPayload: saas_client.CreateSubscriptionRequestPayload{
-			PlanName:           &cr.Spec.ForProvider.PlanName,
+			PlanName:           planName,
 			SubscriptionParams: s.ConvertToClientParams(cr),
 		},
 	}

--- a/internal/clients/subscription/subscription_test.go
+++ b/internal/clients/subscription/subscription_test.go
@@ -290,6 +290,18 @@ age: 30`)
 	assert.Equal(t, float64(30), mapped.SubscriptionParams["age"])
 }
 
+func TestSubscriptionTypeMapper_ConvertToCreatePayloadEmptyPlan(t *testing.T) {
+	raw := rawExtension(`{}`)
+	cr := NewSubscription("someName", "name1", "", raw)
+
+	uut := NewSubscriptionTypeMapper()
+	mapped := uut.ConvertToCreatePayload(cr)
+
+	assert.NotNil(t, mapped)
+	assert.Equal(t, "name1", mapped.appName)
+	assert.Nil(t, mapped.PlanName)
+}
+
 func TestSubscriptionTypeMapper_IsSynced(t *testing.T) {
 	raw := rawExtension(`{"name": "John", "age": 30}`)
 	cr := NewSubscription("someName", "name1", "plan2", raw)


### PR DESCRIPTION
Fixes #430 

Passing `{ "planName": "" }` to the SAP SaaS Provisioning Service API when subscribing creates a new entitled application instead of subscribing to the existing one. This leaves the existing one with "state": "NOT_SUBSCRIBED".

Observe gets the existing one, tries to subscribe and receives a HTTP 409 Conflict because the subaccount is already subscribed to the application.

We avoid this by omitting `planName` when it's empty.