### PR TITLE
fix: remove approval from e2e matrix job

### DIFF
--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -1,3 +1,5 @@
+# Runs e2e tests, potentially requiring approval based on the `environment` input.
+#
 # Enviroment variables/secrets that are needed
 # CLI_SERVER_URL contains the CLI server URL
 # GLOBAL_ACCOUNT contains the subdomain of the global account
@@ -11,7 +13,6 @@
 name: E2E Test
 
 on:
-  workflow_dispatch:
   workflow_call:
     inputs:
       checkout-ref:
@@ -38,7 +39,7 @@ env:
 jobs:
   prepare-matrix:
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
+    environment: ${{ inputs.environment }}  # approval here for the entire workflow, later jobs use no approval environment
     outputs:
       test-names: ${{ steps.set-matrix.outputs.test-names }}
     steps:
@@ -131,7 +132,7 @@ jobs:
   e2e-test:
     runs-on: ubuntu-latest
     needs: [prepare-matrix, build] # build provides the prebuilt image/xpkg/tools artifacts
-    environment: ${{ inputs.environment }}
+    environment: pr-e2e-no-approval  # approval is on the preceding prepare-matrix job
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pr-e2e.yaml
+++ b/.github/workflows/pr-e2e.yaml
@@ -1,9 +1,11 @@
+# Runs e2e tests on PRs that are not solely markdown changes.
+#
 # The on.pull_request_target runs on changes to a pull request. Contrary to the on.pull_request, this pipeline has access to secrets and can therefore run e2e tests.
 # DANGEROUS: 1) with access to secrets it is possible to steal those by a pull request that executes code that reads the secrets and exfiltrates those.
 # DANGEROUS: 2) the GITHUB_TOKEN has read and write permissions by default. Therefore, restrict the permissions with the permissions field
 # To adress (1), we use an environment pr-e2e-approval that will only execute the job after an explicit approval from team member (after inspecting the code for non-malicious activity).
 
-# Requiremenets: 
+# Requirements:
 # 1) pr-e2e-approval environment configured to require approval before running
 # 2) pr-e2e-no-approval environment configured that does not require approval.
 


### PR DESCRIPTION
GHA Workflow: for e2e tests, remove environment approval from matrix job. This spams all approvers for each matrix job.

Also remove workflow_dispatch since this currently has no "environment" input, and would circumvent the env selection.