### PR TITLE
ci(e2e): harden test setup against transient flakes

### DIFF
--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -35,6 +35,7 @@ env:
   GO_VERSION: '1.25'
   E2E_BUILD_REGISTRY: index.docker.io/e2e
   E2E_PROVIDER_IMAGE: index.docker.io/e2e/provider-btp-amd64
+  CROSSPLANE_CLI_VERSION: v2.0.2
 
 jobs:
   prepare-matrix:
@@ -44,7 +45,7 @@ jobs:
       test-names: ${{ steps.set-matrix.outputs.test-names }}
     steps:
       - name: checkout repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           #use inputs.checkout-ref to be able to call it from a pull_request_target workflow, since there it needs to be github.event.pull_request.merge_commit_sha and not the default
           ref: ${{ inputs.checkout-ref }}
@@ -77,27 +78,44 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
+      - name: Restore CLI tools cache (kind, kubectl, crank)
+        id: cli-tools-cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: .cache/tools
+          key: e2e-tools-${{ runner.os }}-${{ runner.arch }}-crank-${{ env.CROSSPLANE_CLI_VERSION }}-${{ hashFiles('build/makelib/k8s_tools.mk') }}
+
       - name: Fetch CLI tools once (kind, kubectl, crank)
         run: |
           set -euo pipefail
+          retry() {
+            local n=1 max=5
+            until "$@"; do
+              if [ "$n" -ge "$max" ]; then
+                echo "::error::'$*' failed after $max attempts"
+                return 1
+              fi
+              echo "attempt $n failed; backing off $((n * 15))s..."
+              sleep "$((n * 15))"
+              n=$((n + 1))
+            done
+          }
           vars="$(make --no-print-directory build.vars | grep -E '^(KIND|KUBECTL)=')"
           eval "$vars"
-          : "${KIND:?}" "${KUBECTL:?}"
-          for attempt in 1 2 3 4 5; do
-            if make "$KIND" "$KUBECTL"; then break; fi
-            if [ "$attempt" -eq 5 ]; then
-              echo "::error::failed to fetch CLI tools from upstream CDNs after 5 attempts"
-              exit 1
-            fi
-            echo "tool fetch attempt $attempt failed; backing off $((attempt * 15))s..."
-            sleep "$((attempt * 15))"
-          done
-          CROSSPLANE_CLI_VERSION=v2.0.2
-          TOOLS_DIR=.cache/tools/linux_x86_64
-          mkdir -p $TOOLS_DIR
-          curl -fsSLo $TOOLS_DIR/crossplane-cli-${CROSSPLANE_CLI_VERSION} \
-            https://releases.crossplane.io/stable/${CROSSPLANE_CLI_VERSION}/bin/linux_amd64/crank
-          chmod +x $TOOLS_DIR/crossplane-cli-${CROSSPLANE_CLI_VERSION}
+          : "${KIND:?}" "${KUBECTL:?}" "${CROSSPLANE_CLI_VERSION:?}"
+          CRANK=".cache/tools/linux_x86_64/crossplane-cli-${CROSSPLANE_CLI_VERSION}"
+          retry make "$KIND" "$KUBECTL"
+          if [ ! -x "$CRANK" ]; then
+            retry curl -fsSL --create-dirs -o "$CRANK" "https://releases.crossplane.io/stable/${CROSSPLANE_CLI_VERSION}/bin/linux_amd64/crank"
+            chmod +x "$CRANK"
+          fi
+
+      - name: Save CLI tools cache (kind, kubectl, crank)
+        if: success() && steps.cli-tools-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: .cache/tools
+          key: ${{ steps.cli-tools-cache.outputs.cache-primary-key }}
 
       - name: Build provider image
         run: make build BUILD_REGISTRY=${{ env.E2E_BUILD_REGISTRY }} PLATFORMS=linux_amd64
@@ -145,13 +163,13 @@ jobs:
         testName: ${{ fromJson(needs.prepare-matrix.outputs.test-names) }}
     steps:
       - name: checkout repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           #use inputs.checkout-ref to be able to call it from a pull_request_target workflow, since there it needs to be github.event.pull_request.merge_commit_sha and not the default
           ref: ${{ inputs.checkout-ref }}
           submodules: true
 
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ env.GO_VERSION }}
       - run: go version
@@ -181,6 +199,27 @@ jobs:
       - name: Validate provider image artifact
         run: test -f "${{ runner.temp }}/artifacts/provider-image/provider-image.tar"
 
