### PR TITLE
fix: throw error when SubaccountApiCredential secret is missing clien…

### DIFF
--- a/config/btp_subaccount_api_credential/config.go
+++ b/config/btp_subaccount_api_credential/config.go
@@ -1,107 +1,124 @@
 package btp_subaccount_api_credential
 
 import (
-	"context"
+"context"
 
-	"github.com/pkg/errors"
+"github.com/pkg/errors"
 
-	"github.com/crossplane/crossplane-runtime/pkg/meta"
-	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
-	"github.com/crossplane/crossplane-runtime/pkg/resource"
-	"github.com/crossplane/upjet/pkg/config"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+"github.com/crossplane/crossplane-runtime/pkg/meta"
+"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
+"github.com/crossplane/crossplane-runtime/pkg/resource"
+"github.com/crossplane/upjet/pkg/config"
+corev1 "k8s.io/api/core/v1"
+"sigs.k8s.io/controller-runtime/pkg/client"
 
-	accountsv1alpha1 "github.com/sap/crossplane-provider-btp/apis/account/v1alpha1"
-
-	securityv1alpha1 "github.com/sap/crossplane-provider-btp/apis/security/v1alpha1"
-	providerv1alpha1 "github.com/sap/crossplane-provider-btp/apis/v1alpha1"
-	"github.com/sap/crossplane-provider-btp/internal/tracking"
+accountsv1alpha1 "github.com/sap/crossplane-provider-btp/apis/account/v1alpha1"
+securityv1alpha1 "github.com/sap/crossplane-provider-btp/apis/security/v1alpha1"
+providerv1alpha1 "github.com/sap/crossplane-provider-btp/apis/v1alpha1"
+"github.com/sap/crossplane-provider-btp/internal/tracking"
 )
 
 const (
-	errTrackRUsage   = "cannot track ResourceUsage"
-	errTypeAssertion = "managed resource is not of type SubaccountApiCredential"
+errTrackRUsage         = "cannot track ResourceUsage"
+errTypeAssertion       = "managed resource is not of type SubaccountApiCredential"
+errMissingClientSecret = "can not read client_secret from source, please delete external resource and re-create Crossplane resource"
 )
 
 // Configure configures individual resources by adding custom ResourceConfigurators.
 func Configure(p *config.Provider) {
-	p.AddResourceConfigurator("btp_subaccount_api_credential", func(r *config.Resource) {
-		r.ShortGroup = "security"
-		r.Kind = "SubaccountApiCredential"
-		r.UseAsync = false
+p.AddResourceConfigurator("btp_subaccount_api_credential", func(r *config.Resource) {
+r.ShortGroup = "security"
+r.Kind = "SubaccountApiCredential"
+r.UseAsync = false
 
-		// Mark all as sensitive to exclude them from the status
-		r.TerraformResource.Schema["client_secret"].Sensitive = true
-		r.TerraformResource.Schema["client_id"].Sensitive = true
-		r.TerraformResource.Schema["token_url"].Sensitive = true
-		r.TerraformResource.Schema["api_url"].Sensitive = true
+// Mark all as sensitive to exclude them from the status
+r.TerraformResource.Schema["client_secret"].Sensitive = true
+r.TerraformResource.Schema["client_id"].Sensitive = true
+r.TerraformResource.Schema["token_url"].Sensitive = true
+r.TerraformResource.Schema["api_url"].Sensitive = true
 
-		r.ExternalName.SetIdentifierArgumentFn = func(base map[string]any, name string) {
-			if name == "" {
-				base["name"] = "managed-subbaccount-api-credential"
-			} else {
-				base["name"] = name
-			}
-		}
+r.ExternalName.SetIdentifierArgumentFn = func(base map[string]any, name string) {
+if name == "" {
+base["name"] = "managed-subbaccount-api-credential"
+} else {
+base["name"] = name
+}
+}
 
-		r.MetaResource.ArgumentDocs["name"] = "The name if left unset defaults to managedsubbaccountapicredential"
+r.MetaResource.ArgumentDocs["name"] = "The name if left unset defaults to managedsubbaccountapicredential"
 
-		r.ExternalName.GetExternalNameFn = func(tfstate map[string]any) (string, error) {
-			return tfstate["name"].(string), nil
-		}
+r.ExternalName.GetExternalNameFn = func(tfstate map[string]any) (string, error) {
+return tfstate["name"].(string), nil
+}
 
-		r.References["subaccount_id"] = config.Reference{
-			Type:              "github.com/sap/crossplane-provider-btp/apis/account/v1alpha1.Subaccount",
-			Extractor:         "github.com/sap/crossplane-provider-btp/apis/account/v1alpha1.SubaccountUuid()",
-			RefFieldName:      "SubaccountRef",
-			SelectorFieldName: "SubaccountSelector",
-		}
+r.References["subaccount_id"] = config.Reference{
+Type:              "github.com/sap/crossplane-provider-btp/apis/account/v1alpha1.Subaccount",
+Extractor:         "github.com/sap/crossplane-provider-btp/apis/account/v1alpha1.SubaccountUuid()",
+RefFieldName:      "SubaccountRef",
+SelectorFieldName: "SubaccountSelector",
+}
 
-		// Add pre-delete hook using InitializerFns for finalizer management
-		r.InitializerFns = append(r.InitializerFns, func(kube client.Client) managed.Initializer {
-			return &DeletionProtectionInitializer{Kube: kube}
-		})
-	})
+// Add pre-delete hook using InitializerFns for finalizer management
+r.InitializerFns = append(r.InitializerFns, func(kube client.Client) managed.Initializer {
+return &DeletionProtectionInitializer{Kube: kube}
+})
+})
 
-	p.ConfigureResources()
+p.ConfigureResources()
 }
 
 // DeletionProtectionInitializer implements the managed.Initializer interface
 type DeletionProtectionInitializer struct {
-	Kube client.Client
+Kube client.Client
 }
 
 // Implement the managed.Initializer interface
 func (d *DeletionProtectionInitializer) Initialize(ctx context.Context, mg resource.Managed) error {
 
-	// Default reference tracker for tracking references
-	referenceTracker := tracking.NewDefaultReferenceResolverTracker(
-		d.Kube,
-	)
+// Default reference tracker for tracking references
+referenceTracker := tracking.NewDefaultReferenceResolverTracker(
+d.Kube,
+)
 
-	cr, ok := mg.(*securityv1alpha1.SubaccountApiCredential)
+cr, ok := mg.(*securityv1alpha1.SubaccountApiCredential)
 
-	if !ok {
-		return errors.New(errTypeAssertion)
-	}
+if !ok {
+return errors.New(errTypeAssertion)
+}
 
-	// Manually define reference tracking for relevant fields
-	if cr.Spec.ForProvider.SubaccountID != nil {
+// Manually define reference tracking for relevant fields
+if cr.Spec.ForProvider.SubaccountID != nil && cr.Spec.ForProvider.SubaccountRef != nil {
 
-		// Use a custom reference tracker to track the subaccount reference
-		err := referenceTracker.CreateTrackingReference(ctx, cr, *cr.Spec.ForProvider.SubaccountRef, accountsv1alpha1.SubaccountGroupVersionKind)
+// Use a custom reference tracker to track the subaccount reference
+err := referenceTracker.CreateTrackingReference(ctx, cr, *cr.Spec.ForProvider.SubaccountRef, accountsv1alpha1.SubaccountGroupVersionKind)
 
-		if err != nil {
-			return errors.Wrap(err, errTrackRUsage)
-		}
-	}
+if err != nil {
+return errors.Wrap(err, errTrackRUsage)
+}
+}
 
-	if meta.WasDeleted(mg) {
+if meta.WasDeleted(mg) {
 
-		referenceTracker.SetConditions(ctx, mg)
-		if blocked := referenceTracker.DeleteShouldBeBlocked(mg); blocked {
-			return errors.New(providerv1alpha1.ErrResourceInUse)
-		}
-	}
-	return nil
+referenceTracker.SetConditions(ctx, mg)
+if blocked := referenceTracker.DeleteShouldBeBlocked(mg); blocked {
+return errors.New(providerv1alpha1.ErrResourceInUse)
+}
+}
+
+if cr.Spec.ForProvider.CertificatePassed == nil {
+secretRef := cr.GetWriteConnectionSecretToReference()
+if secretRef != nil && secretRef.Name != "" {
+secret := &corev1.Secret{}
+err := d.Kube.Get(ctx, client.ObjectKey{
+Name:      secretRef.Name,
+Namespace: secretRef.Namespace,
+}, secret)
+if err == nil {
+if _, ok := secret.Data["attribute.client_secret"]; !ok {
+return errors.New(errMissingClientSecret)
+}
+}
+}
+}
+return nil
 }

