### PR TITLE
docs: unify CloudManagement name to cis-local

### DIFF
--- a/docs/end-user-guides/account/subaccount.mdx
+++ b/docs/end-user-guides/account/subaccount.mdx
@@ -157,7 +157,7 @@ You can then create a Cloud Management service using the `CloudManagement` custo
     apiVersion: account.btp.sap.crossplane.io/v1alpha1
     kind: CloudManagement
     metadata:
-      name: my-subaccount-cis
+      name: cis-local
     spec:
       writeConnectionSecretToRef:
         name: cis-local

--- a/docs/end-user-guides/services/create-services.mdx
+++ b/docs/end-user-guides/services/create-services.mdx
@@ -177,7 +177,7 @@ Once the entitlement is in place, you can subscribe to SAP HANA Cloud Administra
         appName: hana-cloud-tools
         planName: tools
       cloudManagementRef:
-        name: my-subaccount-cis
+        name: cis-local
     ```
 
     <button onClick={() => window.open("https://doc.crds.dev/github.com/SAP/crossplane-provider-btp/account.btp.sap.crossplane.io/Subscription/v1alpha1@v1.6.0", "_blank")} className='button button--secondary'>See full CRD reference</button>


### PR DESCRIPTION
Use "cis-local" as the name of the `CloudManagement` resource everywhere so the different end user guides fit together.