### PR TITLE
fix: propagate forProvider.name to external-name for SubaccountApiCredential

### DIFF
--- a/config/btp_subaccount_api_credential/config.go
+++ b/config/btp_subaccount_api_credential/config.go
@@ -22,6 +22,7 @@ const (
 	errTrackRUsage         = "cannot track ResourceUsage"
 	errTypeAssertion       = "managed resource is not of type SubaccountApiCredential"
 	errMissingClientSecret = "cannot read client_secret from source, please delete external resource and re-create Crossplane resource"
+	errUpdateExternalName  = "cannot update external-name annotation"
 )
 
 // Configure configures individual resources by adding custom ResourceConfigurators.
@@ -60,11 +61,65 @@ func Configure(p *config.Provider) {
 
 		// Add pre-delete hook using InitializerFns for finalizer management
 		r.InitializerFns = append(r.InitializerFns, func(kube client.Client) managed.Initializer {
+			return &NameAsExternalName{Kube: kube}
+		})
+		r.InitializerFns = append(r.InitializerFns, func(kube client.Client) managed.Initializer {
 			return &DeletionProtectionInitializer{Kube: kube}
 		})
 	})
 
 	p.ConfigureResources()
+}
+
+// NameAsExternalName propagates forProvider.name to the external-name annotation.
+// When the name changes, the connection secret is deleted so that
+// DeletionProtectionInitializer does not block with stale data.
+type NameAsExternalName struct {
+	Kube client.Client
+}
+
+func (n *NameAsExternalName) Initialize(ctx context.Context, mg resource.Managed) error {
+	cr, ok := mg.(*securityv1alpha1.SubaccountApiCredential)
+	if !ok {
+		return errors.New(errTypeAssertion)
+	}
+
+	if meta.WasDeleted(mg) {
+		return nil
+	}
+
+	if cr.Spec.ForProvider.Name == nil || *cr.Spec.ForProvider.Name == "" {
+		return nil
+	}
+
+	desiredName := *cr.Spec.ForProvider.Name
+	if meta.GetExternalName(cr) == desiredName {
+		return nil
+	}
+
+	if err := n.deleteConnectionSecret(ctx, cr); err != nil {
+		return err
+	}
+
+	meta.SetExternalName(cr, desiredName)
+	return errors.Wrap(n.Kube.Update(ctx, cr), errUpdateExternalName)
+}
+
+func (n *NameAsExternalName) deleteConnectionSecret(ctx context.Context, cr *securityv1alpha1.SubaccountApiCredential) error {
+	secretRef := cr.GetWriteConnectionSecretToReference()
+	if secretRef == nil || secretRef.Name == "" {
+		return nil
+	}
+
+	secret := &corev1.Secret{}
+	if err := n.Kube.Get(ctx, client.ObjectKey{
+		Name:      secretRef.Name,
+		Namespace: secretRef.Namespace,
+	}, secret); err != nil {
+		return resource.IgnoreNotFound(err)
+	}
+
+	return resource.IgnoreNotFound(n.Kube.Delete(ctx, secret))
 }
 
 // DeletionProtectionInitializer implements the managed.Initializer interface

--- a/config/btp_subaccount_api_credential/config_test.go
+++ b/config/btp_subaccount_api_credential/config_test.go
@@ -5,14 +5,186 @@ import (
 	"testing"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	securityv1alpha1 "github.com/sap/crossplane-provider-btp/apis/security/v1alpha1"
 )
