### PR TITLE
fix: cache btpclient between reconciles to minimize login calls

### DIFF
--- a/internal/controller/environment/cloudfoundry/cfenvironment.go
+++ b/internal/controller/environment/cloudfoundry/cfenvironment.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sap/crossplane-provider-btp/apis/environment/v1alpha1"
 	providerv1alpha1 "github.com/sap/crossplane-provider-btp/apis/v1alpha1"
 	env "github.com/sap/crossplane-provider-btp/internal/clients/cfenvironment"
+	"github.com/sap/crossplane-provider-btp/internal/controller/providerconfig"
 	"github.com/sap/crossplane-provider-btp/internal/tracking"
 
 	"github.com/sap/crossplane-provider-btp/btp"
@@ -101,9 +102,16 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 	if cisBinding == nil {
 		return nil, errors.New(errGetCredentialsSecret)
 	}
-	svc, err := c.newServiceFn(cisBinding, ServiceAccountSecretData)
 
-	return &external{client: env.NewCloudFoundryOrganization(*svc), kube: c.kube}, err
+	pcName := mg.GetProviderConfigReference().Name
+	svc, err := providerconfig.DefaultClientCache.GetOrCreate(pcName, cisBinding, ServiceAccountSecretData, func() (*btp.Client, error) {
+		return c.newServiceFn(cisBinding, ServiceAccountSecretData)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &external{client: env.NewCloudFoundryOrganization(*svc), kube: c.kube}, nil
 }
 
 // An ExternalClient observes, then either creates, updates, or deletes an

--- a/internal/controller/environment/kyma/zz_connect.go
+++ b/internal/controller/environment/kyma/zz_connect.go
@@ -13,7 +13,9 @@ import (
 
 	"github.com/sap/crossplane-provider-btp/apis/environment/v1alpha1"
 	providerv1alpha1 "github.com/sap/crossplane-provider-btp/apis/v1alpha1"
+	"github.com/sap/crossplane-provider-btp/btp"
 	kymaenv "github.com/sap/crossplane-provider-btp/internal/clients/kymaenvironment"
+	"github.com/sap/crossplane-provider-btp/internal/controller/providerconfig"
 )
 
 // Connect typically produces an ExternalClient by:
@@ -68,7 +70,14 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 	if cisBinding == nil {
 		return nil, errors.New(errGetCredentialsSecret)
 	}
-	svc, err := c.newServiceFn(cisBinding, ServiceAccountSecretData)
 
-	return &external{client: kymaenv.NewKymaEnvironments(*svc), log: c.log, record: c.record, kube: c.kube, tracker: c.resourcetracker, httpClient: &http.Client{Timeout: 10 * time.Second}}, err
+	pcName := mg.GetProviderConfigReference().Name
+	svc, err := providerconfig.DefaultClientCache.GetOrCreate(pcName, cisBinding, ServiceAccountSecretData, func() (*btp.Client, error) {
+		return c.newServiceFn(cisBinding, ServiceAccountSecretData)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &external{client: kymaenv.NewKymaEnvironments(*svc), log: c.log, record: c.record, kube: c.kube, tracker: c.resourcetracker, httpClient: &http.Client{Timeout: 10 * time.Second}}, nil
 }

--- a/internal/controller/kymaenvironmentbinding/zz_connect.go
+++ b/internal/controller/kymaenvironmentbinding/zz_connect.go
@@ -15,6 +15,7 @@ import (
 	providerv1alpha1 "github.com/sap/crossplane-provider-btp/apis/v1alpha1"
 	"github.com/sap/crossplane-provider-btp/btp"
 	"github.com/sap/crossplane-provider-btp/internal/clients/kymaenvironmentbinding"
+	"github.com/sap/crossplane-provider-btp/internal/controller/providerconfig"
 )
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
@@ -64,7 +65,14 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 	if cisBinding == nil {
 		return nil, errors.New(errGetCredentialsSecret)
 	}
-	svc, err := c.newServiceFn(cisBinding, ServiceAccountSecretData)
+
+	pcName := mg.GetProviderConfigReference().Name
+	svc, err := providerconfig.DefaultClientCache.GetOrCreate(pcName, cisBinding, ServiceAccountSecretData, func() (*btp.Client, error) {
+		return c.newServiceFn(cisBinding, ServiceAccountSecretData)
+	})
+	if err != nil {
+		return nil, err
+	}
 	return &external{
 			client:     kymaenvironmentbinding.NewKymaBindings(*svc),
 			tracker:    c.resourcetracker,
@@ -72,5 +80,5 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 			httpClient: btp.DebugPrintHTTPClient(btp.WithHttpClient(&http.Client{Timeout: 10 * time.Second})),
 			kube:       c.kube,
 		},
-		err
+		nil
 }

--- a/internal/controller/providerconfig/client_cache.go
+++ b/internal/controller/providerconfig/client_cache.go
@@ -1,0 +1,106 @@
+package providerconfig
+
+import (
+	"crypto/sha256"
+	"sync"
+	"time"
+
+	"github.com/sap/crossplane-provider-btp/btp"
+)
+
+const defaultEvictionTimeout = 2 * time.Hour
+
+type cachedEntry struct {
+	client     *btp.Client
+	secretHash [32]byte
+	lastUsed   time.Time
+}
+
+// ClientCache caches BTP clients per ProviderConfig name, invalidating only
+// when the underlying secret content changes. Token refresh is handled
+// automatically by the oauth2 library inside each cached HTTP client.
+// Entries unused for longer than the eviction timeout are removed.
+type ClientCache struct {
+	mu              sync.RWMutex
+	entries         map[string]*cachedEntry
+	evictionTimeout time.Duration
+}
+
+// NewClientCache creates a new client cache.
+func NewClientCache() *ClientCache {
+	return &ClientCache{
+		entries:         make(map[string]*cachedEntry),
+		evictionTimeout: defaultEvictionTimeout,
+	}
+}
+
+// GetOrCreate returns a cached client if the secret content hash matches.
+// Otherwise it calls createFn to build a new client and caches it.
+// Token refresh is handled transparently by the oauth2 transport inside the client.
+// Stale entries unused for longer than the eviction timeout are removed on each call.
+func (c *ClientCache) GetOrCreate(
+	pcName string,
+	cisSecret []byte,
+	saSecret []byte,
+	createFn func() (*btp.Client, error),
+) (*btp.Client, error) {
+	hash := computeHash(cisSecret, saSecret)
+	now := time.Now()
+
+	c.mu.RLock()
+	entry, ok := c.entries[pcName]
+	c.mu.RUnlock()
+
+	if ok && entry.secretHash == hash {
+		c.mu.Lock()
+		entry.lastUsed = now
+		c.evictExpiredLocked(now)
+		c.mu.Unlock()
+		return entry.client, nil
+	}
+
+	// Cache miss — create new client.
+	// Note: On cold start, multiple goroutines may reach this point concurrently
+	// for the same pcName, each creating their own client. This is acceptable —
+	// last write wins, and the extra clients get GC'd. Holding the lock during
+	// createFn() would block all controllers on a single client creation (which
+	// involves network I/O on first use). In steady state, only one cached entry exists per pcName.
+	client, err := createFn()
+	if err != nil {
+		return nil, err
+	}
+
+	c.mu.Lock()
+	c.entries[pcName] = &cachedEntry{
+		client:     client,
+		secretHash: hash,
+		lastUsed:   now,
+	}
+	c.evictExpiredLocked(now)
+	c.mu.Unlock()
+
+	return client, nil
+}
+
+// evictExpiredLocked removes entries that haven't been used within the eviction timeout.
+// Must be called while holding c.mu write lock.
+func (c *ClientCache) evictExpiredLocked(now time.Time) {
+	for name, entry := range c.entries {
+		if now.Sub(entry.lastUsed) > c.evictionTimeout {
+			delete(c.entries, name)
+		}
+	}
+}
+
+func computeHash(cisSecret []byte, saSecret []byte) [32]byte {
+	h := sha256.New()
+	h.Write(cisSecret)
+	h.Write([]byte{0}) // separator
+	h.Write(saSecret)
+	var result [32]byte
+	copy(result[:], h.Sum(nil))
+	return result
+}
+
+// DefaultClientCache is the package-level cache used by CreateClient.
+var DefaultClientCache = NewClientCache()

--- a/internal/controller/providerconfig/client_cache_test.go
+++ b/internal/controller/providerconfig/client_cache_test.go
@@ -1,0 +1,175 @@
+package providerconfig
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sap/crossplane-provider-btp/btp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClientCache_GetOrCreate_CacheHit(t *testing.T) {
+	cache := NewClientCache()
+
+	callCount := 0
+	createFn := func() (*btp.Client, error) {
+		callCount++
+		return &btp.Client{}, nil
+	}
+
+	cis := []byte("cis-secret-data")
+	sa := []byte("sa-secret-data")
+
+	client1, err := cache.GetOrCreate("pc1", cis, sa, createFn)
+	assert.NoError(t, err)
+	assert.NotNil(t, client1)
+	assert.Equal(t, 1, callCount)
+
+	// Second call with same data should return cached client
+	client2, err := cache.GetOrCreate("pc1", cis, sa, createFn)
+	assert.NoError(t, err)
+	assert.Same(t, client1, client2)
+	assert.Equal(t, 1, callCount) // createFn not called again
+}
+
+func TestClientCache_GetOrCreate_DifferentProviderConfigs(t *testing.T) {
+	cache := NewClientCache()
+
+	callCount := 0
+	createFn := func() (*btp.Client, error) {
+		callCount++
+		return &btp.Client{}, nil
+	}
+
+	cis := []byte("cis-secret-data")
+	sa := []byte("sa-secret-data")
+
+	client1, err := cache.GetOrCreate("pc1", cis, sa, createFn)
+	assert.NoError(t, err)
+	assert.NotNil(t, client1)
+
+	// Different provider config name → cache miss
+	client2, err := cache.GetOrCreate("pc2", cis, sa, createFn)
+	assert.NoError(t, err)
+	assert.NotNil(t, client2)
+	assert.Equal(t, 2, callCount)
+}
+
+func TestClientCache_GetOrCreate_SecretChange(t *testing.T) {
+	cache := NewClientCache()
+
+	callCount := 0
+	createFn := func() (*btp.Client, error) {
+		callCount++
+		return &btp.Client{}, nil
+	}
+
+	cis := []byte("cis-secret-data")
+	sa := []byte("sa-secret-data")
+
+	client1, err := cache.GetOrCreate("pc1", cis, sa, createFn)
+	assert.NoError(t, err)
+	assert.NotNil(t, client1)
+	assert.Equal(t, 1, callCount)
+
+	// Changed CIS secret → cache miss, new client created
+	newCis := []byte("cis-secret-data-rotated")
+	client2, err := cache.GetOrCreate("pc1", newCis, sa, createFn)
+	assert.NoError(t, err)
+	assert.NotNil(t, client2)
+	assert.NotSame(t, client1, client2)
+	assert.Equal(t, 2, callCount)
+}
+
+func TestClientCache_GetOrCreate_SASecretChange(t *testing.T) {
+	cache := NewClientCache()
+
+	callCount := 0
+	createFn := func() (*btp.Client, error) {
+		callCount++
+		return &btp.Client{}, nil
+	}
+
+	cis := []byte("cis-secret-data")
+	sa := []byte("sa-secret-data")
+
+	_, err := cache.GetOrCreate("pc1", cis, sa, createFn)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, callCount)
+
+	// Changed SA secret → cache miss
+	newSa := []byte("sa-secret-data-rotated")
+	_, err = cache.GetOrCreate("pc1", cis, newSa, createFn)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, callCount)
+}
+
+func TestClientCache_GetOrCreate_ConcurrentAccess(t *testing.T) {
+	cache := NewClientCache()
+
+	var callCount int
+	var mu sync.Mutex
+	createFn := func() (*btp.Client, error) {
+		mu.Lock()
+		callCount++
+		mu.Unlock()
+		return &btp.Client{}, nil
+	}
+
+	cis := []byte("cis-secret-data")
+	sa := []byte("sa-secret-data")
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := cache.GetOrCreate("pc1", cis, sa, createFn)
+			assert.NoError(t, err)
+		}()
+	}
+	wg.Wait()
+
+	// Due to race between RUnlock and Lock, a few goroutines may create clients,
+	// but the total should be much less than 100
+	mu.Lock()
+	assert.Less(t, callCount, 100)
+	mu.Unlock()
+}
+
+func TestClientCache_GetOrCreate_EvictsStaleEntries(t *testing.T) {
+	cache := NewClientCache()
+	cache.evictionTimeout = 1 * time.Millisecond
+
+	createFn := func() (*btp.Client, error) {
+		return &btp.Client{}, nil
+	}
+
+	cis := []byte("cis-secret-data")
+	sa := []byte("sa-secret-data")
+
+	// Create two entries
+	_, err := cache.GetOrCreate("pc1", cis, sa, createFn)
+	assert.NoError(t, err)
+	_, err = cache.GetOrCreate("pc2", cis, sa, createFn)
+	assert.NoError(t, err)
+
+	assert.Len(t, cache.entries, 2)
+
+	// Wait for eviction timeout
+	time.Sleep(2 * time.Millisecond)
+
+	// Access pc1 only — this triggers eviction sweep and refreshes pc1's lastUsed
+	_, err = cache.GetOrCreate("pc1", cis, sa, createFn)
+	assert.NoError(t, err)
+
+	// pc2 should have been evicted, pc1 kept (it was just accessed)
+	cache.mu.RLock()
+	_, pc1Exists := cache.entries["pc1"]
+	_, pc2Exists := cache.entries["pc2"]
+	cache.mu.RUnlock()
+
+	assert.True(t, pc1Exists)
+	assert.False(t, pc2Exists)
+}

