### PR TITLE
fix: flatten connection details in ServiceBinding Create path

### DIFF
--- a/internal/controller/account/servicebinding/servicebinding.go
+++ b/internal/controller/account/servicebinding/servicebinding.go
@@ -217,6 +217,11 @@ func (e *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 		return managed.ExternalCreation{}, errors.Wrap(err, errCreateBinding)
 	}
 
+	creation.ConnectionDetails, err = flattenSecretData(creation.ConnectionDetails)
+	if err != nil {
+		return managed.ExternalCreation{}, errors.Wrap(err, errFlattenSecret)
+	}
+
 	return creation, nil
 }
 


### PR DESCRIPTION
Fixes #633

## Summary
- Apply `flattenSecretData` to connection details returned from `Create`, matching the existing behavior in `Observe`
- Prevents `attribute.credentials` from briefly appearing in the connection secret after creation