--- a/config/btp_subaccount_api_credential/config.go
+++ b/config/btp_subaccount_api_credential/config.go
@@ -1,124 +1,124 @@
 package btp_subaccount_api_credential
 
 import (
-"context"
+	"context"
 
-"github.com/pkg/errors"
+	"github.com/pkg/errors"
 
-"github.com/crossplane/crossplane-runtime/pkg/meta"
-"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
-"github.com/crossplane/crossplane-runtime/pkg/resource"
-"github.com/crossplane/upjet/pkg/config"
-corev1 "k8s.io/api/core/v1"
-"sigs.k8s.io/controller-runtime/pkg/client"
+	"github.com/crossplane/crossplane-runtime/pkg/meta"
+	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
+	"github.com/crossplane/upjet/pkg/config"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
-accountsv1alpha1 "github.com/sap/crossplane-provider-btp/apis/account/v1alpha1"
-securityv1alpha1 "github.com/sap/crossplane-provider-btp/apis/security/v1alpha1"
-providerv1alpha1 "github.com/sap/crossplane-provider-btp/apis/v1alpha1"
-"github.com/sap/crossplane-provider-btp/internal/tracking"
+	accountsv1alpha1 "github.com/sap/crossplane-provider-btp/apis/account/v1alpha1"
+	securityv1alpha1 "github.com/sap/crossplane-provider-btp/apis/security/v1alpha1"
+	providerv1alpha1 "github.com/sap/crossplane-provider-btp/apis/v1alpha1"
+	"github.com/sap/crossplane-provider-btp/internal/tracking"
 )
 
 const (
-errTrackRUsage         = "cannot track ResourceUsage"
-errTypeAssertion       = "managed resource is not of type SubaccountApiCredential"
-errMissingClientSecret = "can not read client_secret from source, please delete external resource and re-create Crossplane resource"
+	errTrackRUsage         = "cannot track ResourceUsage"
+	errTypeAssertion       = "managed resource is not of type SubaccountApiCredential"
+	errMissingClientSecret = "can not read client_secret from source, please delete external resource and re-create Crossplane resource"
 )
 
 // Configure configures individual resources by adding custom ResourceConfigurators.
 func Configure(p *config.Provider) {
-p.AddResourceConfigurator("btp_subaccount_api_credential", func(r *config.Resource) {
-r.ShortGroup = "security"
-r.Kind = "SubaccountApiCredential"
-r.UseAsync = false
+	p.AddResourceConfigurator("btp_subaccount_api_credential", func(r *config.Resource) {
+		r.ShortGroup = "security"
+		r.Kind = "SubaccountApiCredential"
+		r.UseAsync = false
 
-// Mark all as sensitive to exclude them from the status
-r.TerraformResource.Schema["client_secret"].Sensitive = true
-r.TerraformResource.Schema["client_id"].Sensitive = true
-r.TerraformResource.Schema["token_url"].Sensitive = true
-r.TerraformResource.Schema["api_url"].Sensitive = true
+		// Mark all as sensitive to exclude them from the status
+		r.TerraformResource.Schema["client_secret"].Sensitive = true
+		r.TerraformResource.Schema["client_id"].Sensitive = true
+		r.TerraformResource.Schema["token_url"].Sensitive = true
+		r.TerraformResource.Schema["api_url"].Sensitive = true
 
-r.ExternalName.SetIdentifierArgumentFn = func(base map[string]any, name string) {
-if name == "" {
-base["name"] = "managed-subbaccount-api-credential"
-} else {
-base["name"] = name
-}
-}
+		r.ExternalName.SetIdentifierArgumentFn = func(base map[string]any, name string) {
+			if name == "" {
+				base["name"] = "managed-subbaccount-api-credential"
+			} else {
+				base["name"] = name
+			}
+		}
 
-r.MetaResource.ArgumentDocs["name"] = "The name if left unset defaults to managedsubbaccountapicredential"
+		r.MetaResource.ArgumentDocs["name"] = "The name if left unset defaults to managedsubbaccountapicredential"
 
-r.ExternalName.GetExternalNameFn = func(tfstate map[string]any) (string, error) {
-return tfstate["name"].(string), nil
-}
+		r.ExternalName.GetExternalNameFn = func(tfstate map[string]any) (string, error) {
+			return tfstate["name"].(string), nil
+		}
 
-r.References["subaccount_id"] = config.Reference{
-Type:              "github.com/sap/crossplane-provider-btp/apis/account/v1alpha1.Subaccount",
-Extractor:         "github.com/sap/crossplane-provider-btp/apis/account/v1alpha1.SubaccountUuid()",
-RefFieldName:      "SubaccountRef",
-SelectorFieldName: "SubaccountSelector",
-}
+		r.References["subaccount_id"] = config.Reference{
+			Type:              "github.com/sap/crossplane-provider-btp/apis/account/v1alpha1.Subaccount",
+			Extractor:         "github.com/sap/crossplane-provider-btp/apis/account/v1alpha1.SubaccountUuid()",
+			RefFieldName:      "SubaccountRef",
+			SelectorFieldName: "SubaccountSelector",
+		}
 
-// Add pre-delete hook using InitializerFns for finalizer management
-r.InitializerFns = append(r.InitializerFns, func(kube client.Client) managed.Initializer {
-return &DeletionProtectionInitializer{Kube: kube}
-})
-})
+		// Add pre-delete hook using InitializerFns for finalizer management
+		r.InitializerFns = append(r.InitializerFns, func(kube client.Client) managed.Initializer {
+			return &DeletionProtectionInitializer{Kube: kube}
+		})
+	})
 
-p.ConfigureResources()
+	p.ConfigureResources()
 }
 
 // DeletionProtectionInitializer implements the managed.Initializer interface
 type DeletionProtectionInitializer struct {
-Kube client.Client
+	Kube client.Client
 }
 
 // Implement the managed.Initializer interface
 func (d *DeletionProtectionInitializer) Initialize(ctx context.Context, mg resource.Managed) error {
 
-// Default reference tracker for tracking references
-referenceTracker := tracking.NewDefaultReferenceResolverTracker(
-d.Kube,
-)
+	// Default reference tracker for tracking references
+	referenceTracker := tracking.NewDefaultReferenceResolverTracker(
+		d.Kube,
+	)
 
-cr, ok := mg.(*securityv1alpha1.SubaccountApiCredential)
+	cr, ok := mg.(*securityv1alpha1.SubaccountApiCredential)
 
-if !ok {
-return errors.New(errTypeAssertion)
-}
+	if !ok {
+		return errors.New(errTypeAssertion)
+	}
 
-// Manually define reference tracking for relevant fields
-if cr.Spec.ForProvider.SubaccountID != nil && cr.Spec.ForProvider.SubaccountRef != nil {
+	// Manually define reference tracking for relevant fields
+	if cr.Spec.ForProvider.SubaccountID != nil && cr.Spec.ForProvider.SubaccountRef != nil {
 
-// Use a custom reference tracker to track the subaccount reference
-err := referenceTracker.CreateTrackingReference(ctx, cr, *cr.Spec.ForProvider.SubaccountRef, accountsv1alpha1.SubaccountGroupVersionKind)
+		// Use a custom reference tracker to track the subaccount reference
+		err := referenceTracker.CreateTrackingReference(ctx, cr, *cr.Spec.ForProvider.SubaccountRef, accountsv1alpha1.SubaccountGroupVersionKind)
 
-if err != nil {
-return errors.Wrap(err, errTrackRUsage)
-}
-}
+		if err != nil {
+			return errors.Wrap(err, errTrackRUsage)
+		}
+	}
 
-if meta.WasDeleted(mg) {
+	if meta.WasDeleted(mg) {
 
-referenceTracker.SetConditions(ctx, mg)
-if blocked := referenceTracker.DeleteShouldBeBlocked(mg); blocked {
-return errors.New(providerv1alpha1.ErrResourceInUse)
-}
-}
+		referenceTracker.SetConditions(ctx, mg)
+		if blocked := referenceTracker.DeleteShouldBeBlocked(mg); blocked {
+			return errors.New(providerv1alpha1.ErrResourceInUse)
+		}
+	}
 
-if cr.Spec.ForProvider.CertificatePassed == nil {
-secretRef := cr.GetWriteConnectionSecretToReference()
-if secretRef != nil && secretRef.Name != "" {
-secret := &corev1.Secret{}
-err := d.Kube.Get(ctx, client.ObjectKey{
-Name:      secretRef.Name,
-Namespace: secretRef.Namespace,
-}, secret)
-if err == nil {
-if _, ok := secret.Data["attribute.client_secret"]; !ok {
-return errors.New(errMissingClientSecret)
-}
-}
-}
-}
-return nil
+	if cr.Spec.ForProvider.CertificatePassed == nil {
+		secretRef := cr.GetWriteConnectionSecretToReference()
+		if secretRef != nil && secretRef.Name != "" {
+			secret := &corev1.Secret{}
+			err := d.Kube.Get(ctx, client.ObjectKey{
+				Name:      secretRef.Name,
+				Namespace: secretRef.Namespace,
+			}, secret)
+			if err == nil {
+				if _, ok := secret.Data["attribute.client_secret"]; !ok {
+					return errors.New(errMissingClientSecret)
+				}
+			}
+		}
+	}
+	return nil
 }