--- a/internal/controller/providerconfig/config.go
+++ b/internal/controller/providerconfig/config.go
@@ -91,7 +91,10 @@ func CreateClient(
 		return nil, saErr
 	}
 
-	svc, err := newServiceFn(CISSecretData, ServiceAccountSecretData)
+	pcName := mg.GetProviderConfigReference().Name
+	svc, err := DefaultClientCache.GetOrCreate(pcName, CISSecretData, ServiceAccountSecretData, func() (*btp.Client, error) {
+		return newServiceFn(CISSecretData, ServiceAccountSecretData)
+	})
 	return svc, errors.Wrap(err, errNewClient)
 }
 


### PR DESCRIPTION
Right now, on every reconcile of any managed resource that uses the btp api client (Entitlement, Subaccount, Directory, GlobalAccount, ServiceManager, KymaEnvironment, KymaEnvironmentBinding, CloudFoundryEnvironment), the `Connect` function creates a new `Client`. This Client performs an oauth flow automatically if necessary. Since we recreate the client all the time, it is doing a login on every reconcile.

The clients oauth flow does perform the oauth flow only if no token exist or if the token is expired/about to epire. So subsequent requests that reuse the same client dont trigger a new login request.

To do so, this PR introduces a Cache for the client. The Key is the ProviderConfigName. On match, it checks the sha256 hash of the secrets (service account and cis binding) against an in-memory vaue. Only than it is a cache hit, otherwise a miss.
On hit, it returns the client that already has the active oauth token inside (as pointer).

Furthermore, the cache tracks lastUsed of every entry and evicts old entries. This is done when an cache entry is read.

One design decision due to the ReadOnly mutex on read:
> 	// Note: On cold start, multiple goroutines may reach this point concurrently
	// for the same pcName, each creating their own client. This is acceptable —
	// last write wins, and the extra clients get GC'd. Holding the lock during
	// createFn() would block all controllers on a single client creation (which
	// involves network I/O on first use). In steady state, only one cached entry exists per pcName.

This is a thundering herd problem, aka all resources creating and logging in at the same time.

Local testing works: I only see one login call even for several minutes of use, compared to a new call per resource on the old version.

TODO: debug through the client library to fully verify the automatic oauth token refresh.

Reviewer Notes: please review carefully and also think of edge cases since we cache credentials we need to make sure they are only returned in the right moments