### PR TITLE
ci(e2e): build provider once and reuse across the test matrix

### DIFF
--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -32,6 +32,8 @@ env:
   # hardcoded BTP CLI version
   btp_cli_version: 2.90.2
   GO_VERSION: '1.25'
+  E2E_BUILD_REGISTRY: e2e
+  E2E_PROVIDER_IMAGE: e2e/provider-btp-amd64
 
 jobs:
   prepare-matrix:
@@ -55,9 +57,80 @@ jobs:
         run: | 
           echo "Test names: ${{ steps.set-matrix.outputs.test-names }}"
 
+  # Build image + xpkg + CLI tools once; the matrix consumes them as artifacts.
+  # NOTE: after the artifact retention window expires (retention-days below),
+  # "Re-run failed jobs" fails — build won't re-run, so its artifacts are gone.
+  # Use "Re-run all jobs" to rebuild them.
+  build:
+    runs-on: ubuntu-latest
+    needs: prepare-matrix
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ inputs.checkout-ref }}
+          submodules: true
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Fetch CLI tools once (kind, kubectl)
+        run: |
+          set -euo pipefail
+          vars="$(make --no-print-directory build.vars | grep -E '^(KIND|KUBECTL)=')"
+          eval "$vars"
+          : "${KIND:?}" "${KUBECTL:?}"
+          for attempt in 1 2 3 4 5; do
+            if make "$KIND" "$KUBECTL"; then break; fi
+            if [ "$attempt" -eq 5 ]; then
+              echo "::error::failed to fetch CLI tools from upstream CDNs after 5 attempts"
+              exit 1
+            fi
+            echo "tool fetch attempt $attempt failed; backing off $((attempt * 15))s..."
+            sleep "$((attempt * 15))"
+          done
+
+      - name: Build provider image
+        run: make build BUILD_REGISTRY=${{ env.E2E_BUILD_REGISTRY }} PLATFORMS=linux_amd64
+
+      - name: Build provider xpkg
+        run: make xpkg.build.provider-btp BUILD_REGISTRY=${{ env.E2E_BUILD_REGISTRY }} PLATFORMS=linux_amd64
+
+      - name: Export provider image
+        run: docker save "${{ env.E2E_PROVIDER_IMAGE }}" -o provider-image.tar
+
+      - name: Upload provider image
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: provider-image
+          path: provider-image.tar
+          retention-days: 7
+          overwrite: true
+          if-no-files-found: error
+
+      - name: Upload provider xpkg
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: provider-xpkg
+          path: _output/xpkg
+          retention-days: 7
+          overwrite: true
+          if-no-files-found: error
+
+      - name: Upload CLI tools
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-tools
+          path: .cache/tools
+          retention-days: 7
+          overwrite: true
+          if-no-files-found: error
+
   e2e-test:
     runs-on: ubuntu-latest
-    needs: prepare-matrix #required to depend on prepare-matrix to be able to use its outputs and its environment manual approval
+    needs: [prepare-matrix, build] # build provides the prebuilt image/xpkg/tools artifacts
     environment: ${{ inputs.environment }}
     strategy:
       fail-fast: false
@@ -76,13 +149,36 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
       - run: go version
 
+      - name: Download CLI tools
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: e2e-tools
+          path: .cache/tools
+
+      - name: Restore tool executable bits
+        # upload-artifact drops the +x bit
+        run: find .cache/tools -type f -exec chmod +x {} +
+
+      - name: Download provider xpkg
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: provider-xpkg
+          path: _output/xpkg
+
+      - name: Download provider image
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: provider-image
+          path: ${{ runner.temp }}/artifacts/provider-image
+
+      - name: Validate provider image artifact
+        run: test -f "${{ runner.temp }}/artifacts/provider-image/provider-image.tar"
+
+      - name: Load provider image
+        run: docker load -i "${{ runner.temp }}/artifacts/provider-image/provider-image.tar"
+
       - name: Install Helm
-        run: |
-          curl -fsSL https://packages.buildkite.com/helm-linux/helm-debian/gpgkey | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
-          sudo apt-get install apt-transport-https --yes
-          echo "deb [signed-by=/usr/share/keyrings/helm.gpg] https://packages.buildkite.com/helm-linux/helm-debian/any/ any main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
-          sudo apt-get update
-          sudo apt-get install -y helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
 
       - name: Install BTP CLI
       #hardcoded version
@@ -102,7 +198,7 @@ jobs:
       - name: Run e2e test
         timeout-minutes: 120
         run: |
-          make e2e testFilter=${{ matrix.testName }}
+          make test-acceptance ACCEPTANCE_DEPLOY=local-deploy-prebuilt BUILD_REGISTRY=${{ env.E2E_BUILD_REGISTRY }} testFilter=${{ matrix.testName }}
         env:
           BUILD_ID: ${{ env.BUILD_ID }}
           CIS_CENTRAL_BINDING: ${{ secrets.CIS_CENTRAL_BINDING }}