--- a/config/btp_subaccount_api_credential/config.go
+++ b/config/btp_subaccount_api_credential/config.go
@@ -108,6 +108,7 @@ func (d *DeletionProtectionInitializer) Initialize(ctx context.Context, mg resou
 	// According to the Terraform BTP provider docs, client_secret is only generated
 	// "if the certificate is omitted". Certificate-based credentials never have a
 	// client_secret, so this check must be skipped for them to avoid false positives.
+	// See: https://registry.terraform.io/providers/SAP/btp/latest/docs/resources/subaccount_api_credential
 	if cr.Spec.ForProvider.CertificatePassed == nil {
 		secretRef := cr.GetWriteConnectionSecretToReference()
 		if secretRef != nil && secretRef.Name != "" {

--- a/config/btp_subaccount_api_credential/config.go
+++ b/config/btp_subaccount_api_credential/config.go
@@ -105,6 +105,9 @@ func (d *DeletionProtectionInitializer) Initialize(ctx context.Context, mg resou
 		}
 	}
 
+	// According to the Terraform BTP provider docs, client_secret is only generated
+	// "if the certificate is omitted". Certificate-based credentials never have a
+	// client_secret, so this check must be skipped for them to avoid false positives.
 	if cr.Spec.ForProvider.CertificatePassed == nil {
 		secretRef := cr.GetWriteConnectionSecretToReference()
 		if secretRef != nil && secretRef.Name != "" {

--- a/config/btp_subaccount_api_credential/config.go
+++ b/config/btp_subaccount_api_credential/config.go
@@ -21,7 +21,7 @@ import (
 const (
 	errTrackRUsage         = "cannot track ResourceUsage"
 	errTypeAssertion       = "managed resource is not of type SubaccountApiCredential"
-	errMissingClientSecret = "can not read client_secret from source, please delete external resource and re-create Crossplane resource"
+	errMissingClientSecret = "cannot read client_secret from source, please delete external resource and re-create Crossplane resource"
 )
 
 // Configure configures individual resources by adding custom ResourceConfigurators.
@@ -114,7 +114,11 @@ func (d *DeletionProtectionInitializer) Initialize(ctx context.Context, mg resou
 				Namespace: secretRef.Namespace,
 			}, secret)
 			if err == nil {
-				if _, ok := secret.Data["attribute.client_secret"]; !ok {
+				_, hasClientID := secret.Data["attribute.client_id"]
+				_, hasTokenURL := secret.Data["attribute.token_url"]
+				_, hasAPIURL := secret.Data["attribute.api_url"]
+				_, hasClientSecret := secret.Data["attribute.client_secret"]
+				if hasClientID && hasTokenURL && hasAPIURL && !hasClientSecret {
 					return errors.New(errMissingClientSecret)
 				}
 			}

--- a/config/btp_subaccount_api_credential/config_test.go
+++ b/config/btp_subaccount_api_credential/config_test.go
@@ -1,0 +1,89 @@
+package btp_subaccount_api_credential
+
+import (
+	"context"
+	"testing"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/pkg/test"
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	securityv1alpha1 "github.com/sap/crossplane-provider-btp/apis/security/v1alpha1"
+)
+
+func TestDeletionProtectionInitializer_Initialize(t *testing.T) {
+	type want struct {
+		err error
+	}
+
+	cases := map[string]struct {
+		cr   *securityv1alpha1.SubaccountApiCredential
+		kube client.Client
+		want want
+	}{
+		"no secret ref": {
+			cr:   &securityv1alpha1.SubaccountApiCredential{},
+			kube: &test.MockClient{},
+			want: want{err: nil},
+		},
+		"secret has client_secret": {
+			cr: &securityv1alpha1.SubaccountApiCredential{
+				Spec: securityv1alpha1.SubaccountApiCredentialSpec{
+					ResourceSpec: xpv1.ResourceSpec{
+						WriteConnectionSecretToReference: &xpv1.SecretReference{
+							Name:      "my-secret",
+							Namespace: "default",
+						},
+					},
+				},
+			},
+			kube: &test.MockClient{
+				MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+					if secret, ok := obj.(*corev1.Secret); ok {
+						secret.Data = map[string][]byte{
+							"attribute.client_secret": []byte("my-secret-value"),
+						}
+					}
+					return nil
+				}),
+			},
+			want: want{err: nil},
+		},
+		"secret missing client_secret": {
+			cr: &securityv1alpha1.SubaccountApiCredential{
+				Spec: securityv1alpha1.SubaccountApiCredentialSpec{
+					ResourceSpec: xpv1.ResourceSpec{
+						WriteConnectionSecretToReference: &xpv1.SecretReference{
+							Name:      "my-secret",
+							Namespace: "default",
+						},
+					},
+				},
+			},
+			kube: &test.MockClient{
+				MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+					if secret, ok := obj.(*corev1.Secret); ok {
+						secret.Data = map[string][]byte{
+							"attribute.client_id": []byte("some-id"),
+						}
+					}
+					return nil
+				}),
+			},
+			want: want{err: errors.New(errMissingClientSecret)},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			d := &DeletionProtectionInitializer{Kube: tc.kube}
+			err := d.Initialize(context.Background(), tc.cr)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("Initialize() error mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/config/btp_subaccount_api_credential/config_test.go
+++ b/config/btp_subaccount_api_credential/config_test.go
@@ -52,7 +52,32 @@ func TestDeletionProtectionInitializer_Initialize(t *testing.T) {
 			},
 			want: want{err: nil},
 		},
-		"secret missing client_secret": {
+		"secret missing client_secret with other keys present": {
+			cr: &securityv1alpha1.SubaccountApiCredential{
+				Spec: securityv1alpha1.SubaccountApiCredentialSpec{
+					ResourceSpec: xpv1.ResourceSpec{
+						WriteConnectionSecretToReference: &xpv1.SecretReference{
+							Name:      "my-secret",
+							Namespace: "default",
+						},
+					},
+				},
+			},
+			kube: &test.MockClient{
+				MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+					if secret, ok := obj.(*corev1.Secret); ok {
+						secret.Data = map[string][]byte{
+							"attribute.client_id": []byte("some-id"),
+							"attribute.token_url": []byte("https://token-url"),
+							"attribute.api_url":   []byte("https://api-url"),
+						}
+					}
+					return nil
+				}),
+			},
+			want: want{err: errors.New(errMissingClientSecret)},
+		},
+		"secret incomplete - only client_id present - no error": {
 			cr: &securityv1alpha1.SubaccountApiCredential{
 				Spec: securityv1alpha1.SubaccountApiCredentialSpec{
 					ResourceSpec: xpv1.ResourceSpec{
@@ -73,7 +98,7 @@ func TestDeletionProtectionInitializer_Initialize(t *testing.T) {
 					return nil
 				}),
 			},
-			want: want{err: errors.New(errMissingClientSecret)},
+			want: want{err: nil},
 		},
 	}
 


### PR DESCRIPTION
Fixes #444

When a SubaccountApiCredential is orphaned (exists in BTP but not managed by Crossplane), the BTP API returns only 3 keys on GET,- omitting `client_secret`. This caused the resource to appear `Ready=True` with an incomplete connection secret.

This PR adds a check in `Initialize()` that verifies the connection secret contains `attribute.client_secret`. If missing, it returns an error so Crossplane marks the resource as not ready. Certificate-based credentials (where `client_secret` is never present) are skipped.

Also fixes a pre-existing nil pointer dereference when `SubaccountRef` is nil but `SubaccountID` is set.