### PR TITLE
chore: makefile cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,31 +64,13 @@ export UUT_XPKG = $(BUILD_REGISTRY)/provider-btp-xpkg:latest
 export UUT_IMAGES = {"crossplane/provider-btp":"$(UUT_XPKG)"}
 testFilter ?= .*
 
-# local-deploy builds the provider image, sideloads the xpkg into a local kind
-# cluster via local.xpkg.mk, and waits for the provider to become healthy.
-# E2E_REUSE_CLUSTER/E2E_CLUSTER_NAME tell xp-testing to reuse this cluster
-# instead of creating a new one and trying to install the provider itself.
-KIND_CLUSTER_NAME ?= local-dev
-CROSSPLANE_VERSION ?= 1.20.1
-TEST_REUSE_CLUSTER ?= 0
-export E2E_REUSE_CLUSTER = $(KIND_CLUSTER_NAME)
-export E2E_CLUSTER_NAME = $(KIND_CLUSTER_NAME)
--include build/makelib/local.xpkg.mk
--include build/makelib/controlplane.mk
-
-.PHONY: local-deploy
-local-deploy: build xpkg.build.provider-btp local-deploy-reuse-check controlplane.up local.xpkg.deploy.provider.provider-btp
-	@$(INFO) waiting for provider to become healthy
-	@$(KUBECTL) wait provider.pkg provider-btp --for condition=Healthy --timeout 5m
-	@$(KUBECTL) -n crossplane-system wait --for=condition=Available deployment --all --timeout=5m
-	@$(OK) provider is healthy
-
-.PHONY: local-deploy-reuse-check
-local-deploy-reuse-check:
-ifeq ($(TEST_REUSE_CLUSTER),0)
-	@$(INFO) deleting any existing kind cluster named $(KIND_CLUSTER_NAME)
-	@$(KIND) delete cluster --name=$(KIND_CLUSTER_NAME) 2>/dev/null || true
-endif
+.PHONY: local-build
+local-build: build xpkg.build.provider-btp
+	$(INFO) "Loading xpkg into docker as $(UUT_XPKG)"; \
+	XPKG_FILE=$(XPKG_OUTPUT_DIR)/$(PLATFORM)/provider-btp-$(VERSION).xpkg && \
+	XPKG_SHA=$$(docker load -i $$XPKG_FILE | sed -n 's/.*ID: //p') && \
+	docker tag $$XPKG_SHA $(UUT_XPKG); \
+	$(OK) "Built local images: $(UUT_CONFIG) $(UUT_XPKG)"; \
 
 # ====================================================================================
 # Setup XPKG
@@ -281,16 +263,10 @@ test.run: go.test.unit
 # e2e tests
 e2e.run: test-acceptance
 
-test-e2e: $(KIND) $(HELM3) build generate-test-crs
-	@$(INFO) running e2e tests
-	@$(INFO) Skipping long running tests
-	@UUT_CONFIG=$(BUILD_REGISTRY)/provider-btp:$(VERSION) go test $(PROJECT_REPO)/test/... -tags=e2e -short -count=1 -timeout 30m
-	@$(OK) e2e tests passed
-
 #run single test-e2e-long test with <make e2e testFilter=functionNameOfTest>
-test-e2e-long: local-deploy $(HELM3) generate-test-crs
+test-e2e-long: local-build $(KIND) $(HELM3) generate-test-crs
 	@$(INFO) running integration tests
-	@UUT_CONFIG=$(BUILD_REGISTRY)/provider-btp:$(VERSION) go test -v $(PROJECT_REPO)/test/... -tags=e2e -count=1 -test.v -run '^$(testFilter)$$' -timeout 240m 2>&1 | tee test-output.log
+	go test -v $(PROJECT_REPO)/test/... -tags=e2e -count=1 -test.v -run '^$(testFilter)$$' -timeout 240m 2>&1 | tee test-output.log
 	@$(OK) integration tests passed
 	@echo "===========Test Summary==========="
 	@grep -E "PASS|FAIL" test-output.log
@@ -301,8 +277,8 @@ test-e2e-long: local-deploy $(HELM3) generate-test-crs
 
 #run single e2e test with <make e2e testFilter=functionNameOfTest>
 .PHONY: test-acceptance
-test-acceptance: local-deploy $(HELM3) generate-test-crs
-	@$(INFO) running integration tests
+test-acceptance: local-build $(KIND) $(HELM3) generate-test-crs
+	@$(INFO) running end-to-end tests
 	@$(INFO) Skipping long running tests
 	go test -v  $(PROJECT_REPO)/test/e2e -tags=e2e -short -count=1 -test.v -run '^$(testFilter)$$' -timeout 120m 2>&1 | tee test-output.log
 	@echo "===========Test Summary==========="
@@ -313,13 +289,12 @@ test-acceptance: local-deploy $(HELM3) generate-test-crs
      esac
 
 .PHONY: test-acceptance-debug
-test-acceptance-debug: $(KIND) $(HELM3) build generate-test-crs
-	@$(INFO) running integration tests
+test-acceptance-debug: local-build $(KIND) $(HELM3) generate-test-crs
+	@$(INFO) running end-to-end tests
 	@$(INFO) Skipping long running tests
-	@echo UUT_CONFIG=$$UUT_CONFIG
 	go test -gcflags="all=-N -l" -c -v  $(PROJECT_REPO)/test/e2e/ -tags=e2e -o ./test/e2e/test-acceptance-debug.test -timeout 30m
 	dlv exec ./test/e2e/test-acceptance-debug.test --wd ./test/e2e/ --headless --listen=:2345 --log --api-version=2 --accept-multiclient -- -test.short -test.count=1 -test.v -test.run '^$(testFilter)$$'; EXIT_CODE=$$?; rm ./test/e2e/test-acceptance-debug.test; exit $$EXIT_CODE
