### PR TITLE
feat: add SAP Kubernetes Service Binding specification support

### DIFF
--- a/apis/account/v1alpha1/servicebinding_types.go
+++ b/apis/account/v1alpha1/servicebinding_types.go
@@ -134,6 +134,14 @@ type ServiceBindingSpec struct {
 	// Rotation defines the parameters for rotating the service credential binding.
 	// +kubebuilder:validation:Optional
 	Rotation *RotationParameters `json:"rotation,omitempty"`
+
+	// SecretFormat controls the format of the connection secret.
+	// When set to "sap-kubernetes", the secret follows the SAP Kubernetes Service Binding specification
+	// with metadata properties (type, label, plan, tags, instance_name, instance_guid) and a .metadata descriptor.
+	// When omitted or empty, only the raw credentials are stored (default, backward-compatible).
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Enum="";"sap-kubernetes"
+	SecretFormat string `json:"secretFormat,omitempty"`
 }
 
 // A ServiceBindingStatus represents the observed state of a ServiceBinding.

--- a/examples/sample/servicebinding.yaml
+++ b/examples/sample/servicebinding.yaml
@@ -17,3 +17,23 @@ spec:
   writeConnectionSecretToRef:
     name: destination-binding
     namespace: default
+---
+# ServiceBinding with SAP Kubernetes service binding format
+# The secret will include metadata properties (type, label, plan, tags, instance_name, instance_guid)
+# and a .metadata descriptor following the SAP Kubernetes Service Binding specification.
+# This enables consumption by SAP libraries (@sap/xsenv, CAP, Cloud SDK).
+apiVersion: account.btp.sap.crossplane.io/v1alpha1
+kind: ServiceBinding
+metadata:
+  name: destination-binding-sap-format
+spec:
+  forProvider:
+    name: destination-binding-sap-format
+    serviceInstanceRef:
+      name: destination-instance
+    subaccountRef:
+      name: sa-serviceinstance
+  secretFormat: sap-kubernetes
+  writeConnectionSecretToRef:
+    name: destination-binding-sap-format
+    namespace: default

