### PR TITLE
chore: external name service manager

### DIFF
--- a/apis/account/v1beta1/servicemanager_types.go
+++ b/apis/account/v1beta1/servicemanager_types.go
@@ -85,6 +85,14 @@ type ServiceManagerStatus struct {
 // +kubebuilder:object:root=true
 
 // A ServiceManager is a managed resource that represents a service manager instance and its API credentials in the SAP Business Technology Platform
+//
+// External-Name Configuration:
+//   - Follows Standard: yes
+//   - Format: `<serviceInstanceID>/<serviceBindingID>` (both UUIDs)
+//   - How to find:
+//     - UI: BTP Cockpit → Subaccounts → [Select Subaccount] → Instances and Subscriptions → Look for service-manager instance and binding IDs
+//     - CLI: `btp list services/instance` and `btp list services/binding` in the subaccount context
+//
 // +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"

--- a/internal/controller/account/servicemanager/servicemanager.go
+++ b/internal/controller/account/servicemanager/servicemanager.go
@@ -2,6 +2,7 @@ package servicemanager
 
 import (
 	"context"
+	"strings"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
@@ -12,6 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apisv1beta1 "github.com/sap/crossplane-provider-btp/apis/account/v1beta1"
+	"github.com/sap/crossplane-provider-btp/internal"
 	providerv1alpha1 "github.com/sap/crossplane-provider-btp/apis/v1alpha1"
 	"github.com/sap/crossplane-provider-btp/btp"
 	"github.com/sap/crossplane-provider-btp/internal/tracking"
@@ -133,6 +135,21 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		return managed.ExternalObservation{}, errors.New(errNotServiceManager)
 	}
 
+	externalName := meta.GetExternalName(cr)
+
+	// Empty external-name means resource doesn't exist yet — trigger Create
+	if externalName == "" {
+		return managed.ExternalObservation{ResourceExists: false}, nil
+	}
+
+	// Validate external-name format
+	if !isValidExternalNameFormat(externalName) {
+		return managed.ExternalObservation{}, errors.Errorf(
+			"invalid external-name format: %q, expected format: <serviceInstanceID> or <serviceInstanceID>/<serviceBindingID> (UUIDs)",
+			externalName,
+		)
+	}
+
 	resStatus, err := c.tfClient.ObserveResources(ctx, cr)
 
 	statusErr := c.setStatus(ctx, resStatus, cr)
@@ -214,4 +231,19 @@ func formExternalName(serviceInstanceID, serviceBindingID string) string {
 		return serviceInstanceID
 	}
 	return serviceInstanceID + "/" + serviceBindingID
+}
+
+// isValidExternalNameFormat validates that the external name is a valid UUID
+// or a compound key of two UUIDs separated by "/".
+// A single UUID is valid during mid-creation when only the instance exists.
+func isValidExternalNameFormat(externalName string) bool {
+	parts := strings.Split(externalName, "/")
+	switch len(parts) {
+	case 1:
+		return internal.IsValidUUID(parts[0])
+	case 2:
+		return internal.IsValidUUID(parts[0]) && internal.IsValidUUID(parts[1])
+	default:
+		return false
+	}
 }