-	@$(OK) integration tests passed
+	@$(OK) end-to-end tests passed
 
 .PHONY: generate-test-crs
 generate-test-crs:
@@ -383,19 +358,13 @@ pull-upgrade-test-version-crs:
 build-upgrade-test-images:
 	@if [ "$(UPGRADE_TEST_FROM_TAG)" == "local" ] || [ "$(UPGRADE_TEST_TO_TAG)" == "local" ]; then \
 		$(INFO) "Building local images (UPGRADE_TEST_FROM_TAG or UPGRADE_TEST_TO_TAG is \"local\")"; \
-		$(MAKE) build; \
-		$(MAKE) xpkg.build.provider-btp; \
-		$(INFO) "Loading xpkg into docker as $(UUT_XPKG)"; \
-		XPKG_FILE=$(XPKG_OUTPUT_DIR)/$(PLATFORM)/provider-btp-$(VERSION).xpkg && \
-		XPKG_SHA=$$(docker load -i $$XPKG_FILE | sed -n 's/.*ID: //p') && \
-		docker tag $$XPKG_SHA $(UUT_XPKG); \
-		$(OK) "Built local images: $(UUT_CONFIG) $(UUT_XPKG)"; \
+		$(MAKE) local-build; \
+		$(OK) "Built local images for upgrade tests"; \
 	fi
 
 .PHONY: upgrade-test
 upgrade-test: $(KIND) check-upgrade-test-vars build-upgrade-test-images pull-upgrade-test-version-crs generate-upgrade-test-crs
 	@$(INFO) Running upgrade tests
-	@$(KIND) delete cluster --name=$(KIND_CLUSTER_NAME) 2>/dev/null || true
 	@go test -tags=upgrade ./test/upgrade -v -short -count=1 -run '^$(testFilter)$$' -timeout 120m 2>&1 | tee upgrade-test-output.log
 	@echo "===========Test Summary==========="
 	@grep -E "PASS|FAIL" upgrade-test-output.log
@@ -407,7 +376,6 @@ upgrade-test: $(KIND) check-upgrade-test-vars build-upgrade-test-images pull-upg
 .PHONY: upgrade-test-debug
 upgrade-test-debug: $(KIND) check-upgrade-test-vars build-upgrade-test-images pull-upgrade-test-version-crs generate-upgrade-test-crs
 	@$(INFO) Running upgrade tests
-	@$(KIND) delete cluster --name=$(KIND_CLUSTER_NAME) 2>/dev/null || true
 	@cd test/upgrade && dlv test --listen=:2345 --headless=true --api-version=2 --build-flags="-tags=upgrade" -- -test.v -test.short -test.count=1 -test.timeout 120m -test.run '^$(testFilter)$$' 2>&1 | tee upgrade-test-output.log
 	@echo "===========Test Summary==========="
 	@grep -E "PASS|FAIL" upgrade-test-output.log

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/crossplane-contrib/xp-testing/pkg/envvar"
+	"github.com/crossplane-contrib/xp-testing/pkg/images"
 	"github.com/crossplane-contrib/xp-testing/pkg/setup"
 	"github.com/crossplane-contrib/xp-testing/pkg/vendored"
 	testutil "github.com/sap/crossplane-provider-btp/test"
@@ -21,6 +22,8 @@ import (
 )
 
 var (
+	UUT_IMAGES_KEY = "UUT_IMAGES"
+
 	CIS_SECRET_NAME              = "cis-provider-secret"
 	SERVICE_USER_SECRET_NAME     = "sa-provider-secret"
 	TECHNICAL_USER_EMAIL_ENV_KEY = "TECHNICAL_USER_EMAIL"
@@ -49,6 +52,9 @@ func SetupClusterWithCrossplane(namespace string) {
 	// e.g. pr-16-3... defaults to empty string if not set
 	BUILD_ID = envvar.Get(UUT_BUILD_ID_KEY)
 
+	uutImages := envvar.GetOrPanic(UUT_IMAGES_KEY)
+	uutConfig, uutController := testutil.GetImagesFromJsonOrPanic(uutImages)
+
 	testenv = env.New()
 
 	bindingSecretData := testutil.GetBindingSecretOrPanic()
@@ -58,8 +64,6 @@ func SetupClusterWithCrossplane(namespace string) {
 
 	// Setup uses pre-defined funcs to create kind cluster
 	// and create a namespace for the environment
-	// The provider is pre-installed via `local-deploy` (local.xpkg.deploy),
-	// and E2E_REUSE_CLUSTER is set so xp-testing reuses the existing cluster.
 
 	deploymentRuntimeConfig := vendored.DeploymentRuntimeConfig{
 		ObjectMeta: metav1.ObjectMeta{
@@ -86,6 +90,10 @@ func SetupClusterWithCrossplane(namespace string) {
 
 	cfg := setup.ClusterSetup{
 		ProviderName: "btp-account",
+		Images: images.ProviderImages{
+			Package:         uutConfig,
+			ControllerImage: &uutController,
+		},
 		CrossplaneSetup: setup.CrossplaneSetup{
 			Version:  "1.20.1",
 			Registry: setup.DockerRegistry,


### PR DESCRIPTION
With #626, the e2e tests were using the `controlplane.up` target to create the test cluster. This PR reverts that behavior while still using the `xpkg.build.provider-btp` step to construct the single image build.