--- a/internal/controller/account/servicebinding/secretformat.go
+++ b/internal/controller/account/servicebinding/secretformat.go
@@ -1,0 +1,147 @@
+package servicebinding
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"sort"
+
+	"github.com/pkg/errors"
+	kubeclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/sap/crossplane-provider-btp/apis/account/v1alpha1"
+)
+
+const (
+	SecretFormatSAPKubernetes = "sap-kubernetes"
+
+	errGetServiceInstance      = "cannot get service instance for secret enrichment"
+	errBuildMetadataDescriptor = "cannot build .metadata descriptor"
+)
+
+type secretMetadataProperty struct {
+	Name      string `json:"name"`
+	Format    string `json:"format"`
+	Container bool   `json:"container,omitempty"`
+}
+
+type secretMetadata struct {
+	MetaDataProperties   []secretMetadataProperty `json:"metaDataProperties"`
+	CredentialProperties []secretMetadataProperty `json:"credentialProperties"`
+}
+
+var metadataKeys = map[string]bool{
+	"type":          true,
+	"label":         true,
+	"plan":          true,
+	"tags":          true,
+	"instance_name": true,
+	"instance_guid": true,
+	".metadata":     true,
+}
+
+func enrichConnectionDetails(
+	credentialData map[string][]byte,
+	instanceName string,
+	instanceGUID string,
+	offeringName string,
+	planName string,
+) (map[string][]byte, error) {
+	if credentialData == nil {
+		credentialData = make(map[string][]byte)
+	}
+
+	credentialData["type"] = []byte(offeringName)
+	credentialData["label"] = []byte(offeringName)
+	credentialData["plan"] = []byte(planName)
+	credentialData["instance_name"] = []byte(instanceName)
+	credentialData["instance_guid"] = []byte(instanceGUID)
+	credentialData["tags"] = []byte("[]")
+
+	metaDataProps := []secretMetadataProperty{
+		{Name: "instance_name", Format: "text"},
+		{Name: "instance_guid", Format: "text"},
+		{Name: "plan", Format: "text"},
+		{Name: "label", Format: "text"},
+		{Name: "type", Format: "text"},
+		{Name: "tags", Format: "json"},
+	}
+
+	var credKeys []string
+	for k := range credentialData {
+		if !metadataKeys[k] {
+			credKeys = append(credKeys, k)
+		}
+	}
+	sort.Strings(credKeys)
+
+	credentialProps := make([]secretMetadataProperty, 0, len(credKeys))
+	for _, k := range credKeys {
+		credentialProps = append(credentialProps, secretMetadataProperty{
+			Name:   k,
+			Format: detectFormat(credentialData[k]),
+		})
+	}
+
+	metadata := secretMetadata{
+		MetaDataProperties:   metaDataProps,
+		CredentialProperties: credentialProps,
+	}
+	metadataJSON, err := json.Marshal(metadata)
+	if err != nil {
+		return nil, errors.Wrap(err, errBuildMetadataDescriptor)
+	}
+	credentialData[".metadata"] = metadataJSON
+
+	return credentialData, nil
+}
+
+func detectFormat(value []byte) string {
+	trimmed := bytes.TrimSpace(value)
+	if len(trimmed) == 0 {
+		return "text"
+	}
+	switch trimmed[0] {
+	case '{', '[':
+		if json.Valid(trimmed) {
+			return "json"
+		}
+	}
+	return "text"
+}
+
+func fetchServiceInstance(ctx context.Context, kube kubeclient.Client, refName string) (*v1alpha1.ServiceInstance, error) {
+	si := &v1alpha1.ServiceInstance{}
+	err := kube.Get(ctx, kubeclient.ObjectKey{Name: refName}, si)
+	if err != nil {
+		return nil, errors.Wrap(err, errGetServiceInstance)
+	}
+	return si, nil
+}
+
+func (e *external) enrichWithSAPMetadata(
+	ctx context.Context,
+	cr *v1alpha1.ServiceBinding,
+	connDetails map[string][]byte,
+) (map[string][]byte, error) {
+	var siRefName string
+	if cr.Spec.ForProvider.ServiceInstanceRef != nil {
+		siRefName = cr.Spec.ForProvider.ServiceInstanceRef.Name
+	}
+	if siRefName == "" {
+		return connDetails, nil
+	}
+
+	si, err := fetchServiceInstance(ctx, e.kube, siRefName)
+	if err != nil {
+		return nil, err
+	}
+
+	return enrichConnectionDetails(
+		connDetails,
+		si.Spec.ForProvider.Name,
+		si.Status.AtProvider.ID,
+		si.Spec.ForProvider.OfferingName,
+		si.Spec.ForProvider.PlanName,
+	)
+}

