### PR TITLE
fix(btp): trim CISCredential to used fields and validate required ones on parse

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ GO111MODULE = on
 
 # Override the GO_LINT_ARGS from golang.mk to use updated golangci-lint parameters
 # this can potentially be removed when we update to a newer version of the build
-GO_LINT_ARGS = --output.checkstyle.path=$(GO_LINT_OUTPUT)/checkstyle.xml
+GO_LINT_ARGS = --output.checkstyle.path=$(GO_LINT_OUTPUT)/checkstyle.xml --output.text.path=stdout
 
 # kind-related versions
 KIND_VERSION ?= v0.23.0

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ $(info VERSION is $(VERSION))
 
 # Setup Versions
 GO_REQUIRED_VERSION=1.25
-GOLANGCILINT_VERSION ?= 2.8.0
+GOLANGCILINT_VERSION ?= 2.12.2
 
 NPROCS ?= 1
 GO_TEST_PARALLEL := $(shell echo $$(( $(NPROCS) / 2 )))
@@ -42,6 +42,7 @@ GO_LDFLAGS += -X $(GO_PROJECT)/internal/version.ProviderVersion=$(VERSION)
 
 GO_SUBDIRS += cmd internal apis
 GO111MODULE = on
+GOTOOLCHAIN = local
 -include build/makelib/golang.mk
 
 # Override the GO_LINT_ARGS from golang.mk to use updated golangci-lint parameters
@@ -402,3 +403,44 @@ upgrade-test-clean: upgrade-test-restore-crs
 	@$(INFO) Cleaning BTP artifacts
 	@$(GO) run .github/workflows/cleanup.go
 	@$(OK) BTP artifacts cleaned
