### PR TITLE
fix(subscription): allow empty plan name in external-name validation

### DIFF
--- a/internal/controller/account/subscription/subscription.go
+++ b/internal/controller/account/subscription/subscription.go
@@ -249,9 +249,9 @@ func (c *external) loadSubscription(ctx context.Context, cr *v1alpha1.Subscripti
 		return nil, nil
 	}
 
-	// Validate external-name format (should be appName/planName)
+	// Validate external-name format (should be appName/planName, planName may be empty)
 	if !isValidExternalNameFormat(externalName) {
-		return nil, errors.Errorf("invalid external-name format: %s, expected format: <appName>/<planName>", externalName)
+		return nil, errors.Errorf("invalid external-name format: %s, expected format: <appName>/<planName> (planName may be empty)", externalName)
 	}
 
 	// Get subscription from API - if it returns nil, it means resource doesn't exist (drift scenario)
@@ -259,9 +259,10 @@ func (c *external) loadSubscription(ctx context.Context, cr *v1alpha1.Subscripti
 }
 
 // isValidExternalNameFormat validates that the external name is in the format appName/planName
+// planName may be empty
 func isValidExternalNameFormat(externalName string) bool {
 	parts := strings.Split(externalName, "/")
-	return len(parts) == 2 && parts[0] != "" && parts[1] != ""
+	return len(parts) == 2 && parts[0] != ""
 }
 
 // syncStatus delegates saving the observation based on external resource to the typemapper

--- a/internal/controller/account/subscription/subscription_test.go
+++ b/internal/controller/account/subscription/subscription_test.go
@@ -67,7 +67,7 @@ func TestObserve(t *testing.T) {
 			},
 			want: want{
 				o:   managed.ExternalObservation{},
-				err: errors.Wrap(errors.New("invalid external-name format: invalid-format-without-slash, expected format: <appName>/<planName>"), "while loading subscription"),
+				err: errors.Wrap(errors.New("invalid external-name format: invalid-format-without-slash, expected format: <appName>/<planName> (planName may be empty)"), "while loading subscription"),
 				cr:  NewSubscription("sub-test", WithStatus(v1alpha1.SubscriptionObservation{}), WithExternalName("invalid-format-without-slash")),
 			},
 		},
@@ -78,19 +78,33 @@ func TestObserve(t *testing.T) {
 			},
 			want: want{
 				o:   managed.ExternalObservation{},
-				err: errors.Wrap(errors.New("invalid external-name format: /, expected format: <appName>/<planName>"), "while loading subscription"),
+				err: errors.Wrap(errors.New("invalid external-name format: /, expected format: <appName>/<planName> (planName may be empty)"), "while loading subscription"),
 				cr:  NewSubscription("sub-test", WithStatus(v1alpha1.SubscriptionObservation{}), WithExternalName("/")),
 			},
 		},
-		"InvalidExternalNameFormatEmptyParts": {
-			reason: "Invalid external-name format with empty parts should return error",
+		"InvalidExternalNameFormatEmptyAppName": {
+			reason: "Invalid external-name format with empty app name should return error",
 			args: args{
-				cr: NewSubscription("sub-test", WithStatus(v1alpha1.SubscriptionObservation{}), WithExternalName("appname/")),
+				cr: NewSubscription("sub-test", WithStatus(v1alpha1.SubscriptionObservation{}), WithExternalName("/planName")),
 			},
 			want: want{
 				o:   managed.ExternalObservation{},
-				err: errors.Wrap(errors.New("invalid external-name format: appname/, expected format: <appName>/<planName>"), "while loading subscription"),
-				cr:  NewSubscription("sub-test", WithStatus(v1alpha1.SubscriptionObservation{}), WithExternalName("appname/")),
+				err: errors.Wrap(errors.New("invalid external-name format: /planName, expected format: <appName>/<planName> (planName may be empty)"), "while loading subscription"),
+				cr:  NewSubscription("sub-test", WithStatus(v1alpha1.SubscriptionObservation{}), WithExternalName("/planName")),
+			},
+		},
+		"ValidExternalNameFormatEmptyPlanName": {
+			reason: "External-name format with empty plan name should be valid",
+			args: args{
+				cr: NewSubscription("sub-test", WithStatus(v1alpha1.SubscriptionObservation{}), WithExternalName("appname/")),
+				mockApiHandler: &MockApiHandler{
+					returnGet: nil,
+					returnErr: nil,
+				},
+			},
+			want: want{
+				o:  managed.ExternalObservation{ResourceExists: false},
+				cr: NewSubscription("sub-test", WithStatus(v1alpha1.SubscriptionObservation{}), WithExternalName("appname/")),
 			},
 		},
 		"APIErrorOnRead": {


### PR DESCRIPTION
Follow up for #430, empty plan name is valid for subscriptions without a plan name