--- a/internal/controller/account/servicebinding/secretformat_test.go
+++ b/internal/controller/account/servicebinding/secretformat_test.go
@@ -1,0 +1,251 @@
+package servicebinding
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestDetectFormat(t *testing.T) {
+	cases := map[string]struct {
+		input []byte
+		want  string
+	}{
+		"PlainString": {
+			input: []byte("hello"),
+			want:  "text",
+		},
+		"EmptyValue": {
+			input: []byte(""),
+			want:  "text",
+		},
+		"URLString": {
+			input: []byte("https://example.com/api"),
+			want:  "text",
+		},
+		"JSONObject": {
+			input: []byte(`{"clientid":"abc","clientsecret":"xyz"}`),
+			want:  "json",
+		},
+		"JSONArray": {
+			input: []byte(`["tag1","tag2"]`),
+			want:  "json",
+		},
+		"EmptyJSONObject": {
+			input: []byte(`{}`),
+			want:  "json",
+		},
+		"EmptyJSONArray": {
+			input: []byte(`[]`),
+			want:  "json",
+		},
+		"InvalidJSON": {
+			input: []byte("{broken"),
+			want:  "text",
+		},
+		"NumberAsString": {
+			input: []byte("42"),
+			want:  "text",
+		},
+		"BooleanAsString": {
+			input: []byte("true"),
+			want:  "text",
+		},
+		"NestedJSON": {
+			input: []byte(`{"uaa":{"url":"https://auth.example.com","clientid":"x"}}`),
+			want:  "json",
+		},
+		"WhitespaceJSON": {
+			input: []byte(`  { "key": "value" }  `),
+			want:  "json",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := detectFormat(tc.input)
+			if got != tc.want {
+				t.Errorf("detectFormat(%q) = %q, want %q", string(tc.input), got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEnrichConnectionDetails(t *testing.T) {
+	cases := map[string]struct {
+		inputCreds   map[string][]byte
+		instanceName string
+		instanceGUID string
+		offeringName string
+		planName     string
+		wantKeys     []string
+		wantErr      bool
+	}{
+		"EmptyCredentials": {
+			inputCreds:   map[string][]byte{},
+			instanceName: "my-instance",
+			instanceGUID: "guid-123",
+			offeringName: "xsuaa",
+			planName:     "application",
+			wantKeys:     []string{"type", "label", "plan", "tags", "instance_name", "instance_guid", ".metadata"},
+		},
+		"NilCredentials": {
+			inputCreds:   nil,
+			instanceName: "my-instance",
+			instanceGUID: "guid-123",
+			offeringName: "xsuaa",
+			planName:     "application",
+			wantKeys:     []string{"type", "label", "plan", "tags", "instance_name", "instance_guid", ".metadata"},
+		},
+		"WithStringCredentials": {
+			inputCreds: map[string][]byte{
+				"url":       []byte("https://api.example.com"),
+				"client_id": []byte("admin"),
+			},
+			instanceName: "my-instance",
+			instanceGUID: "guid-123",
+			offeringName: "destination",
+			planName:     "lite",
+			wantKeys:     []string{"type", "label", "plan", "tags", "instance_name", "instance_guid", ".metadata", "url", "client_id"},
+		},
+		"WithJSONCredentials": {
+			inputCreds: map[string][]byte{
+				"uaa": []byte(`{"clientid":"x","clientsecret":"y"}`),
+			},
+			instanceName: "my-instance",
+			instanceGUID: "guid-123",
+			offeringName: "xsuaa",
+			planName:     "application",
+			wantKeys:     []string{"type", "label", "plan", "tags", "instance_name", "instance_guid", ".metadata", "uaa"},
+		},
+		"ReservedKeyOverwrite": {
+			inputCreds: map[string][]byte{
+				"type": []byte("old-type-from-credentials"),
+				"url":  []byte("https://api.example.com"),
+			},
+			instanceName: "my-instance",
+			instanceGUID: "guid-123",
+			offeringName: "xsuaa",
+			planName:     "application",
+			wantKeys:     []string{"type", "label", "plan", "tags", "instance_name", "instance_guid", ".metadata", "url"},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			result, err := enrichConnectionDetails(tc.inputCreds, tc.instanceName, tc.instanceGUID, tc.offeringName, tc.planName)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			for _, key := range tc.wantKeys {
+				if _, ok := result[key]; !ok {
+					t.Errorf("expected key %q in result, but not found", key)
+				}
+			}
+		})
+	}
+}
+
+func TestEnrichConnectionDetails_MetadataValues(t *testing.T) {
+	result, err := enrichConnectionDetails(
+		map[string][]byte{
+			"url":       []byte("https://api.example.com"),
+			"client_id": []byte("admin"),
+		},
+		"my-instance",
+		"guid-123",
+		"destination",
+		"lite",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if diff := cmp.Diff(string(result["type"]), "destination"); diff != "" {
+		t.Errorf("type mismatch (-got +want):\n%s", diff)
+	}
+	if diff := cmp.Diff(string(result["label"]), "destination"); diff != "" {
+		t.Errorf("label mismatch (-got +want):\n%s", diff)
+	}
+	if diff := cmp.Diff(string(result["plan"]), "lite"); diff != "" {
+		t.Errorf("plan mismatch (-got +want):\n%s", diff)
+	}
+	if diff := cmp.Diff(string(result["instance_name"]), "my-instance"); diff != "" {
+		t.Errorf("instance_name mismatch (-got +want):\n%s", diff)
+	}
+	if diff := cmp.Diff(string(result["instance_guid"]), "guid-123"); diff != "" {
+		t.Errorf("instance_guid mismatch (-got +want):\n%s", diff)
+	}
+	if diff := cmp.Diff(string(result["tags"]), "[]"); diff != "" {
+		t.Errorf("tags mismatch (-got +want):\n%s", diff)
+	}
+}
+
+func TestEnrichConnectionDetails_MetadataDescriptor(t *testing.T) {
+	result, err := enrichConnectionDetails(
+		map[string][]byte{
+			"url": []byte("https://api.example.com"),
+			"uaa": []byte(`{"clientid":"x"}`),
+		},
+		"my-instance",
+		"guid-123",
+		"xsuaa",
+		"application",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var md secretMetadata
+	if err := json.Unmarshal(result[".metadata"], &md); err != nil {
+		t.Fatalf("failed to unmarshal .metadata: %v", err)
+	}
+
+	expectedMetaProps := []secretMetadataProperty{
+		{Name: "instance_name", Format: "text"},
+		{Name: "instance_guid", Format: "text"},
+		{Name: "plan", Format: "text"},
+		{Name: "label", Format: "text"},
+		{Name: "type", Format: "text"},
+		{Name: "tags", Format: "json"},
+	}
+	if diff := cmp.Diff(md.MetaDataProperties, expectedMetaProps); diff != "" {
+		t.Errorf("metaDataProperties mismatch (-got +want):\n%s", diff)
+	}
+
+	expectedCredProps := []secretMetadataProperty{
+		{Name: "uaa", Format: "json"},
+		{Name: "url", Format: "text"},
+	}
+	if diff := cmp.Diff(md.CredentialProperties, expectedCredProps); diff != "" {
+		t.Errorf("credentialProperties mismatch (-got +want):\n%s", diff)
+	}
+}
+
+func TestEnrichConnectionDetails_ReservedKeyOverwrite(t *testing.T) {
+	result, err := enrichConnectionDetails(
+		map[string][]byte{
+			"type": []byte("old-value"),
+		},
+		"my-instance",
+		"guid-123",
+		"xsuaa",
+		"application",
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if string(result["type"]) != "xsuaa" {
+		t.Errorf("expected type to be overwritten to 'xsuaa', got %q", string(result["type"]))
+	}
+}

--- a/internal/controller/account/servicebinding/servicebinding.go
+++ b/internal/controller/account/servicebinding/servicebinding.go
@@ -163,6 +163,13 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		return managed.ExternalObservation{}, errors.Wrap(err, errFlattenSecret)
 	}
 
+	if cr.Spec.SecretFormat == SecretFormatSAPKubernetes && observation.ConnectionDetails != nil {
+		observation.ConnectionDetails, err = e.enrichWithSAPMetadata(ctx, cr, observation.ConnectionDetails)
+		if err != nil {
+			return managed.ExternalObservation{}, errors.Wrap(err, "cannot enrich connection details")
+		}
+	}
+
 	observation.ResourceUpToDate = observation.ResourceUpToDate && !e.keyRotator.HasExpiredKeys(cr)
 
 	// Validate rotation settings and set status condition

--- a/internal/controller/account/servicebinding/servicebinding.go
+++ b/internal/controller/account/servicebinding/servicebinding.go
@@ -229,6 +229,13 @@ func (e *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 		return managed.ExternalCreation{}, errors.Wrap(err, errFlattenSecret)
 	}
 
+	if cr.Spec.SecretFormat == SecretFormatSAPKubernetes && creation.ConnectionDetails != nil {
+		creation.ConnectionDetails, err = e.enrichWithSAPMetadata(ctx, cr, creation.ConnectionDetails)
+		if err != nil {
+			return managed.ExternalCreation{}, errors.Wrap(err, "cannot enrich connection details")
+		}
+	}
+
 	return creation, nil
 }
 

--- a/internal/controller/account/servicebinding/servicebinding_test.go
+++ b/internal/controller/account/servicebinding/servicebinding_test.go
@@ -2,6 +2,7 @@ package servicebinding
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -554,6 +555,14 @@ func withConditions(conditions ...xpv1.Condition) func(*v1alpha1.ServiceBinding)
 	}
 }
 
+func mustMarshalJSON(v interface{}) []byte {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
 // Test Observe method - This validates the main observation logic
 func TestObserve(t *testing.T) {
 	type fields struct {
@@ -814,6 +823,175 @@ func TestObserve(t *testing.T) {
 						cr.Status.AtProvider.CreatedDate = &metav1.Time{Time: createdTime}
 						lastModifiedTime, _ := time.Parse(time.RFC3339, "2023-10-21T15:45:00Z")
 						cr.Status.AtProvider.LastModified = &metav1.Time{Time: lastModifiedTime}
+					},
+				),
+			},
+		},
+		"SAPFormatEnrichesConnectionDetails": {
+			reason: "should enrich connection details when secretFormat is sap-kubernetes",
+			fields: fields{
+				clientFactory: &MockServiceBindingClientFactory{
+					Client: &MockServiceBindingClient{
+						observation: managed.ExternalObservation{
+							ResourceExists:   true,
+							ResourceUpToDate: false,
+							ConnectionDetails: managed.ConnectionDetails{
+								"url":       []byte("https://api.example.com"),
+								"client_id": []byte("admin"),
+							},
+						},
+					},
+				},
+				keyRotator: &MockKeyRotator{
+					hasExpiredKeysResult: false,
+				},
+				tracker: &MockTracker{},
+				kube: &test.MockClient{
+					MockGet: func(_ context.Context, key kubeclient.ObjectKey, obj kubeclient.Object) error {
+						if si, ok := obj.(*v1alpha1.ServiceInstance); ok {
+							si.Spec.ForProvider.Name = "my-instance"
+							si.Spec.ForProvider.OfferingName = "xsuaa"
+							si.Spec.ForProvider.PlanName = "application"
+							si.Status.AtProvider.ID = "instance-guid-123"
+							return nil
+						}
+						return errors.New("unexpected Get call")
+					},
+				},
+			},
+			args: args{
+				mg: expectedServiceBinding(
+					withMetadata("test-external-name", nil),
+					func(cr *v1alpha1.ServiceBinding) {
+						cr.Spec.SecretFormat = "sap-kubernetes"
+						cr.Spec.ForProvider.ServiceInstanceRef = &xpv1.Reference{Name: "my-si"}
+					},
+				),
+			},
+			want: want{
+				o: managed.ExternalObservation{
+					ResourceExists:   true,
+					ResourceUpToDate: false,
+					ConnectionDetails: managed.ConnectionDetails{
+						"url":           []byte("https://api.example.com"),
+						"client_id":     []byte("admin"),
+						"type":          []byte("xsuaa"),
+						"label":         []byte("xsuaa"),
+						"plan":          []byte("application"),
+						"instance_name": []byte("my-instance"),
+						"instance_guid": []byte("instance-guid-123"),
+						"tags":          []byte("[]"),
+						".metadata":     mustMarshalJSON(secretMetadata{
+							MetaDataProperties: []secretMetadataProperty{
+								{Name: "instance_name", Format: "text"},
+								{Name: "instance_guid", Format: "text"},
+								{Name: "plan", Format: "text"},
+								{Name: "label", Format: "text"},
+								{Name: "type", Format: "text"},
+								{Name: "tags", Format: "json"},
+							},
+							CredentialProperties: []secretMetadataProperty{
+								{Name: "client_id", Format: "text"},
+								{Name: "url", Format: "text"},
+							},
+						}),
+					},
+				},
+				cr: expectedServiceBinding(
+					withMetadata("test-external-name", nil),
+					func(cr *v1alpha1.ServiceBinding) {
+						cr.Spec.SecretFormat = "sap-kubernetes"
+						cr.Spec.ForProvider.ServiceInstanceRef = &xpv1.Reference{Name: "my-si"}
+					},
+				),
+			},
+		},
+		"SAPFormatNoRefGracefulDegradation": {
+			reason: "should return unenriched details when secretFormat is sap-kubernetes but no ServiceInstanceRef",
+			fields: fields{
+				clientFactory: &MockServiceBindingClientFactory{
+					Client: &MockServiceBindingClient{
+						observation: managed.ExternalObservation{
+							ResourceExists:   true,
+							ResourceUpToDate: false,
+							ConnectionDetails: managed.ConnectionDetails{
+								"url": []byte("https://api.example.com"),
+							},
+						},
+					},
+				},
+				keyRotator: &MockKeyRotator{
+					hasExpiredKeysResult: false,
+				},
+				tracker: &MockTracker{},
+				kube:    &test.MockClient{},
+			},
+			args: args{
+				mg: expectedServiceBinding(
+					withMetadata("test-external-name", nil),
+					func(cr *v1alpha1.ServiceBinding) {
+						cr.Spec.SecretFormat = "sap-kubernetes"
+						// No ServiceInstanceRef set
+					},
+				),
+			},
+			want: want{
+				o: managed.ExternalObservation{
+					ResourceExists:   true,
+					ResourceUpToDate: false,
+					ConnectionDetails: managed.ConnectionDetails{
+						"url": []byte("https://api.example.com"),
+					},
+				},
+				cr: expectedServiceBinding(
+					withMetadata("test-external-name", nil),
+					func(cr *v1alpha1.ServiceBinding) {
+						cr.Spec.SecretFormat = "sap-kubernetes"
+					},
+				),
+			},
+		},
+		"DefaultFormatNoEnrichment": {
+			reason: "should not enrich connection details when secretFormat is empty",
+			fields: fields{
+				clientFactory: &MockServiceBindingClientFactory{
+					Client: &MockServiceBindingClient{
+						observation: managed.ExternalObservation{
+							ResourceExists:   true,
+							ResourceUpToDate: false,
+							ConnectionDetails: managed.ConnectionDetails{
+								"url": []byte("https://api.example.com"),
+							},
+						},
+					},
+				},
+				keyRotator: &MockKeyRotator{
+					hasExpiredKeysResult: false,
+				},
+				tracker: &MockTracker{},
+				kube:    &test.MockClient{},
+			},
+			args: args{
+				mg: expectedServiceBinding(
+					withMetadata("test-external-name", nil),
+					func(cr *v1alpha1.ServiceBinding) {
+						cr.Spec.ForProvider.ServiceInstanceRef = &xpv1.Reference{Name: "my-si"}
+						// No SecretFormat set
+					},
+				),
+			},
+			want: want{
+				o: managed.ExternalObservation{
+					ResourceExists:   true,
+					ResourceUpToDate: false,
+					ConnectionDetails: managed.ConnectionDetails{
+						"url": []byte("https://api.example.com"),
+					},
+				},
+				cr: expectedServiceBinding(
+					withMetadata("test-external-name", nil),
+					func(cr *v1alpha1.ServiceBinding) {
+						cr.Spec.ForProvider.ServiceInstanceRef = &xpv1.Reference{Name: "my-si"}
 					},
 				),
 			},

--- a/package/crds/account.btp.sap.crossplane.io_servicebindings.yaml
+++ b/package/crds/account.btp.sap.crossplane.io_servicebindings.yaml
@@ -434,6 +434,16 @@ spec:
                 - message: ttl must be greater than or equal to frequency
                   rule: '!has(self.ttl) || (has(self.frequency) && duration(self.ttl)
                     >= duration(self.frequency))'
+              secretFormat:
+                description: |-
+                  SecretFormat controls the format of the connection secret.
+                  When set to "sap-kubernetes", the secret follows the SAP Kubernetes Service Binding specification
+                  with metadata properties (type, label, plan, tags, instance_name, instance_guid) and a .metadata descriptor.
+                  When omitted or empty, only the raw credentials are stored (default, backward-compatible).
+                enum:
+                - ""
+                - sap-kubernetes
+                type: string
               writeConnectionSecretToRef:
                 description: |-
                   WriteConnectionSecretToReference specifies the namespace and name of a


### PR DESCRIPTION
Add opt-in secretFormat field to ServiceBindingSpec that enriches connection secrets with SAP metadata (type, label, plan, tags, instance_name, instance_guid) and a .metadata JSON descriptor when set to "sap-kubernetes". This enables consumption by SAP libraries (@sap/xsenv, CAP, Cloud SDK). Existing bindings are unaffected.