### PR TITLE
fix: move crank download to build step

### DIFF
--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -77,7 +77,7 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
-      - name: Fetch CLI tools once (kind, kubectl)
+      - name: Fetch CLI tools once (kind, kubectl, crank)
         run: |
           set -euo pipefail
           vars="$(make --no-print-directory build.vars | grep -E '^(KIND|KUBECTL)=')"
@@ -92,6 +92,12 @@ jobs:
             echo "tool fetch attempt $attempt failed; backing off $((attempt * 15))s..."
             sleep "$((attempt * 15))"
           done
+          CROSSPLANE_CLI_VERSION=v2.0.2
+          TOOLS_DIR=.cache/tools/linux_x86_64
+          mkdir -p $TOOLS_DIR
+          curl -fsSLo $TOOLS_DIR/crossplane-cli-${CROSSPLANE_CLI_VERSION} \
+            https://releases.crossplane.io/stable/${CROSSPLANE_CLI_VERSION}/bin/linux_amd64/crank
+          chmod +x $TOOLS_DIR/crossplane-cli-${CROSSPLANE_CLI_VERSION}
 
       - name: Build provider image
         run: make build BUILD_REGISTRY=${{ env.E2E_BUILD_REGISTRY }} PLATFORMS=linux_amd64
@@ -197,16 +203,6 @@ jobs:
 
       - name: Install gettext for envsubst
         run: sudo apt-get update && sudo apt-get install -y gettext
-
-      - name: Install Crossplane CLI
-        run: |
-          set -e
-          CROSSPLANE_CLI_VERSION=v2.0.2
-          TOOLS_DIR=.cache/tools/linux_x86_64
-          mkdir -p $TOOLS_DIR
-          curl -fsSLo $TOOLS_DIR/crossplane-cli-${CROSSPLANE_CLI_VERSION} \
-            https://releases.crossplane.io/stable/${CROSSPLANE_CLI_VERSION}/bin/linux_amd64/crank
-          chmod +x $TOOLS_DIR/crossplane-cli-${CROSSPLANE_CLI_VERSION}
 
       - name: Run e2e test
         timeout-minutes: 120


### PR DESCRIPTION
Crank downloads started to be an issue again. This PR moves it to the build step to reduce load.