### PR TITLE
fix: add recreateOnCreationFailure for KymaEnvironment

### DIFF
--- a/apis/environment/v1alpha1/cfenvironment_types.go
+++ b/apis/environment/v1alpha1/cfenvironment_types.go
@@ -10,10 +10,13 @@ import (
 )
 
 const (
-	InstanceStateOk       = "OK"
-	InstanceStateCreating = "CREATING"
-	InstanceStateDeleting = "DELETING"
-	InstanceStateUpdating = "UPDATING"
+	InstanceStateOk             = "OK"
+	InstanceStateCreating       = "CREATING"
+	InstanceStateDeleting       = "DELETING"
+	InstanceStateUpdating       = "UPDATING"
+	InstanceStateCreationFailed = "CREATION_FAILED"
+	InstanceStateDeletionFailed = "DELETION_FAILED"
+	InstanceStateUpdateFailed   = "UPDATE_FAILED"
 )
 
 const (

--- a/apis/environment/v1alpha1/kymaenvironment_types.go
+++ b/apis/environment/v1alpha1/kymaenvironment_types.go
@@ -46,6 +46,11 @@ type KymaEnvironmentObservation struct {
 type KymaEnvironmentSpec struct {
 	xpv1.ResourceSpec `json:",inline"`
 	ForProvider       KymaEnvironmentParameters `json:"forProvider"`
+
+	// RecreateOnCreationFailure indicates whether the environment should be
+	// automatically deleted and recreated when it enters CREATION_FAILED state.
+	// +kubebuilder:validation:Optional
+	RecreateOnCreationFailure bool `json:"recreateOnCreationFailure,omitempty"`
 	// +crossplane:generate:reference:type=github.com/sap/crossplane-provider-btp/apis/account/v1alpha1.Subaccount
 	// +crossplane:generate:reference:refFieldName=SubaccountRef
 	// +crossplane:generate:reference:selectorFieldName=SubaccountSelector

--- a/internal/controller/environment/kyma/fake/fake.go
+++ b/internal/controller/environment/kyma/fake/fake.go
@@ -4,18 +4,12 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/sap/crossplane-provider-btp/apis/environment/v1alpha1"
-	apisv1alpha1 "github.com/sap/crossplane-provider-btp/apis/v1alpha1"
 	environments "github.com/sap/crossplane-provider-btp/internal/clients/kymaenvironment"
 	provisioningclient "github.com/sap/crossplane-provider-btp/internal/openapi_clients/btp-provisioning-service-api-go/pkg"
-	"github.com/sap/crossplane-provider-btp/internal/tracking"
 )
 
 var _ environments.Client = &MockClient{}
-var _ tracking.ReferenceResolverTracker = &MockTracker{}
 
 type MockClient struct {
 	MockDescribeCluster func(ctx context.Context, input *v1alpha1.KymaEnvironment) (*provisioningclient.BusinessEnvironmentInstanceResponseObject, error)
@@ -39,31 +33,5 @@ func (c MockClient) DeleteInstance(ctx context.Context, cr v1alpha1.KymaEnvironm
 	if c.MockDeleteCluster != nil {
 		return c.MockDeleteCluster(ctx, &cr)
 	}
-	return nil, nil
-}
-
-type MockTracker struct {
-	MockDeleteShouldBeBlocked func(mg resource.Managed) bool
-}
-
-func (m *MockTracker) Track(ctx context.Context, mg resource.Managed) error {
-	return nil
-}
-
-func (m *MockTracker) SetConditions(ctx context.Context, mg resource.Managed) {
-}
-
-func (m *MockTracker) DeleteShouldBeBlocked(mg resource.Managed) bool {
-	if m.MockDeleteShouldBeBlocked != nil {
-		return m.MockDeleteShouldBeBlocked(mg)
-	}
-	return false
-}
-
-func (m *MockTracker) ResolveSource(ctx context.Context, ru apisv1alpha1.ResourceUsage) (*metav1.PartialObjectMetadata, error) {
-	return nil, nil
-}
-
-func (m *MockTracker) ResolveTarget(ctx context.Context, ru apisv1alpha1.ResourceUsage) (*metav1.PartialObjectMetadata, error) {
 	return nil, nil
 }

--- a/internal/controller/environment/kyma/fake/fake.go
+++ b/internal/controller/environment/kyma/fake/fake.go
@@ -4,13 +4,18 @@ import (
 	"context"
 	"net/http"
 
-	environments "github.com/sap/crossplane-provider-btp/internal/clients/kymaenvironment"
-	provisioningclient "github.com/sap/crossplane-provider-btp/internal/openapi_clients/btp-provisioning-service-api-go/pkg"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/sap/crossplane-provider-btp/apis/environment/v1alpha1"
+	apisv1alpha1 "github.com/sap/crossplane-provider-btp/apis/v1alpha1"
+	environments "github.com/sap/crossplane-provider-btp/internal/clients/kymaenvironment"
+	provisioningclient "github.com/sap/crossplane-provider-btp/internal/openapi_clients/btp-provisioning-service-api-go/pkg"
+	"github.com/sap/crossplane-provider-btp/internal/tracking"
 )
 
 var _ environments.Client = &MockClient{}
+var _ tracking.ReferenceResolverTracker = &MockTracker{}
 
 type MockClient struct {
 	MockDescribeCluster func(ctx context.Context, input *v1alpha1.KymaEnvironment) (*provisioningclient.BusinessEnvironmentInstanceResponseObject, error)
@@ -34,5 +39,31 @@ func (c MockClient) DeleteInstance(ctx context.Context, cr v1alpha1.KymaEnvironm
 	if c.MockDeleteCluster != nil {
 		return c.MockDeleteCluster(ctx, &cr)
 	}
+	return nil, nil
+}
+
+type MockTracker struct {
+	MockDeleteShouldBeBlocked func(mg resource.Managed) bool
+}
+
+func (m *MockTracker) Track(ctx context.Context, mg resource.Managed) error {
+	return nil
+}
+
+func (m *MockTracker) SetConditions(ctx context.Context, mg resource.Managed) {
+}
+
+func (m *MockTracker) DeleteShouldBeBlocked(mg resource.Managed) bool {
+	if m.MockDeleteShouldBeBlocked != nil {
+		return m.MockDeleteShouldBeBlocked(mg)
+	}
+	return false
+}
+
+func (m *MockTracker) ResolveSource(ctx context.Context, ru apisv1alpha1.ResourceUsage) (*metav1.PartialObjectMetadata, error) {
+	return nil, nil
+}
+
+func (m *MockTracker) ResolveTarget(ctx context.Context, ru apisv1alpha1.ResourceUsage) (*metav1.PartialObjectMetadata, error) {
 	return nil, nil
 }

--- a/internal/controller/environment/kyma/kymaenvironment.go
+++ b/internal/controller/environment/kyma/kymaenvironment.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -75,6 +76,27 @@ type external struct {
 	record     event.Recorder
 }
 
+var creationFailureStates = []string{
+	v1alpha1.InstanceStateCreationFailed,
+}
+
+func environmentBeingDeleted(cr *v1alpha1.KymaEnvironment) bool {
+	readyCondition := cr.GetCondition(xpv1.TypeReady)
+	return readyCondition.Status == corev1.ConditionFalse && readyCondition.Reason == xpv1.ReasonDeleting
+}
+
+func (c *external) shouldRecreateOnFailure(cr *v1alpha1.KymaEnvironment, state *string) bool {
+	if !cr.Spec.RecreateOnCreationFailure || state == nil {
+		return false
+	}
+	for _, s := range creationFailureStates {
+		if *state == s {
+			return true
+		}
+	}
+	return false
+}
+
 // Disconnect is a no-op for the external client to close its connection.
 // Since we dont need this, we only have it to fullfil the interface.
 func (c *external) Disconnect(ctx context.Context) error {
@@ -127,6 +149,18 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 
 	lastModified := cr.Status.AtProvider.ModifiedDate
 	cr.Status.AtProvider = kymaenv.GenerateObservation(instance)
+
+	if c.shouldRecreateOnFailure(cr, cr.Status.AtProvider.State) {
+		var err error
+		if !environmentBeingDeleted(cr) {
+			_, err = c.Delete(ctx, mg)
+		}
+		return managed.ExternalObservation{
+			ResourceExists:    true,
+			ResourceUpToDate:  true,
+			ConnectionDetails: managed.ConnectionDetails{},
+		}, err
+	}
 
 	if cr.Status.AtProvider.State == nil {
 		cr.Status.SetConditions(xpv1.Unavailable())

--- a/internal/controller/environment/kyma/kymaenvironment_test.go
+++ b/internal/controller/environment/kyma/kymaenvironment_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sap/crossplane-provider-btp/internal"
 	kyma "github.com/sap/crossplane-provider-btp/internal/clients/kymaenvironment"
 	"github.com/sap/crossplane-provider-btp/internal/controller/environment/kyma/fake"
+	"github.com/sap/crossplane-provider-btp/internal/testutils"
 )
 
 // Unlike many Kubernetes projects Crossplane does not use third party testing
@@ -609,7 +610,7 @@ func TestRecreateOnCreationFailure(t *testing.T) {
 		httpClient: http.DefaultClient,
 		kube:       test.NewMockClient(),
 		record:     event.NewNopRecorder(),
-		tracker:    &fake.MockTracker{},
+		tracker:    testutils.NewResourceTrackerMock(),
 	}
 
 	cr := environment(

--- a/internal/controller/environment/kyma/kymaenvironment_test.go
+++ b/internal/controller/environment/kyma/kymaenvironment_test.go
@@ -588,6 +588,88 @@ func TestObserve(t *testing.T) {
 	}
 }
 
+func TestRecreateOnCreationFailure(t *testing.T) {
+	deleteCounter := 0
+	mockClient := fake.MockClient{
+		MockDescribeCluster: func(ctx context.Context, input *v1alpha1.KymaEnvironment) (*provisioningclient.BusinessEnvironmentInstanceResponseObject, error) {
+			return &provisioningclient.BusinessEnvironmentInstanceResponseObject{
+				Id:         internal.Ptr(testUUID),
+				State:      internal.Ptr(v1alpha1.InstanceStateCreationFailed),
+				Parameters: internal.Ptr("{\"name\":\"kyma\"}"),
+			}, nil
+		},
+		MockDeleteCluster: func(ctx context.Context, input *v1alpha1.KymaEnvironment) (*http.Response, error) {
+			deleteCounter++
+			return &http.Response{StatusCode: http.StatusOK}, nil
+		},
+	}
+
+	e := external{
+		client:     mockClient,
+		httpClient: http.DefaultClient,
+		kube:       test.NewMockClient(),
+		record:     event.NewNopRecorder(),
+		tracker:    &fake.MockTracker{},
+	}
+
+	cr := environment(
+		withExternalName(testUUID),
+		withUID("1234"),
+		withRecreateOnCreationFailure(),
+	)
+
+	t.Run("TriggersDelete", func(t *testing.T) {
+		got, err := e.Observe(context.Background(), cr)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if deleteCounter != 1 {
+			t.Errorf("expected 1 delete call, got %d", deleteCounter)
+		}
+		if diff := cmp.Diff(managed.ExternalObservation{
+			ResourceExists:    true,
+			ResourceUpToDate:  true,
+			ConnectionDetails: managed.ConnectionDetails{},
+		}, got); diff != "" {
+			t.Errorf("-want, +got:\n%s", diff)
+		}
+	})
+
+	t.Run("SkipsDeleteWhenAlreadyDeleting", func(t *testing.T) {
+		got, err := e.Observe(context.Background(), cr)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if deleteCounter != 1 {
+			t.Errorf("expected no additional delete call, got %d", deleteCounter)
+		}
+		if diff := cmp.Diff(managed.ExternalObservation{
+			ResourceExists:    true,
+			ResourceUpToDate:  true,
+			ConnectionDetails: managed.ConnectionDetails{},
+		}, got); diff != "" {
+			t.Errorf("-want, +got:\n%s", diff)
+		}
+	})
+
+	t.Run("ResourceGoneAfterDeletion", func(t *testing.T) {
+		e.client = fake.MockClient{
+			MockDescribeCluster: func(ctx context.Context, input *v1alpha1.KymaEnvironment) (*provisioningclient.BusinessEnvironmentInstanceResponseObject, error) {
+				return nil, nil
+			},
+		}
+		got, err := e.Observe(context.Background(), cr)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if diff := cmp.Diff(managed.ExternalObservation{
+			ResourceExists: false,
+		}, got); diff != "" {
+			t.Errorf("-want, +got:\n%s", diff)
+		}
+	})
+}
+
 func ignoreCircuitBreakerStatus() cmp.Option {
 	return cmpopts.IgnoreTypes(&v1alpha1.RetryStatus{})
 }
@@ -847,6 +929,12 @@ func withRetryStatus(retryStatus *v1alpha1.RetryStatus) environmentModifier {
 func withObservation(observation v1alpha1.KymaEnvironmentObservation) environmentModifier {
 	return func(r *v1alpha1.KymaEnvironment) {
 		r.Status.AtProvider = observation
+	}
+}
+
+func withRecreateOnCreationFailure() environmentModifier {
+	return func(r *v1alpha1.KymaEnvironment) {
+		r.Spec.RecreateOnCreationFailure = true
 	}
 }
 

--- a/package/crds/environment.btp.sap.crossplane.io_kymaenvironments.yaml
+++ b/package/crds/environment.btp.sap.crossplane.io_kymaenvironments.yaml
@@ -249,6 +249,11 @@ spec:
                 required:
                 - name
                 type: object
+              recreateOnCreationFailure:
+                description: |-
+                  RecreateOnCreationFailure indicates whether the environment should be
+                  automatically deleted and recreated when it enters CREATION_FAILED state.
+                type: boolean
               subaccountGuid:
                 type: string
               subaccountRef:


### PR DESCRIPTION
Fixes #672

When a KymaEnvironment enters `CREATION_FAILED` state, the reconciler gets stuck. This adds an opt-in `recreateOnCreationFailure` spec field that triggers automatic deletion so the next reconcile re-creates the environment. Follows the same pattern as Subscription's `recreateOnSubscriptionFailure`.

## What I changed

- Added `CREATION_FAILED`, `DELETION_FAILED`, `UPDATE_FAILED` state constants
- Added `recreateOnCreationFailure` field to `KymaEnvironmentSpec` (defaults to `false`)
- Added `shouldRecreateOnFailure()` check in `Observe()` that triggers `Delete()` when enabled
- Added `MockTracker` to the kyma fake package for test support
- Regenerated CRD