+      - name: Route Docker Hub pulls through mirror.gcr.io
+        # Routing docker.io through Google's pull-through cache for kindest/node.
+        run: |
+          set -euo pipefail
+          sudo mkdir -p /etc/docker
+          if sudo test -s /etc/docker/daemon.json; then
+            sudo jq '. + {"registry-mirrors":["https://mirror.gcr.io"]}' /etc/docker/daemon.json \
+              | sudo tee /etc/docker/daemon.json.tmp >/dev/null
+            sudo mv /etc/docker/daemon.json.tmp /etc/docker/daemon.json
+          else
+            printf '%s\n' '{"registry-mirrors":["https://mirror.gcr.io"]}' | sudo tee /etc/docker/daemon.json >/dev/null
+          fi
+          sudo systemctl reload docker
+          for _ in $(seq 1 10); do
+            case "$(docker info --format '{{.RegistryConfig.Mirrors}}')" in
+              *mirror.gcr.io*) echo "registry mirror applied"; exit 0 ;;
+            esac
+            sleep 1
+          done
+          echo "::error::mirror.gcr.io not applied to docker daemon"; exit 1
+
       - name: Load provider image
         run: docker load -i "${{ runner.temp }}/artifacts/provider-image/provider-image.tar"
 
@@ -207,7 +246,16 @@ jobs:
       - name: Run e2e test
         timeout-minutes: 120
         run: |
-          make test-acceptance ACCEPTANCE_DEPLOY=local-deploy-prebuilt BUILD_REGISTRY=${{ env.E2E_BUILD_REGISTRY }} testFilter=${{ matrix.testName }}
+          set -uo pipefail
+          for attempt in 1 2 3; do
+            rm -f test-output.log
+            make test-acceptance ACCEPTANCE_DEPLOY=local-deploy-prebuilt BUILD_REGISTRY=${{ env.E2E_BUILD_REGISTRY }} testFilter=${{ matrix.testName }} && exit 0
+            rc=$?
+            grep -qE 'crossplane helm chart repo|upgrade helm repo|install crossplane Helm chart|not a valid chart repository or cannot be reached|failed to pull image' test-output.log 2>/dev/null || exit "$rc"
+            echo "::warning::transient setup flake (helm/node-image); retry $attempt/3"
+            sleep $((attempt * 15))
+          done
+          exit "$rc"
         env:
           BUILD_ID: ${{ env.BUILD_ID }}
           CIS_CENTRAL_BINDING: ${{ secrets.CIS_CENTRAL_BINDING }}
@@ -225,13 +273,13 @@ jobs:
     if: always() && needs.prepare-matrix.result == 'success'  # only run if prepare-matrix was successful (requires manual approval) and then always run after e2e-test
     steps:
       - name: checkout repo
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # use github.base_ref to checkout the base branch, since the cleanup should always run on the base branch to make it harder for malicious code execution. Consequently, this will not pick up changes to the cleanup.go file in the PR, but that is accebtable.
           ref: ${{ github.base_ref }}
           submodules: true
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ env.GO_VERSION }}
 


### PR DESCRIPTION
## Harden the e2e test setup against transient CI failures

Mitigates three independent flake sources in the e2e workflow, plus runner action bumps.

### Problem
- `kind`/`kubectl`/crank were re-fetched from upstream CDNs on every `build` run; the crank download was un-retried and had been failing repeatedly (#697, #703).
- `kindest/node` is pulled from Docker Hub, whose per-IP rate limit is shared across GitHub-hosted runners, so cluster creation could fail with `failed to pull image`.
- A transient setup error (helm repo, node-image pull) failed the whole matrix shard with no retry.

### Fix
- Cache `.cache/tools` across runs (`actions/cache`, keyed on `k8s_tools.mk` hash + crank version); fetch only on a miss, save only on success. The retry/backoff helper now also wraps the crank download, not just the tool fetch.
- New step routes Docker Hub through `mirror.gcr.io` (`registry-mirrors` in `daemon.json` + `systemctl reload docker`, verified via `docker info`) before kind runs, so `kindest/node` pulls bypass the Hub rate limit.
- Wrap `make test-acceptance` in a 3-attempt loop that retries only on known transient setup signatures and fails fast on real test failures.
- Bump `actions/checkout` v4→v6 and `actions/setup-go` v5→v6 (SHA-pinned).