--- a/internal/controller/account/servicemanager/servicemanager_test.go
+++ b/internal/controller/account/servicemanager/servicemanager_test.go
@@ -22,6 +22,9 @@ import (
 
 var (
 	errTracking = errors.New("trackingError")
+
+	testInstanceID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+	testBindingID  = "f0e1d2c3-b4a5-6789-0abc-def123456789"
 )
 
 // ====================================================================================
@@ -297,9 +300,41 @@ func TestObserve(t *testing.T) {
 		want want
 	}{
 		{
+			name: "EmptyExternalName",
+			args: args{
+				cr: NewServiceManager("test", WithExternalName("")),
+				tfClient: &TfClientFake{
+					observeFn: func() (sm.ResourcesStatus, error) {
+						return sm.ResourcesStatus{}, nil
+					},
+				},
+			},
+			want: want{
+				obs: managed.ExternalObservation{ResourceExists: false},
+				err: nil,
+				cr:  NewServiceManager("test", WithExternalName("")),
+			},
+		},
+		{
+			name: "InvalidExternalNameFormat",
+			args: args{
+				cr: NewServiceManager("test", WithExternalName("not-a-uuid")),
+				tfClient: &TfClientFake{
+					observeFn: func() (sm.ResourcesStatus, error) {
+						return sm.ResourcesStatus{}, nil
+					},
+				},
+			},
+			want: want{
+				obs: managed.ExternalObservation{},
+				err: errors.New("invalid external-name format"),
+				cr:  NewServiceManager("test", WithExternalName("not-a-uuid")),
+			},
+		},
+		{
 			name: "InstanceObserveError",
 			args: args{
-				cr: NewServiceManager("test"),
+				cr: NewServiceManager("test", WithExternalName(testInstanceID+"/"+testBindingID)),
 				tfClient: &TfClientFake{
 					observeFn: func() (sm.ResourcesStatus, error) {
 						return sm.ResourcesStatus{}, errors.New("observeError")
@@ -310,6 +345,7 @@ func TestObserve(t *testing.T) {
 				obs: managed.ExternalObservation{},
 				err: errors.New("observeError"),
 				cr: NewServiceManager("test",
+					WithExternalName(testInstanceID+"/"+testBindingID),
 					WithStatus(apisv1beta1.ServiceManagerObservation{
 						Status: apisv1beta1.ServiceManagerUnbound,
 					}),
@@ -319,7 +355,7 @@ func TestObserve(t *testing.T) {
 		{
 			name: "NotAvailable",
 			args: args{
-				cr: NewServiceManager("test"),
+				cr: NewServiceManager("test", WithExternalName(testInstanceID+"/"+testBindingID)),
 				tfClient: &TfClientFake{
 					observeFn: func() (sm.ResourcesStatus, error) {
 						// Doesn't matter what observe is returned exactly, as long as its passed through and IDs are persisted
@@ -334,6 +370,7 @@ func TestObserve(t *testing.T) {
 				obs: managed.ExternalObservation{ResourceExists: false},
 				err: nil,
 				cr: NewServiceManager("test",
+					WithExternalName(testInstanceID+"/"+testBindingID),
 					WithStatus(apisv1beta1.ServiceManagerObservation{
 						Status:            apisv1beta1.ServiceManagerUnbound,
 						ServiceInstanceID: "someID",
@@ -345,7 +382,7 @@ func TestObserve(t *testing.T) {
 		{
 			name: "IsAvailable",
 			args: args{
-				cr: NewServiceManager("test"),
+				cr: NewServiceManager("test", WithExternalName(testInstanceID+"/"+testBindingID)),
 				tfClient: &TfClientFake{
 					observeFn: func() (sm.ResourcesStatus, error) {
 						// Doesn't matter if updated or not
@@ -366,12 +403,39 @@ func TestObserve(t *testing.T) {
 				obs: managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: true, ConnectionDetails: map[string][]byte{"key": []byte("value")}},
 				err: nil,
 				cr: NewServiceManager("test",
+					WithExternalName(testInstanceID+"/"+testBindingID),
 					WithStatus(apisv1beta1.ServiceManagerObservation{
 						Status:            apisv1beta1.ServiceManagerBound,
 						ServiceInstanceID: "someID",
 						ServiceBindingID:  "anotherID",
 					}),
 					WithConditions(xpv1.Available())),
+			},
+		},
+		{
+			name: "ValidSingleUUID_MidCreation",
+			args: args{
+				cr: NewServiceManager("test", WithExternalName(testInstanceID)),
+				tfClient: &TfClientFake{
+					observeFn: func() (sm.ResourcesStatus, error) {
+						return sm.ResourcesStatus{
+							ExternalObservation: managed.ExternalObservation{ResourceExists: false},
+							InstanceID:          testInstanceID,
+						}, nil
+					},
+				},
+			},
+			want: want{
+				obs: managed.ExternalObservation{ResourceExists: false},
+				err: nil,
+				cr: NewServiceManager("test",
+					WithExternalName(testInstanceID),
+					WithStatus(apisv1beta1.ServiceManagerObservation{
+						Status:            apisv1beta1.ServiceManagerUnbound,
+						ServiceInstanceID: testInstanceID,
+					}),
+					WithConditions(xpv1.Unavailable()),
+				),
 			},
 		},
 	}
@@ -390,7 +454,11 @@ func TestObserve(t *testing.T) {
 				t.Errorf("\ne.Observe(): -want, +got:\n%s\n", diff)
 			}
 			if diff := cmp.Diff(err, tc.want.err, test.EquateErrors()); diff != "" {
-				t.Errorf("\ne.Observe(): -want error, +got error:\n%s\n", diff)
+				if err != nil && tc.want.err != nil && strings.Contains(err.Error(), tc.want.err.Error()) {
+					// error messages match by substring
+				} else {
+					t.Errorf("\ne.Observe(): -want error, +got error:\n%s\n", diff)
+				}
 			}
 			if diff := cmp.Diff(tc.args.cr, tc.want.cr); diff != "" {
 				t.Errorf("\ne.Observe(): expected cr after operation -want, +got:\n%s\n", diff)
@@ -584,6 +652,35 @@ func TestDelete(t *testing.T) {
 			}
 			if diff := cmp.Diff(tc.want.cr, tc.args.cr); diff != "" {
 				t.Errorf("\ne.Delete(): expected cr after operation -want, +got:\n%s\n", diff)
+			}
+		})
+	}
+}
+
+func TestIsValidExternalNameFormat(t *testing.T) {
+	tests := []struct {
+		name         string
+		externalName string
+		want         bool
+	}{
+		{name: "ValidCompoundKey", externalName: testInstanceID + "/" + testBindingID, want: true},
+		{name: "ValidSingleUUID", externalName: testInstanceID, want: true},
+		{name: "Empty", externalName: "", want: false},
+		{name: "NotAUUID", externalName: "not-a-uuid", want: false},
+		{name: "MetadataName", externalName: "my-service-manager", want: false},
+		{name: "SlashOnly", externalName: "/", want: false},
+		{name: "EmptyParts", externalName: "/", want: false},
+		{name: "UUIDSlashEmpty", externalName: testInstanceID + "/", want: false},
+		{name: "EmptySlashUUID", externalName: "/" + testBindingID, want: false},
+		{name: "ThreeParts", externalName: testInstanceID + "/" + testBindingID + "/extra", want: false},
+		{name: "UUIDSlashNotUUID", externalName: testInstanceID + "/not-uuid", want: false},
+		{name: "NotUUIDSlashUUID", externalName: "not-uuid/" + testBindingID, want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isValidExternalNameFormat(tc.externalName)
+			if got != tc.want {
+				t.Errorf("isValidExternalNameFormat(%q) = %v, want %v", tc.externalName, got, tc.want)
 			}
 		})
 	}

--- a/internal/controller/account/servicemanager/zz_setup.go
+++ b/internal/controller/account/servicemanager/zz_setup.go
@@ -19,7 +19,7 @@ import (
 
 // Setup adds a controller that reconciles GlobalAccount managed resources.
 func Setup(mgr ctrl.Manager, o internalopts.CrossplaneOptions) error {
-	return providerconfig.DefaultSetup(
+	return providerconfig.DefaultSetupWithoutDefaultInitializer(
 		mgr,
 		o,
 		&apisv1beta1.ServiceManager{},

--- a/test/e2e/servicemanager_test.go
+++ b/test/e2e/servicemanager_test.go
@@ -17,7 +17,6 @@ import (
 	"sigs.k8s.io/e2e-framework/pkg/features"
 
 	"github.com/sap/crossplane-provider-btp/apis"
-	"github.com/sap/crossplane-provider-btp/apis/account/v1alpha1"
 	"github.com/sap/crossplane-provider-btp/apis/account/v1beta1"
 )
 
@@ -46,7 +45,7 @@ func TestServiceManagerCreationFlow(t *testing.T) {
 				sm := &v1beta1.ServiceManager{}
 				MustGetResource(t, cfg, smCreateName, nil, sm)
 				// Status bound?
-				if sm.Status.AtProvider.Status != v1alpha1.ServiceManagerBound {
+				if sm.Status.AtProvider.Status != v1beta1.ServiceManagerBound {
 					t.Error("Binding status not set as expected")
 				}
 
@@ -75,127 +74,30 @@ func TestServiceManagerCreationFlow(t *testing.T) {
 }
 
 func TestServiceManagerImport(t *testing.T) {
-	importFeatureSuite := features.New("ServiceManager Import Flow").
-		Setup(
-			func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-				resources.ImportResources(ctx, t, cfg, "testdata/crs/servicemanager/import/environment")
-				r, _ := res.New(cfg.Client().RESTConfig())
-				_ = apis.AddToScheme(r.GetScheme())
-
-				// Wait for the subaccount to be ready before creating ServiceManager
-				waitForResource(&v1alpha1.Subaccount{
-					ObjectMeta: metav1.ObjectMeta{Name: "sm-import-sa-test", Namespace: cfg.Namespace()},
-				}, cfg, t, wait.WithTimeout(15*time.Minute))
-
-				// This will create the external resource but not delete it when we remove the k8s resource
-				sm := &v1beta1.ServiceManager{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      smImportName + "-create",
-						Namespace: cfg.Namespace(),
-					},
-					Spec: v1beta1.ServiceManagerSpec{
-						ResourceSpec: xpv1.ResourceSpec{
-							ManagementPolicies: []xpv1.ManagementAction{
-								xpv1.ManagementActionObserve,
-								xpv1.ManagementActionCreate,
-								xpv1.ManagementActionUpdate,
-								xpv1.ManagementActionLateInitialize,
-							},
-							WriteConnectionSecretToReference: &xpv1.SecretReference{
-								Name:      smImportName + "-create",
-								Namespace: cfg.Namespace(),
-							},
-						},
-						ForProvider: v1beta1.ServiceManagerParameters{
-							SubaccountRef: &xpv1.Reference{Name: "sm-import-sa-test"},
-						},
-					},
-				}
-
-				err := cfg.Client().Resources().Create(ctx, sm)
-				if err != nil {
-					t.Errorf("Failed to create ServiceManager for import preparation: %v", err)
-				}
-
-				waitForResource(sm, cfg, t, wait.WithTimeout(7*time.Minute))
-
-				createdSM := &v1beta1.ServiceManager{}
-
-				MustGetResource(t, cfg, smImportName+"-create", nil, createdSM)
-
-				actualExternalName := createdSM.GetAnnotations()["crossplane.io/external-name"]
-				t.Logf("Using external name for import: %s", actualExternalName)
-
-				AwaitResourceDeletionOrFail(ctx, t, cfg, createdSM, wait.WithTimeout(time.Minute*2))
-
-				ctx = context.WithValue(ctx, "actualExternalName", actualExternalName)
-
-				return ctx
+	baseServiceManager := &v1beta1.ServiceManager{
+		Spec: v1beta1.ServiceManagerSpec{
+			ResourceSpec: xpv1.ResourceSpec{
+				WriteConnectionSecretToReference: &xpv1.SecretReference{
+					Name:      smImportName,
+					Namespace: "default",
+				},
 			},
-		).
-		Assess(
-			"Check Imported ServiceManager gets healthy", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-				actualExternalName := ctx.Value("actualExternalName").(string)
-
-				sm := &v1beta1.ServiceManager{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      smImportName,
-						Namespace: cfg.Namespace(),
-						Annotations: map[string]string{
-							"crossplane.io/external-name": actualExternalName,
-						},
-					},
-					Spec: v1beta1.ServiceManagerSpec{
-						ResourceSpec: xpv1.ResourceSpec{
-							ManagementPolicies: []xpv1.ManagementAction{xpv1.ManagementActionObserve},
-							WriteConnectionSecretToReference: &xpv1.SecretReference{
-								Name:      smImportName,
-								Namespace: cfg.Namespace(),
-							},
-						},
-						ForProvider: v1beta1.ServiceManagerParameters{
-							SubaccountRef: &xpv1.Reference{Name: "sm-import-sa-test"},
-						},
-					},
-				}
-
-				err := cfg.Client().Resources().Create(ctx, sm)
-				if err != nil {
-					t.Errorf("Failed to create import ServiceManager: %v", err)
-				}
-
-				waitForResource(sm, cfg, t)
-
-				importedSM := &v1beta1.ServiceManager{}
-				MustGetResource(t, cfg, smImportName, nil, importedSM)
-
-				if importedSM.Status.AtProvider.Status != v1beta1.ServiceManagerBound {
-					t.Error("ServiceManager Status not as expected")
-				}
-
-				assertServiceManagerSecret(t, ctx, cfg, importedSM)
-
-				return ctx
+			ForProvider: v1beta1.ServiceManagerParameters{
+				SubaccountRef: &xpv1.Reference{Name: "sm-import-sa-test"},
 			},
-		).Teardown(
-		func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			sm := &v1beta1.ServiceManager{}
-			MustGetResource(t, cfg, smImportName, nil, sm)
-
-			// Allow resource to be deleted for teardown
-			sm.Spec.ResourceSpec.ManagementPolicies = []xpv1.ManagementAction{xpv1.ManagementActionDelete, xpv1.ManagementActionObserve}
-			if err := cfg.Client().Resources().Update(ctx, sm); err != nil {
-				t.Errorf("Failed to update ServiceManager deletion policy: %v", err)
-			}
-
-			AwaitResourceDeletionOrFail(ctx, t, cfg, sm, wait.WithTimeout(time.Minute*5))
-
-			DeleteResourcesIgnoreMissing(ctx, t, cfg, "servicemanager/import/environment", wait.WithTimeout(time.Minute*15))
-			return ctx
 		},
-	).Feature()
+	}
 
-	testenv.Test(t, importFeatureSuite)
+	importTester := NewImportTester(
+		baseServiceManager,
+		"sm-import-test",
+		WithDependentResourceDirectory[*v1beta1.ServiceManager]("testdata/crs/servicemanager/import/environment"),
+		WithWaitCreateTimeout[*v1beta1.ServiceManager](wait.WithTimeout(7*time.Minute)),
+		WithWaitDeletionTimeout[*v1beta1.ServiceManager](wait.WithTimeout(5*time.Minute)),
+		WithWaitDependentResourceTimeout[*v1beta1.ServiceManager](wait.WithTimeout(15*time.Minute)),
+	)
+
+	testenv.Test(t, importTester.BuildTestFeature("ServiceManager Import Flow").Feature())
 }
 
 func assertServiceManagerSecret(t *testing.T, ctx context.Context, cfg *envconf.Config, cm *v1beta1.ServiceManager) {


### PR DESCRIPTION
WIP

Remark:
When applying a serviceManager MR with external name set, the first event is:
```
cannot patch the managed resource via server-side apply: .spec.forProvi │
│ der.planName: field not declared in schema                                                                                                        
```
Probably due to the necessary planName resolution in the first obeservation before the service instance and binding can be created. This needs to be adressed.