+
+func ptr(s string) *string { return &s }
+
+func TestNameAsExternalName_Initialize(t *testing.T) {
+	type want struct {
+		err          error
+		externalName string
+	}
+
+	cases := map[string]struct {
+		cr   *securityv1alpha1.SubaccountApiCredential
+		kube client.Client
+		want want
+	}{
+		"name set, annotation empty - sets annotation": {
+			cr: &securityv1alpha1.SubaccountApiCredential{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+				Spec: securityv1alpha1.SubaccountApiCredentialSpec{
+					ForProvider: securityv1alpha1.SubaccountApiCredentialParameters{
+						Name: ptr("my-credential"),
+					},
+				},
+			},
+			kube: &test.MockClient{
+				MockUpdate: test.NewMockUpdateFn(nil),
+			},
+			want: want{err: nil, externalName: "my-credential"},
+		},
+		"name set, annotation already matches - no-op": {
+			cr: func() *securityv1alpha1.SubaccountApiCredential {
+				cr := &securityv1alpha1.SubaccountApiCredential{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{},
+					},
+					Spec: securityv1alpha1.SubaccountApiCredentialSpec{
+						ForProvider: securityv1alpha1.SubaccountApiCredentialParameters{
+							Name: ptr("my-credential"),
+						},
+					},
+				}
+				meta.SetExternalName(cr, "my-credential")
+				return cr
+			}(),
+			kube: &test.MockClient{},
+			want: want{err: nil, externalName: "my-credential"},
+		},
+		"name set, annotation differs - deletes secret and updates annotation": {
+			cr: func() *securityv1alpha1.SubaccountApiCredential {
+				cr := &securityv1alpha1.SubaccountApiCredential{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{},
+					},
+					Spec: securityv1alpha1.SubaccountApiCredentialSpec{
+						ResourceSpec: xpv1.ResourceSpec{
+							WriteConnectionSecretToReference: &xpv1.SecretReference{
+								Name:      "my-secret",
+								Namespace: "default",
+							},
+						},
+						ForProvider: securityv1alpha1.SubaccountApiCredentialParameters{
+							Name: ptr("new-credential"),
+						},
+					},
+				}
+				meta.SetExternalName(cr, "old-credential")
+				return cr
+			}(),
+			kube: &test.MockClient{
+				MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+					if secret, ok := obj.(*corev1.Secret); ok {
+						secret.Data = map[string][]byte{
+							"attribute.client_id": []byte("some-id"),
+							"attribute.token_url": []byte("https://token-url"),
+							"attribute.api_url":   []byte("https://api-url"),
+						}
+					}
+					return nil
+				}),
+				MockDelete: test.NewMockDeleteFn(nil),
+				MockUpdate: test.NewMockUpdateFn(nil),
+			},
+			want: want{err: nil, externalName: "new-credential"},
+		},
+		"name nil - no-op": {
+			cr: &securityv1alpha1.SubaccountApiCredential{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+				Spec: securityv1alpha1.SubaccountApiCredentialSpec{
+					ForProvider: securityv1alpha1.SubaccountApiCredentialParameters{},
+				},
+			},
+			kube: &test.MockClient{},
+			want: want{err: nil},
+		},
+		"name empty string - no-op": {
+			cr: &securityv1alpha1.SubaccountApiCredential{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+				Spec: securityv1alpha1.SubaccountApiCredentialSpec{
+					ForProvider: securityv1alpha1.SubaccountApiCredentialParameters{
+						Name: ptr(""),
+					},
+				},
+			},
+			kube: &test.MockClient{},
+			want: want{err: nil},
+		},
+		"name set, annotation differs, secret Get fails - propagates error": {
+			cr: func() *securityv1alpha1.SubaccountApiCredential {
+				cr := &securityv1alpha1.SubaccountApiCredential{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{},
+					},
+					Spec: securityv1alpha1.SubaccountApiCredentialSpec{
+						ResourceSpec: xpv1.ResourceSpec{
+							WriteConnectionSecretToReference: &xpv1.SecretReference{
+								Name:      "my-secret",
+								Namespace: "default",
+							},
+						},
+						ForProvider: securityv1alpha1.SubaccountApiCredentialParameters{
+							Name: ptr("new-credential"),
+						},
+					},
+				}
+				meta.SetExternalName(cr, "old-credential")
+				return cr
+			}(),
+			kube: &test.MockClient{
+				MockGet: test.NewMockGetFn(errors.New("api server unavailable")),
+			},
+			want: want{err: errors.New("api server unavailable"), externalName: "old-credential"},
+		},
+		"resource being deleted - no-op": {
+			cr: func() *securityv1alpha1.SubaccountApiCredential {
+				now := metav1.Now()
+				return &securityv1alpha1.SubaccountApiCredential{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations:       map[string]string{},
+						DeletionTimestamp: &now,
+					},
+					Spec: securityv1alpha1.SubaccountApiCredentialSpec{
+						ForProvider: securityv1alpha1.SubaccountApiCredentialParameters{
+							Name: ptr("my-credential"),
+						},
+					},
+				}
+			}(),
+			kube: &test.MockClient{},
+			want: want{err: nil},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			n := &NameAsExternalName{Kube: tc.kube}
+			err := n.Initialize(context.Background(), tc.cr)
+			if diff := cmp.Diff(tc.want.err, err, test.EquateErrors()); diff != "" {
+				t.Errorf("Initialize() error mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.want.externalName, meta.GetExternalName(tc.cr)); diff != "" {
+				t.Errorf("external-name mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
 
 func TestDeletionProtectionInitializer_Initialize(t *testing.T) {
 	type want struct {


### PR DESCRIPTION
Fixes #664

## What I found

`spec.forProvider.name` was silently ignored on `SubaccountApiCredential`. The `SetIdentifierArgumentFn` receives the external-name annotation value, not `forProvider.name`. On first creation the annotation is always empty (because `IdentifierFromProvider` disables Upjet's `NameAsExternalName` initializer), so the function always fell back to the hardcoded default `managed-subbaccount-api-credential` regardless of what the user set.

## What I changed

Added a `NameAsExternalName` initializer that runs before `DeletionProtectionInitializer` and propagates `spec.forProvider.name` to the external-name annotation whenever they differ. When the name changes (annotation != forProvider.name), the stale connection secret is deleted first so `DeletionProtectionInitializer` does not block the reconcile with incomplete credential data. The secret is recreated by Upjet after the new credential is provisioned.

## Limitations (Option A)

This implements Option A from the issue. Recovery from the reimport stuck-state (Scenario 2) requires the caller to change `forProvider.name` to a new value, which triggers the initializer to create a fresh credential. The old BTP credential is orphaned and must be cleaned up out-of-band. Option B (autonomous self-healing) remains a future consideration.