### PR TITLE
Fix/fix crank missing

### DIFF
--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -97,8 +97,6 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y gettext
 
       - name: Install Crossplane CLI
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -e
           CROSSPLANE_CLI_VERSION=v2.0.2

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -103,7 +103,7 @@ jobs:
           TOOLS_DIR=.cache/tools/linux_x86_64
           mkdir -p $TOOLS_DIR
           curl -fsSLo $TOOLS_DIR/crossplane-cli-${CROSSPLANE_CLI_VERSION} \
-          https://releases.crossplane.io/stable/${CROSSPLANE_CLI_VERSION}/bin/linux_amd64/crank
+            https://releases.crossplane.io/stable/${CROSSPLANE_CLI_VERSION}/bin/linux_amd64/crank
           chmod +x $TOOLS_DIR/crossplane-cli-${CROSSPLANE_CLI_VERSION}
 
       - name: Run e2e test

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -105,8 +105,7 @@ jobs:
           TOOLS_DIR=.cache/tools/linux_x86_64
           mkdir -p $TOOLS_DIR
           curl -fsSLo $TOOLS_DIR/crossplane-cli-${CROSSPLANE_CLI_VERSION} \
-            -H "Authorization: token ${GITHUB_TOKEN}" \
-            https://github.com/crossplane/crossplane/releases/download/${CROSSPLANE_CLI_VERSION}/crossplane_linux_amd64
+          https://releases.crossplane.io/stable/${CROSSPLANE_CLI_VERSION}/bin/linux_amd64/crank
           chmod +x $TOOLS_DIR/crossplane-cli-${CROSSPLANE_CLI_VERSION}
 
       - name: Run e2e test


### PR DESCRIPTION
Pre-installs the Crossplane CLI from releases.crossplane.io instead of GitHub releases, fixing a 404 caused by the binary being renamed from crossplane_linux_amd64 to crank in v2.x.