+
+# ====================================================================================
+# E2E Test Environment Setup
+# ====================================================================================
+
+# Interactively ask for the file paths containing each required e2e configuration value
+# and write them into a .env file. Each variable's value is read from the specified file
+# so that secrets never need to be typed on the command line.
+.PHONY: e2e-tests-create-dot-env-from-files
+e2e-tests-create-dot-env-from-files:
+	@echo "This target creates a .env file for e2e tests by reading each required"
+	@echo "configuration value from a file you specify."
+	@echo "See https://github.com/SAP/crossplane-provider-btp#required-configuration"
+	@echo ""
+	@> .env
+	@for entry in \
+		"BTP_TECHNICAL_USER:JSON file with BTP technical user credentials (email/username/password)" \
+		"CIS_CENTRAL_BINDING:JSON file with the cis-central service binding data" \
+		"CLI_SERVER_URL:File containing the BTP CLI server URL (e.g. https://cli.btp.cloud.sap/)" \
+		"GLOBAL_ACCOUNT:File containing the global account subdomain" \
+		"IDP_URL:File containing the IDP URL connectable to the global account" \
+		"SECOND_DIRECTORY_ADMIN_EMAIL:File containing a second admin email (different from technical user)" \
+		"TECHNICAL_USER_EMAIL:File containing the email address of the BTP technical user" \
+	; do \
+		varname=$${entry%%:*}; \
+		description=$${entry#*:}; \
+		printf "%s\n  (%s)\n  Path: " "$$varname" "$$description" >&2; \
+		read -r filepath; \
+		if [ -z "$$filepath" ]; then \
+			echo "⚠️  Skipping $$varname (no path provided)" >&2; \
+			continue; \
+		fi; \
+		if [ ! -f "$$filepath" ]; then \
+			echo "❌ Error: file not found: $$filepath" >&2; exit 1; \
+		fi; \
+		value=$$(cat "$$filepath"); \
+		printf '%s=%s\n' "$$varname" "$$value" >> .env; \
+		echo "✅ $$varname written" >&2; \
+	done
+	@echo ""
+	@$(OK) .env file created

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ make test-acceptance
 ```
 
 > [!NOTE]  
-> Make sure to set required environment variables before starting the e2e tests wit real valid credentials!
+> Make sure to set required environment variables before starting the e2e tests with real valid credentials!
 
 This will spin up a specific kind cluster which runs the provider as docker container in it. The e2e tests will run kubectl commands against that cluster to test the provider's functionality.
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ The provider comes with a set of end-to-end tests that can be run locally. To ru
 make test-acceptance
 ```
 
+> [!NOTE]  
+> Make sure to set required environment variables before starting the e2e tests wit real valid credentials!
+
 This will spin up a specific kind cluster which runs the provider as docker container in it. The e2e tests will run kubectl commands against that cluster to test the provider's functionality.
 
 If you want to run a single E2E Test locally simply set the `testFilter` variable like this:

--- a/btp/cf_environment.go
+++ b/btp/cf_environment.go
@@ -19,9 +19,9 @@ func CloudFoundryEnvironmentType() EnvironmentType {
 }
 
 type CloudFoundryOrg struct {
-	Id          string `json:"Org Id,"`
-	Name        string `json:"Org Name,"`
-	ApiEndpoint string `json:"API Endpoint,"`
+	Id          string `json:"Org Id"`
+	Name        string `json:"Org Name"`
+	ApiEndpoint string `json:"API Endpoint"`
 }
 
 // CreateCloudFoundryEnvironment creates a Cloud Foundry environment instance with the given parameters. It returns the instance ID of the created environment.

--- a/btp/cisclient.go
+++ b/btp/cisclient.go
@@ -19,6 +19,8 @@ import (
 const (
 	errCouldNotParseCISSecret      = "CIS Secret seems malformed"
 	errCouldNotParseUserCredential = "error while parsing sa-provider-secret JSON"
+	errCISBindingCredentialIsNil        = "CIS binding credential is nil"
+	errCISBindingMissingRequiredFields  = "CIS binding is missing required fields: %s"
 )
 
 type InstanceParameters = map[string]interface{}
@@ -63,7 +65,7 @@ type CISCredential struct {
 
 func validateCISCredential(c *CISCredential) error {
 	if c == nil {
-		return fmt.Errorf("CIS binding credential is nil")
+		return fmt.Errorf(errCISBindingCredentialIsNil)
 	}
 	var missing []string
 	if c.Uaa.Clientid == "" {
@@ -85,7 +87,7 @@ func validateCISCredential(c *CISCredential) error {
 		missing = append(missing, "endpoints.provisioning_service_url")
 	}
 	if len(missing) > 0 {
-		return fmt.Errorf("CIS binding is missing required fields: %s", strings.Join(missing, ", "))
+		return fmt.Errorf(errCISBindingMissingRequiredFields, strings.Join(missing, ", "))
 	}
 	return nil
 }

--- a/btp/cisclient.go
+++ b/btp/cisclient.go
@@ -65,7 +65,8 @@ type CISCredential struct {
 
 func validateCISCredential(c *CISCredential) error {
 	if c == nil {
-		return fmt.Errorf(errCISBindingCredentialIsNil)
+		return errors.New(errCISBindingCredentialIsNil)
+
 	}
 	var missing []string
 	if c.Uaa.Clientid == "" {

--- a/btp/cisclient.go
+++ b/btp/cisclient.go
@@ -2,7 +2,9 @@ package btp
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/crossplane/crossplane-runtime/pkg/errors"
 	"github.com/go-openapi/runtime"
@@ -46,36 +48,46 @@ type UserCredential struct {
 
 type CISCredential struct {
 	Endpoints struct {
-		AccountsServiceUrl          string `json:"accounts_service_url"`
-		CloudAutomationUrl          string `json:"cloud_automation_url"`
-		EntitlementsServiceUrl      string `json:"entitlements_service_url"`
-		EventsServiceUrl            string `json:"events_service_url"`
-		ExternalProviderRegistryUrl string `json:"external_provider_registry_url"`
-		MetadataServiceUrl          string `json:"metadata_service_url"`
-		OrderProcessingUrl          string `json:"order_processing_url"`
-		ProvisioningServiceUrl      string `json:"provisioning_service_url"`
-		SaasRegistryServiceUrl      string `json:"saas_registry_service_url"`
+		AccountsServiceUrl     string `json:"accounts_service_url"`
+		EntitlementsServiceUrl string `json:"entitlements_service_url"`
+		ProvisioningServiceUrl string `json:"provisioning_service_url"`
+		SaasRegistryServiceUrl string `json:"saas_registry_service_url"`
 	} `json:"endpoints"`
-	GrantType       string `json:"grant_type"`
-	SapCloudService string `json:"sap.cloud.service"`
-	Uaa             struct {
-		Apiurl          string `json:"apiurl"`
-		Clientid        string `json:"clientid"`
-		Clientsecret    string `json:"clientsecret"`
-		CredentialType  string `json:"credential-type"`
-		Identityzone    string `json:"identityzone"`
-		Identityzoneid  string `json:"identityzoneid"`
-		Sburl           string `json:"sburl"`
-		Subaccountid    string `json:"subaccountid"`
-		Tenantid        string `json:"tenantid"`
-		Tenantmode      string `json:"tenantmode"`
-		Uaadomain       string `json:"uaadomain"`
-		Url             string `json:"url"`
-		Verificationkey string `json:"verificationkey"`
-		Xsappname       string `json:"xsappname"`
-		Xsmasterappname string `json:"xsmasterappname"`
-		Zoneid          string `json:"zoneid"`
+	GrantType string `json:"grant_type"`
+	Uaa       struct {
+		Clientid     string `json:"clientid"`
+		Clientsecret string `json:"clientsecret"`
+		Url          string `json:"url"`
 	} `json:"uaa"`
+}
+
+func validateCISCredential(c *CISCredential) error {
+	if c == nil {
+		return fmt.Errorf("CIS binding credential is nil")
+	}
+	var missing []string
+	if c.Uaa.Clientid == "" {
+		missing = append(missing, "uaa.clientid")
+	}
+	if c.Uaa.Clientsecret == "" {
+		missing = append(missing, "uaa.clientsecret")
+	}
+	if c.Uaa.Url == "" {
+		missing = append(missing, "uaa.url")
+	}
+	if c.Endpoints.AccountsServiceUrl == "" {
+		missing = append(missing, "endpoints.accounts_service_url")
+	}
+	if c.Endpoints.EntitlementsServiceUrl == "" {
+		missing = append(missing, "endpoints.entitlements_service_url")
+	}
+	if c.Endpoints.ProvisioningServiceUrl == "" {
+		missing = append(missing, "endpoints.provisioning_service_url")
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("CIS binding is missing required fields: %s", strings.Join(missing, ", "))
+	}
+	return nil
 }
 
 const (
@@ -214,6 +226,10 @@ func ServiceClientFromSecret(cisSecret []byte, userSecret []byte) (Client, error
 	var cisCredential CISCredential
 	if err := json.Unmarshal(cisSecret, &cisCredential); err != nil {
 		return Client{}, errors.Wrap(err, errCouldNotParseCISSecret)
+	}
+
+	if err := validateCISCredential(&cisCredential); err != nil {
+		return Client{}, err
 	}
 
 	var userCredential UserCredential

--- a/btp/cisclient_test.go
+++ b/btp/cisclient_test.go
@@ -102,22 +102,9 @@ func Test_authenticationParams(t *testing.T) {
 					CISCredential: &CISCredential{
 						GrantType: "user_token",
 						Uaa: struct {
-							Apiurl          string `json:"apiurl"`
-							Clientid        string `json:"clientid"`
-							Clientsecret    string `json:"clientsecret"`
-							CredentialType  string `json:"credential-type"`
-							Identityzone    string `json:"identityzone"`
-							Identityzoneid  string `json:"identityzoneid"`
-							Sburl           string `json:"sburl"`
-							Subaccountid    string `json:"subaccountid"`
-							Tenantid        string `json:"tenantid"`
-							Tenantmode      string `json:"tenantmode"`
-							Uaadomain       string `json:"uaadomain"`
-							Url             string `json:"url"`
-							Verificationkey string `json:"verificationkey"`
-							Xsappname       string `json:"xsappname"`
-							Xsmasterappname string `json:"xsmasterappname"`
-							Zoneid          string `json:"zoneid"`
+							Clientid     string `json:"clientid"`
+							Clientsecret string `json:"clientsecret"`
+							Url          string `json:"url"`
 						}{
 							Clientid: "myclientid",
 						},
@@ -135,22 +122,9 @@ func Test_authenticationParams(t *testing.T) {
 					CISCredential: &CISCredential{
 						GrantType: "client_credentials",
 						Uaa: struct {
-							Apiurl          string `json:"apiurl"`
-							Clientid        string `json:"clientid"`
-							Clientsecret    string `json:"clientsecret"`
-							CredentialType  string `json:"credential-type"`
-							Identityzone    string `json:"identityzone"`
-							Identityzoneid  string `json:"identityzoneid"`
-							Sburl           string `json:"sburl"`
-							Subaccountid    string `json:"subaccountid"`
-							Tenantid        string `json:"tenantid"`
-							Tenantmode      string `json:"tenantmode"`
-							Uaadomain       string `json:"uaadomain"`
-							Url             string `json:"url"`
-							Verificationkey string `json:"verificationkey"`
-							Xsappname       string `json:"xsappname"`
-							Xsmasterappname string `json:"xsmasterappname"`
-							Zoneid          string `json:"zoneid"`
+							Clientid     string `json:"clientid"`
+							Clientsecret string `json:"clientsecret"`
+							Url          string `json:"url"`
 						}{
 							Clientid:     "myclientid",
 							Clientsecret: "myclientsecret",
@@ -170,22 +144,9 @@ func Test_authenticationParams(t *testing.T) {
 					CISCredential: &CISCredential{
 						GrantType: "user_token",
 						Uaa: struct {
-							Apiurl          string `json:"apiurl"`
-							Clientid        string `json:"clientid"`
-							Clientsecret    string `json:"clientsecret"`
-							CredentialType  string `json:"credential-type"`
-							Identityzone    string `json:"identityzone"`
-							Identityzoneid  string `json:"identityzoneid"`
-							Sburl           string `json:"sburl"`
-							Subaccountid    string `json:"subaccountid"`
-							Tenantid        string `json:"tenantid"`
-							Tenantmode      string `json:"tenantmode"`
-							Uaadomain       string `json:"uaadomain"`
-							Url             string `json:"url"`
-							Verificationkey string `json:"verificationkey"`
-							Xsappname       string `json:"xsappname"`
-							Xsmasterappname string `json:"xsmasterappname"`
-							Zoneid          string `json:"zoneid"`
+							Clientid     string `json:"clientid"`
+							Clientsecret string `json:"clientsecret"`
+							Url          string `json:"url"`
 						}{
 							Clientid: "",
 						},

--- a/btp/cisclient_test.go
+++ b/btp/cisclient_test.go
@@ -3,6 +3,7 @@ package btp
 import (
 	"net/url"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/sap/crossplane-provider-btp/internal"
@@ -280,5 +281,127 @@ func TestCloudFoundryOrgByLabel(t *testing.T) {
 				}
 			},
 		)
+	}
+}
+
+func TestValidateCISCredential(t *testing.T) {
+	validCredential := func() *CISCredential {
+		return &CISCredential{
+			GrantType: "client_credentials",
+			Uaa: struct {
+				Clientid     string `json:"clientid"`
+				Clientsecret string `json:"clientsecret"`
+				Url          string `json:"url"`
+			}{
+				Clientid:     "my-client-id",
+				Clientsecret: "my-client-secret",
+				Url:          "https://my-tenant.authentication.eu10.hana.ondemand.com",
+			},
+			Endpoints: struct {
+				AccountsServiceUrl     string `json:"accounts_service_url"`
+				EntitlementsServiceUrl string `json:"entitlements_service_url"`
+				ProvisioningServiceUrl string `json:"provisioning_service_url"`
+				SaasRegistryServiceUrl string `json:"saas_registry_service_url"`
+			}{
+				AccountsServiceUrl:     "https://accounts-service.eu10.hana.ondemand.com",
+				EntitlementsServiceUrl: "https://entitlements-service.eu10.hana.ondemand.com",
+				ProvisioningServiceUrl: "https://provisioning-service.cfapps.eu10.hana.ondemand.com",
+				SaasRegistryServiceUrl: "https://saas-manager.cfapps.eu10.hana.ondemand.com",
+			},
+		}
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(*CISCredential)
+		useNil  bool
+		wantErr bool
+		wantMsg string
+		wantMsg2 string
+	}{
+		{
+			name:    "valid credential - all required fields present",
+			mutate:  func(c *CISCredential) {},
+			wantErr: false,
+		},
+		{
+			name:    "missing uaa.clientid",
+			mutate:  func(c *CISCredential) { c.Uaa.Clientid = "" },
+			wantErr: true,
+			wantMsg: "uaa.clientid",
+		},
+		{
+			name:    "missing uaa.clientsecret",
+			mutate:  func(c *CISCredential) { c.Uaa.Clientsecret = "" },
+			wantErr: true,
+			wantMsg: "uaa.clientsecret",
+		},
+		{
+			name:    "missing uaa.url",
+			mutate:  func(c *CISCredential) { c.Uaa.Url = "" },
+			wantErr: true,
+			wantMsg: "uaa.url",
+		},
+		{
+			name:    "missing endpoints.accounts_service_url",
+			mutate:  func(c *CISCredential) { c.Endpoints.AccountsServiceUrl = "" },
+			wantErr: true,
+			wantMsg: "endpoints.accounts_service_url",
+		},
+		{
+			name:    "missing endpoints.entitlements_service_url",
+			mutate:  func(c *CISCredential) { c.Endpoints.EntitlementsServiceUrl = "" },
+			wantErr: true,
+			wantMsg: "endpoints.entitlements_service_url",
+		},
+		{
+			name:    "missing endpoints.provisioning_service_url",
+			mutate:  func(c *CISCredential) { c.Endpoints.ProvisioningServiceUrl = "" },
+			wantErr: true,
+			wantMsg: "endpoints.provisioning_service_url",
+		},
+		{
+			name:     "multiple missing fields reported together",
+			mutate:   func(c *CISCredential) { c.Uaa.Clientid = ""; c.Uaa.Url = "" },
+			wantErr:  true,
+			wantMsg:  "uaa.clientid",
+			wantMsg2: "uaa.url",
+		},
+		{
+			name:    "completely empty credential",
+			mutate:  func(c *CISCredential) { *c = CISCredential{} },
+			wantErr: true,
+			wantMsg: "uaa.clientid",
+		},
+		{
+			name:    "nil credential",
+			useNil:  true,
+			mutate:  func(c *CISCredential) {},
+			wantErr: true,
+			wantMsg: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var cred *CISCredential
+			if tt.useNil {
+				cred = nil
+			} else {
+				cred = validCredential()
+				tt.mutate(cred)
+			}
+			err := validateCISCredential(cred)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateCISCredential() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr && tt.wantMsg != "" && !strings.Contains(err.Error(), tt.wantMsg) {
+				t.Errorf("validateCISCredential() error %q does not contain %q", err.Error(), tt.wantMsg)
+			}
+			if tt.wantErr && tt.wantMsg2 != "" && !strings.Contains(err.Error(), tt.wantMsg2) {
+				t.Errorf("validateCISCredential() error %q does not contain %q", err.Error(), tt.wantMsg2)
+			}
+		})
 	}
 }

--- a/scripts/generate-external-name-docs.go
+++ b/scripts/generate-external-name-docs.go
@@ -247,7 +247,7 @@ func generateDocumentation(configs []ResourceConfig) string {
 		if i > 0 {
 			sb.WriteString("\n")
 		}
-		sb.WriteString(fmt.Sprintf("### %s\n\n", config.Name))
+		fmt.Fprintf(&sb, "### %s\n\n", config.Name)
 		sb.WriteString(config.Content)
 		sb.WriteString("\n")
 	}


### PR DESCRIPTION
## Summary

- **Remove 19 unused fields** from `CISCredential` — only the 8 fields actually accessed by provider code are kept (`Endpoints.{AccountsServiceUrl, EntitlementsServiceUrl, ProvisioningServiceUrl, SaasRegistryServiceUrl}`, `GrantType`, `Uaa.{Clientid, Clientsecret, Url}`)
- **Add `validateCISCredential`** — collects all missing required fields and returns a single descriptive error (e.g. `CIS binding is missing required fields: uaa.clientid, uaa.url`)
- **Wire validation into `ServiceClientFromSecret`** — misconfigured secrets now fail at ProviderConfig reconciliation time instead of silently producing a broken HTTP client

## Background

`encoding/json` silently zero-values missing fields, so a CIS binding secret missing e.g. `uaa.url` would unmarshal successfully but produce a client that only fails at the first API call with a confusing connection error. The validator surfaces the problem immediately with a clear error message.

## Test Plan

- [x] `go test ./btp/... -v -run TestValidateCISCredential` — 10 subtests: 1 positive (all fields present), 6 per-field negatives, 1 multi-field, 1 nil, 1 empty struct
- [x] `go test ./btp/... -count=1` — full `btp` package, zero failures
- [x] `go test ./... -count=1` — full unit suite, zero failures