@@ -151,21 +247,27 @@ jobs:
           GLOBAL_ACCOUNT: ${{ secrets.GLOBAL_ACCOUNT }}
 
   # required for test matrix status reporting. Ignores cleanup-e2e job failure/success.
-  e2e-test-success:
+  e2e-tests:
     runs-on: ubuntu-latest
-    needs: 
+    needs:
       - prepare-matrix
+      - build
       - e2e-test
     timeout-minutes: 1
     if: always()
     steps:
       - name: Fail for failed prepare-matrix job
         if: |
-          needs.prepare-matrix.result == 'failure' || 
+          needs.prepare-matrix.result == 'failure' ||
           needs.prepare-matrix.result == 'cancelled'
+        run: exit 1
+      - name: Fail for failed build job
+        if: |
+          needs.build.result == 'failure' ||
+          needs.build.result == 'cancelled'
         run: exit 1
       - name: Fail for failed matrix jobs
         if: |
-          needs.e2e-test.result == 'failure' || 
+          needs.e2e-test.result == 'failure' ||
           needs.e2e-test.result == 'cancelled'
         run: exit 1

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,14 @@ local-build: build xpkg.build.provider-btp
 	docker tag $$XPKG_SHA $(UUT_XPKG);
 	$(OK) "Built local images: $(UUT_CONFIG) $(UUT_XPKG)"
 
+.PHONY: local-deploy-prebuilt
+local-deploy-prebuilt:
+	$(INFO) "Loading prebuilt xpkg into docker as $(UUT_XPKG)"
+	@XPKG_FILE=$$(find $(XPKG_OUTPUT_DIR)/$(PLATFORM) -name "*.xpkg" | head -1) && \
+	XPKG_SHA=$$(docker load -i $$XPKG_FILE | sed -n 's/.*ID: //p') && \
+	docker tag $$XPKG_SHA $(UUT_XPKG)
+	$(OK) "Prebuilt xpkg loaded as $(UUT_XPKG)"
+
 # ====================================================================================
 # Setup XPKG
 
@@ -281,8 +289,12 @@ test-e2e-long: local-build $(KIND) $(HELM3) generate-test-crs
      esac
 
 #run single e2e test with <make e2e testFilter=functionNameOfTest>
+# Deploy mechanism for test-acceptance. Default rebuilds locally (local dev);
+# CI overrides to local-deploy-prebuilt to consume artifacts from the build job.
+ACCEPTANCE_DEPLOY ?= local-build
+
 .PHONY: test-acceptance
-test-acceptance: local-build $(KIND) $(HELM3) generate-test-crs
+test-acceptance: $(ACCEPTANCE_DEPLOY) $(KIND) generate-test-crs
 	@$(INFO) running end-to-end tests
 	@$(INFO) Skipping long running tests
 	go test -v  $(PROJECT_REPO)/test/e2e -tags=e2e -short -count=1 -test.v -run '^$(testFilter)$$' -timeout 120m 2>&1 | tee test-output.log


### PR DESCRIPTION
## Build the provider once, reuse across the e2e matrix

Splits the e2e workflow into a single `build` job that compiles the image, xpkg, and CLI tools, and a matrix of `e2e-test` jobs that consume those as artifacts instead of each rebuilding.

### Problem
Every matrix shard ran `make e2e`, which invoked `local-build` to rebuild the image and xpkg from scratch for each test function. Each shard also re-fetched `kind`/`kubectl`, exposing CDN rate limits that could fail any shard.

### Fix
- New `build` job (`needs: prepare-matrix`) builds the image + xpkg once with `BUILD_REGISTRY=e2e PLATFORMS=linux_amd64`, fetches `kind`/`kubectl` with a 5-attempt backoff, and uploads image (`docker save`), xpkg, and tools as artifacts (`retention-days: 7`, `if-no-files-found: error`).
- `e2e-test` shards download the artifacts, restore the executable bit `upload-artifact` strips, `docker load` the image, and deploy via a prebuilt path instead of building.
- `Makefile`: add `local-deploy-prebuilt`, which `docker load`s the prebuilt xpkg and tags it as
`$(UUT_XPKG)`; route `test-acceptance` through `ACCEPTANCE_DEPLOY ?= local-build` so local dev rebuilds as before and CI overrides it to `local-deploy-prebuilt`.
- Run e2e via `make test-acceptance` instead of `make e2e`.
- Swap the apt/buildkite Helm install for `azure/setup-helm`.
- Rename `e2e-test-success` to `e2e-tests` and fail it closed on a failed/cancelled `build` job.