### PR TITLE
fix: e2e workflow inherit secrets param

### DIFF
--- a/.github/workflows/pr-e2e.yaml
+++ b/.github/workflows/pr-e2e.yaml
@@ -26,4 +26,4 @@ jobs:
     with:
       checkout-ref: ${{ github.event.pull_request.head.sha }}
       environment: pr-e2e-approval # environment that requires approval for execution
-      secrets: inherit
+    secrets: inherit


### PR DESCRIPTION
fix indentation error - needs to be outside `with` 