### PR TITLE
refactor: consolidate connection-detail flatten + add __raw to ServiceBinding/ServiceManager

### DIFF
--- a/apis/environment/v1alpha1/cfenvironment_types.go
+++ b/apis/environment/v1alpha1/cfenvironment_types.go
@@ -20,7 +20,6 @@ const (
 	ResourceAPIEndpoint = "apiEndpoint"
 	ResourceOrgId       = "orgId"
 	ResourceOrgName     = "orgName"
-	ResourceRaw         = "__raw"
 )
 
 // User identifies a user by username and origin

--- a/internal/clients/cfenvironment/client.go
+++ b/internal/clients/cfenvironment/client.go
@@ -11,6 +11,7 @@ import (
 	provisioningclient "github.com/sap/crossplane-provider-btp/internal/openapi_clients/btp-provisioning-service-api-go/pkg"
 
 	"github.com/sap/crossplane-provider-btp/apis/environment/v1alpha1"
+	providerv1alpha1 "github.com/sap/crossplane-provider-btp/apis/v1alpha1"
 	"github.com/sap/crossplane-provider-btp/internal"
 )
 
@@ -105,7 +106,7 @@ func GetConnectionDetails(instance *provisioningclient.BusinessEnvironmentInstan
 		return managed.ConnectionDetails{}, err
 	}
 	details := managed.ConnectionDetails{
-		v1alpha1.ResourceRaw: label,
+		providerv1alpha1.RawBindingKey: label,
 	}
 
 	if orgName, ok := cflabels["Org Name"]; ok {

--- a/internal/clients/cfenvironment/client_test.go
+++ b/internal/clients/cfenvironment/client_test.go
@@ -9,6 +9,7 @@ import (
 	provisioningclient "github.com/sap/crossplane-provider-btp/internal/openapi_clients/btp-provisioning-service-api-go/pkg"
 
 	"github.com/sap/crossplane-provider-btp/apis/environment/v1alpha1"
+	providerv1alpha1 "github.com/sap/crossplane-provider-btp/apis/v1alpha1"
 )
 
 func TestGetConnectionDetails(t *testing.T) {
@@ -38,7 +39,7 @@ func TestGetConnectionDetails(t *testing.T) {
 				v1alpha1.ResourceOrgName:     []byte("name"),
 				v1alpha1.ResourceOrgId:       []byte("uuid"),
 				v1alpha1.ResourceAPIEndpoint: []byte("url"),
-				v1alpha1.ResourceRaw:         []byte("{\"API Endpoint\":\"url\",\"Org Name\":\"name\",\"Org ID\":\"uuid\"}"),
+				providerv1alpha1.RawBindingKey:         []byte("{\"API Endpoint\":\"url\",\"Org Name\":\"name\",\"Org ID\":\"uuid\"}"),
 			},
 			wantErr: false,
 		},
@@ -48,7 +49,7 @@ func TestGetConnectionDetails(t *testing.T) {
 				instance: instance(withLabels("{\"asd\":\"url\",\"asdf\":\"name\",\"bar\":\"uuid\"}")),
 			},
 			want: managed.ConnectionDetails{
-				v1alpha1.ResourceRaw: []byte("{\"asd\":\"url\",\"asdf\":\"name\",\"bar\":\"uuid\"}"),
+				providerv1alpha1.RawBindingKey: []byte("{\"asd\":\"url\",\"asdf\":\"name\",\"bar\":\"uuid\"}"),
 			},
 			wantErr: false,
 		},
@@ -69,7 +70,7 @@ func TestGetConnectionDetails(t *testing.T) {
 				v1alpha1.ResourceOrgName:     []byte("my-org"),
 				v1alpha1.ResourceOrgId:       []byte("old-uuid"),
 				v1alpha1.ResourceAPIEndpoint: []byte("https://api.cf.example.com"),
-				v1alpha1.ResourceRaw:         []byte("{\"API Endpoint:\":\"https://api.cf.example.com\",\"Org Name\":\"my-org\",\"Org ID:\":\"old-uuid\"}"),
+				providerv1alpha1.RawBindingKey:         []byte("{\"API Endpoint:\":\"https://api.cf.example.com\",\"Org Name\":\"my-org\",\"Org ID:\":\"old-uuid\"}"),
 			},
 			wantErr: false,
 		},

--- a/internal/clients/servicemanager/service_manager_tf_client.go
+++ b/internal/clients/servicemanager/service_manager_tf_client.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 	apisv1alpha1 "github.com/sap/crossplane-provider-btp/apis/account/v1alpha1"
 	apisv1beta1 "github.com/sap/crossplane-provider-btp/apis/account/v1beta1"
+	providerv1alpha1 "github.com/sap/crossplane-provider-btp/apis/v1alpha1"
 
 	"github.com/sap/crossplane-provider-btp/internal"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -284,5 +285,6 @@ func mapTfConnectionDetails(conDetails map[string][]byte) (managed.ConnectionDet
 		apisv1beta1.ResourceCredentialsXsuaaUrl:          []byte(internal.Val(creds.Url)),
 		apisv1beta1.ResourceCredentialsXsappname:         []byte(internal.Val(creds.Xsappname)),
 		apisv1beta1.ResourceCredentialsXsuaaUrlSufix:     []byte("/oauth/token"),
+		providerv1alpha1.RawBindingKey:                   bindingAsBytes,
 	}, nil
 }

--- a/internal/clients/servicemanager/service_manager_tf_client_test.go
+++ b/internal/clients/servicemanager/service_manager_tf_client_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sap/crossplane-provider-btp/apis/account/v1alpha1"
 	"github.com/sap/crossplane-provider-btp/apis/account/v1beta1"
+	providerv1alpha1 "github.com/sap/crossplane-provider-btp/apis/v1alpha1"
 	"github.com/sap/crossplane-provider-btp/internal"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -308,6 +309,7 @@ func TestObserveResources(t *testing.T) {
 							v1beta1.ResourceCredentialsXsuaaUrl:          []byte("https://subdomain.authentication.eu12.hana.ondemand.com"),
 							v1beta1.ResourceCredentialsXsappname:         []byte("someAppName"),
 							v1beta1.ResourceCredentialsXsuaaUrlSufix:     []byte("/oauth/token"),
+							providerv1alpha1.RawBindingKey:               []byte(`{"clientid":"someClientID","clientsecret":"someSecret","sm_url":"https://service-manager.cfapps.eu12.hana.ondemand.com","url":"https://subdomain.authentication.eu12.hana.ondemand.com","xsappname":"someAppName"}`),
 						},
 					},
 					InstanceID: "someID",
@@ -395,6 +397,7 @@ func TestObserveResources(t *testing.T) {
 							v1beta1.ResourceCredentialsXsuaaUrl:          []byte("https://subdomain.authentication.eu12.hana.ondemand.com"),
 							v1beta1.ResourceCredentialsXsappname:         []byte("someAppName"),
 							v1beta1.ResourceCredentialsXsuaaUrlSufix:     []byte("/oauth/token"),
+							providerv1alpha1.RawBindingKey:               []byte(`{"clientid":"someClientID","clientsecret":"someSecret","sm_url":"https://service-manager.cfapps.eu12.hana.ondemand.com","url":"https://subdomain.authentication.eu12.hana.ondemand.com","xsappname":"someAppName"}`),
 						}},
 					InstanceID: "someID",
 					BindingID:  "anotherID",

--- a/internal/clients/tfclient/tfcontroller.go
+++ b/internal/clients/tfclient/tfcontroller.go
@@ -2,7 +2,6 @@ package tfclient
 
 import (
 	"context"
-	"encoding/json"
 	"time"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
@@ -11,6 +10,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
 	ujresource "github.com/crossplane/upjet/v2/pkg/resource"
 	"github.com/sap/crossplane-provider-btp/apis/account/v1alpha1"
+	"github.com/sap/crossplane-provider-btp/internal"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -199,36 +199,9 @@ func (t *TfProxyController[UPJETTED]) Observe(ctx context.Context) (Status, map[
 		return Drift, map[string][]byte{}, nil
 	}
 
-	flatDetails, err := flattenSecretData(obs.ConnectionDetails)
+	flatDetails, err := internal.FlattenConnectionDetails(obs.ConnectionDetails)
 	if err != nil {
 		return Unknown, nil, err
 	}
 	return UpToDate, flatDetails, nil
-}
-
-// flattenSecretData takes a map[string][]byte and flattens any JSON object values into the result map.
-// For each key whose value is a JSON object, its keys/values are added to the result map as top-level entries.
-// Non-JSON values are kept as-is.
-func flattenSecretData(secretData map[string][]byte) (map[string][]byte, error) {
-	result := make(map[string][]byte)
-	for k, v := range secretData {
-		var jsonMap map[string]any
-		if err := json.Unmarshal(v, &jsonMap); err == nil {
-			for jk, jv := range jsonMap {
-				switch val := jv.(type) {
-				case string:
-					result[jk] = []byte(val)
-				default:
-					b, err := json.Marshal(val)
-					if err != nil {
-						return nil, err
-					}
-					result[jk] = b
-				}
-			}
-		} else {
-			result[k] = v
-		}
-	}
-	return result, nil
 }

--- a/internal/clients/tfclient/tfcontroller_test.go
+++ b/internal/clients/tfclient/tfcontroller_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/crossplane/upjet/v2/pkg/resource/fake"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
+	providerv1alpha1 "github.com/sap/crossplane-provider-btp/apis/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -200,8 +201,9 @@ func TestObserve(t *testing.T) {
 				status: UpToDate,
 				err:    nil,
 				details: map[string][]byte{
-					"key1": []byte("value1"),
-					"key2": []byte("value2"),
+					"key1":                         []byte("value1"),
+					"key2":                         []byte("value2"),
+					providerv1alpha1.RawBindingKey: []byte(`{"key1":"value1","key2":"value2"}`),
 				},
 			},
 		},

--- a/internal/controller/account/servicebinding/secretformat.go
+++ b/internal/controller/account/servicebinding/secretformat.go
@@ -10,6 +10,7 @@ import (
 	kubeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/sap/crossplane-provider-btp/apis/account/v1alpha1"
+	"github.com/sap/crossplane-provider-btp/internal"
 )
 
 const (
@@ -163,7 +164,7 @@ func processConnectionDetails(cr *v1alpha1.ServiceBinding, details map[string][]
 	if cr.Spec.SecretKey != nil {
 		return bundleCredentials(*cr.Spec.SecretKey, details)
 	}
-	return flattenSecretData(details)
+	return internal.FlattenConnectionDetails(details)
 }
 
 func fetchServiceInstance(ctx context.Context, kube kubeclient.Client, refName string) (*v1alpha1.ServiceInstance, error) {

--- a/internal/controller/account/servicebinding/servicebinding.go
+++ b/internal/controller/account/servicebinding/servicebinding.go
@@ -2,7 +2,6 @@ package servicebinding
 
 import (
 	"context"
-	"encoding/json"
 	"time"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
@@ -385,31 +384,4 @@ func parseIso8601Date(t string) (metav1.Time, error) {
 	return metav1.Time{
 		Time: iTime,
 	}, nil
-}
-
-// flattenSecretData takes a map[string][]byte and flattens any JSON object values into the result map.
-// For each key whose value is a JSON object, its keys/values are added to the result map as top-level entries.
-// Non-JSON values are kept as-is.
-func flattenSecretData(secretData map[string][]byte) (map[string][]byte, error) {
-	result := make(map[string][]byte)
-	for k, v := range secretData {
-		var jsonMap map[string]any
-		if err := json.Unmarshal(v, &jsonMap); err == nil {
-			for jk, jv := range jsonMap {
-				switch val := jv.(type) {
-				case string:
-					result[jk] = []byte(val)
-				default:
-					b, err := json.Marshal(val)
-					if err != nil {
-						return nil, err
-					}
-					result[jk] = b
-				}
-			}
-		} else {
-			result[k] = v
-		}
-	}
-	return result, nil
 }

--- a/internal/controller/account/servicebinding/servicebinding_test.go
+++ b/internal/controller/account/servicebinding/servicebinding_test.go
@@ -378,66 +378,6 @@ func TestConnect(t *testing.T) {
 	}
 }
 
-// Test flattenSecretData function
-func TestFlattenSecretData(t *testing.T) {
-	cases := map[string]struct {
-		reason string
-		input  map[string][]byte
-		want   map[string][]byte
-		err    error
-	}{
-		"EmptyInput": {
-			reason: "should handle empty input",
-			input:  map[string][]byte{},
-			want:   map[string][]byte{},
-		},
-		"NonJSONValue": {
-			reason: "should keep non-JSON values as-is",
-			input: map[string][]byte{
-				"simple": []byte("value"),
-			},
-			want: map[string][]byte{
-				"simple": []byte("value"),
-			},
-		},
-		"JSONObjectValue": {
-			reason: "should flatten JSON object values",
-			input: map[string][]byte{
-				"json_obj": []byte(`{"key1": "value1", "key2": "value2"}`),
-			},
-			want: map[string][]byte{
-				"key1": []byte("value1"),
-				"key2": []byte("value2"),
-			},
-		},
-		"MixedValues": {
-			reason: "should handle mixed JSON and non-JSON values",
-			input: map[string][]byte{
-				"simple":   []byte("simple_value"),
-				"json_obj": []byte(`{"nested_key": "nested_value"}`),
-			},
-			want: map[string][]byte{
-				"simple":     []byte("simple_value"),
-				"nested_key": []byte("nested_value"),
-			},
-		},
-	}
-
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
-			got, err := flattenSecretData(tc.input)
-
-			if diff := cmp.Diff(tc.err, err, test.EquateErrors()); diff != "" {
-				t.Errorf("\n%s\nflattenSecretData(...): -want error, +got error:\n%s\n", tc.reason, diff)
-			}
-
-			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("\n%s\nflattenSecretData(...): -want, +got:\n%s\n", tc.reason, diff)
-			}
-		})
-	}
-}
-
 // Test helper function validation
 func TestServiceBindingHelpers(t *testing.T) {
 	t.Run("expectedServiceBinding creates valid CR", func(t *testing.T) {

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -19,6 +19,8 @@ import (
 	yamlv3 "gopkg.in/yaml.v3"
 
 	"sigs.k8s.io/yaml"
+
+	providerv1alpha1 "github.com/sap/crossplane-provider-btp/apis/v1alpha1"
 )
 
 const (
@@ -70,6 +72,40 @@ func Flatten(m map[string]interface{}) map[string][]byte {
 		}
 	}
 	return o
+}
+
+// FlattenConnectionDetails flattens JSON object values in a Crossplane
+// ConnectionDetails map. For every input value that parses as a JSON object,
+// its top-level keys are promoted to the result and the original blob is
+// preserved under providerv1alpha1.RawBindingKey ("__raw"). Non-object values
+// are passed through unchanged.
+//
+// If multiple input values are JSON objects, the last one written wins on the
+// __raw key. In practice BTP terraform observations carry a single
+// "attribute.credentials" blob, so this is unambiguous.
+func FlattenConnectionDetails(in map[string][]byte) (map[string][]byte, error) {
+	out := make(map[string][]byte, len(in))
+	for k, v := range in {
+		var jsonMap map[string]any
+		if err := json.Unmarshal(v, &jsonMap); err != nil {
+			out[k] = v
+			continue
+		}
+		out[providerv1alpha1.RawBindingKey] = v
+		for jk, jv := range jsonMap {
+			switch val := jv.(type) {
+			case string:
+				out[jk] = []byte(val)
+			default:
+				b, err := json.Marshal(val)
+				if err != nil {
+					return nil, err
+				}
+				out[jk] = b
+			}
+		}
+	}
+	return out, nil
 }
 
 func SliceEqualsFold(left []string, right []string) bool {

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -3,7 +3,10 @@ package internal
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+
+	providerv1alpha1 "github.com/sap/crossplane-provider-btp/apis/v1alpha1"
 )
 
 func TestVal(t *testing.T) {
@@ -33,4 +36,78 @@ func TestVal(t *testing.T) {
 	ptrBool = &emptyB
 	assert.Equal(t, false, Val(ptrBool))
 
+}
+
+func TestFlattenConnectionDetails(t *testing.T) {
+	jsonBlob := []byte(`{"key1":"value1","key2":"value2"}`)
+	mixedBlob := []byte(`{"nested_key":"nested_value"}`)
+
+	cases := map[string]struct {
+		reason string
+		input  map[string][]byte
+		want   map[string][]byte
+		err    error
+	}{
+		"EmptyInput": {
+			reason: "should handle empty input",
+			input:  map[string][]byte{},
+			want:   map[string][]byte{},
+		},
+		"NonJSONValue": {
+			reason: "should keep non-JSON values as-is",
+			input: map[string][]byte{
+				"simple": []byte("value"),
+			},
+			want: map[string][]byte{
+				"simple": []byte("value"),
+			},
+		},
+		"JSONObjectValue": {
+			reason: "should flatten JSON object values and preserve raw blob",
+			input: map[string][]byte{
+				"json_obj": jsonBlob,
+			},
+			want: map[string][]byte{
+				"key1":                         []byte("value1"),
+				"key2":                         []byte("value2"),
+				providerv1alpha1.RawBindingKey: jsonBlob,
+			},
+		},
+		"MixedValues": {
+			reason: "should handle mixed JSON and non-JSON values",
+			input: map[string][]byte{
+				"simple":   []byte("simple_value"),
+				"json_obj": mixedBlob,
+			},
+			want: map[string][]byte{
+				"simple":                       []byte("simple_value"),
+				"nested_key":                   []byte("nested_value"),
+				providerv1alpha1.RawBindingKey: mixedBlob,
+			},
+		},
+		"NestedObjectValue": {
+			reason: "should re-marshal non-string nested values",
+			input: map[string][]byte{
+				"json_obj": []byte(`{"endpoints":{"api":"https://api.example.com"}}`),
+			},
+			want: map[string][]byte{
+				"endpoints":                    []byte(`{"api":"https://api.example.com"}`),
+				providerv1alpha1.RawBindingKey: []byte(`{"endpoints":{"api":"https://api.example.com"}}`),
+			},
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := FlattenConnectionDetails(tc.input)
+
+			if (err == nil) != (tc.err == nil) {
+				t.Errorf("\n%s\nFlattenConnectionDetails(...): want err=%v, got err=%v\n", tc.reason, tc.err, err)
+			}
+
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("\n%s\nFlattenConnectionDetails(...): -want, +got:\n%s\n", tc.reason, diff)
+			}
+		})
+	}
 }

--- a/test/e2e/servicebinding_norotation_test.go
+++ b/test/e2e/servicebinding_norotation_test.go
@@ -5,10 +5,12 @@ package e2e
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/crossplane-contrib/xp-testing/pkg/resources"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	res "sigs.k8s.io/e2e-framework/klient/k8s/resources"
 	"sigs.k8s.io/e2e-framework/klient/wait"
@@ -17,6 +19,7 @@ import (
 
 	"github.com/sap/crossplane-provider-btp/apis"
 	"github.com/sap/crossplane-provider-btp/apis/account/v1alpha1"
+	providerv1alpha1 "github.com/sap/crossplane-provider-btp/apis/v1alpha1"
 )
 
 var (
@@ -53,6 +56,28 @@ func TestServiceBinding_CreationFlow(t *testing.T) {
 				return ctx
 			},
 		).Assess(
+		"Check ServiceBinding secret carries flattened keys plus __raw blob", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			sb := &v1alpha1.ServiceBinding{}
+			MustGetResource(t, cfg, sbCreateName, nil, sb)
+			secretRef := sb.GetWriteConnectionSecretToReference()
+			secret := &corev1.Secret{}
+			MustGetResource(t, cfg, secretRef.Name, &secretRef.Namespace, secret)
+			rawBlob, ok := secret.Data[providerv1alpha1.RawBindingKey]
+			if !ok || len(rawBlob) == 0 {
+				t.Errorf("ServiceBinding secret missing %q key with raw credentials blob", providerv1alpha1.RawBindingKey)
+				return ctx
+			}
+			var rawCreds map[string]any
+			if err := json.Unmarshal(rawBlob, &rawCreds); err != nil {
+				t.Errorf("ServiceBinding secret %q value is not valid JSON: %v", providerv1alpha1.RawBindingKey, err)
+				return ctx
+			}
+			if len(rawCreds) == 0 {
+				t.Errorf("ServiceBinding secret %q blob has no fields", providerv1alpha1.RawBindingKey)
+			}
+			return ctx
+		},
+	).Assess(
 		"Properly delete all resources", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			// k8s resource cleaned up?
 			sb := &v1alpha1.ServiceBinding{}

--- a/test/e2e/servicebinding_secretformat_test.go
+++ b/test/e2e/servicebinding_secretformat_test.go
@@ -1,0 +1,147 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/crossplane-contrib/xp-testing/pkg/resources"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	res "sigs.k8s.io/e2e-framework/klient/k8s/resources"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+
+	"github.com/sap/crossplane-provider-btp/apis"
+	"github.com/sap/crossplane-provider-btp/apis/account/v1alpha1"
+)
+
+var (
+	sbSecretFormatName = "e2e-destination-binding-fmt"
+	sbSecretFormatKey  = "credentials"
+)
+
+// TestServiceBinding_SecretFormatSAPKubernetes verifies the sap-kubernetes
+// secret format: the connection secret carries SAP Kubernetes Service Binding
+// metadata fields (type, label, plan, instance_name, instance_guid, tags) plus
+// a .metadata descriptor, and credentials are bundled under the configured
+// secretKey instead of flattened.
+func TestServiceBinding_SecretFormatSAPKubernetes(t *testing.T) {
+	feature := features.New("ServiceBinding sap-kubernetes secret format").
+		Setup(
+			func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+				resources.ImportResources(ctx, t, cfg, "testdata/crs/servicebinding/secretformat-env")
+				resources.ImportResources(ctx, t, cfg, "testdata/crs/servicebinding/secretformat")
+				r, _ := res.New(cfg.Client().RESTConfig())
+				_ = apis.AddToScheme(r.GetScheme())
+
+				sb := v1alpha1.ServiceBinding{
+					ObjectMeta: metav1.ObjectMeta{Name: sbSecretFormatName, Namespace: cfg.Namespace()},
+				}
+				waitForResource(&sb, cfg, t, wait.WithTimeout(7*time.Minute))
+				return ctx
+			},
+		).Assess(
+		"ServiceBinding spec carries secretFormat and secretKey", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			sb := &v1alpha1.ServiceBinding{}
+			MustGetResource(t, cfg, sbSecretFormatName, nil, sb)
+			if sb.Spec.SecretFormat != "sap-kubernetes" {
+				t.Errorf("expected secretFormat=sap-kubernetes, got %q", sb.Spec.SecretFormat)
+			}
+			if sb.Spec.SecretKey == nil || *sb.Spec.SecretKey != sbSecretFormatKey {
+				t.Errorf("expected secretKey=%q, got %v", sbSecretFormatKey, sb.Spec.SecretKey)
+			}
+			if sb.Status.AtProvider.ID == "" {
+				t.Error("ServiceBinding not fully initialized")
+			}
+			return ctx
+		},
+	).Assess(
+		"Secret carries sap-kubernetes metadata fields, .metadata descriptor and bundled credentials", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			sb := &v1alpha1.ServiceBinding{}
+			MustGetResource(t, cfg, sbSecretFormatName, nil, sb)
+			secretRef := sb.GetWriteConnectionSecretToReference()
+			secret := &corev1.Secret{}
+			MustGetResource(t, cfg, secretRef.Name, &secretRef.Namespace, secret)
+
+			// Required SAP Kubernetes Service Binding metadata keys.
+			for _, key := range []string{"type", "label", "plan", "instance_name", "instance_guid", "tags"} {
+				if _, ok := secret.Data[key]; !ok {
+					t.Errorf("Secret missing sap-kubernetes metadata key %q", key)
+				}
+			}
+
+			// Bundled credentials under the configured secretKey.
+			bundled, ok := secret.Data[sbSecretFormatKey]
+			if !ok || len(bundled) == 0 {
+				t.Errorf("Secret missing bundled credentials under key %q", sbSecretFormatKey)
+				return ctx
+			}
+			var bundleObj map[string]any
+			if err := json.Unmarshal(bundled, &bundleObj); err != nil {
+				t.Errorf("bundled credentials under %q are not valid JSON: %v", sbSecretFormatKey, err)
+				return ctx
+			}
+			if len(bundleObj) == 0 {
+				t.Errorf("bundled credentials under %q are an empty object", sbSecretFormatKey)
+			}
+
+			// .metadata descriptor JSON.
+			meta, ok := secret.Data[".metadata"]
+			if !ok || len(meta) == 0 {
+				t.Errorf("Secret missing .metadata descriptor")
+				return ctx
+			}
+			var metaObj struct {
+				MetaDataProperties []struct {
+					Name      string `json:"name"`
+					Format    string `json:"format"`
+					Container bool   `json:"container,omitempty"`
+				} `json:"metaDataProperties"`
+				CredentialProperties []struct {
+					Name      string `json:"name"`
+					Format    string `json:"format"`
+					Container bool   `json:"container,omitempty"`
+				} `json:"credentialProperties"`
+			}
+			if err := json.Unmarshal(meta, &metaObj); err != nil {
+				t.Errorf(".metadata is not valid JSON: %v", err)
+				return ctx
+			}
+			if len(metaObj.MetaDataProperties) == 0 {
+				t.Error(".metadata.metaDataProperties is empty")
+			}
+			// credentialProperties must mark the bundle key with container: true.
+			var foundContainer bool
+			for _, p := range metaObj.CredentialProperties {
+				if p.Name == sbSecretFormatKey && p.Container {
+					foundContainer = true
+					break
+				}
+			}
+			if !foundContainer {
+				t.Errorf(".metadata.credentialProperties does not mark %q as container:true", sbSecretFormatKey)
+			}
+			return ctx
+		},
+	).Assess(
+		"Properly delete all resources", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			sb := &v1alpha1.ServiceBinding{}
+			MustGetResource(t, cfg, sbSecretFormatName, nil, sb)
+			AwaitResourceDeletionOrFail(ctx, t, cfg, sb, wait.WithTimeout(time.Minute*5))
+			return ctx
+		},
+	).Teardown(
+		func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			DeleteResourcesIgnoreMissing(ctx, t, cfg, "servicebinding/secretformat-env", wait.WithTimeout(time.Minute*15))
+			return ctx
+		},
+	).Feature()
+
+	testenv.Test(t, feature)
+}

--- a/test/e2e/servicemanager_test.go
+++ b/test/e2e/servicemanager_test.go
@@ -4,6 +4,7 @@ package e2e
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -19,6 +20,7 @@ import (
 	"github.com/sap/crossplane-provider-btp/apis"
 	"github.com/sap/crossplane-provider-btp/apis/account/v1alpha1"
 	"github.com/sap/crossplane-provider-btp/apis/account/v1beta1"
+	providerv1alpha1 "github.com/sap/crossplane-provider-btp/apis/v1alpha1"
 )
 
 var (
@@ -209,6 +211,22 @@ func assertServiceManagerSecret(t *testing.T, ctx context.Context, cfg *envconf.
 	// secret contains correct structure
 	if _, ok := secret.Data["tokenurl"]; !ok {
 		t.Error("Secret not in proper format")
+	}
+	// raw credentials blob preserved under __raw
+	rawBlob, ok := secret.Data[providerv1alpha1.RawBindingKey]
+	if !ok || len(rawBlob) == 0 {
+		t.Errorf("Secret missing %q key with raw credentials blob", providerv1alpha1.RawBindingKey)
+		return
+	}
+	var rawCreds map[string]any
+	if err := json.Unmarshal(rawBlob, &rawCreds); err != nil {
+		t.Errorf("Secret %q value is not valid JSON: %v", providerv1alpha1.RawBindingKey, err)
+		return
+	}
+	for _, key := range []string{"clientid", "clientsecret", "sm_url", "url", "xsappname"} {
+		if _, ok := rawCreds[key]; !ok {
+			t.Errorf("Secret %q blob missing field %q", providerv1alpha1.RawBindingKey, key)
+		}
 	}
 }
 

--- a/test/e2e/testdata/crs/servicebinding/secretformat-env/serviceinstance.yaml
+++ b/test/e2e/testdata/crs/servicebinding/secretformat-env/serviceinstance.yaml
@@ -1,0 +1,16 @@
+apiVersion: account.btp.sap.crossplane.io/v1alpha1
+kind: ServiceInstance
+metadata:
+  name: e2e-destination-instance-fmt
+  namespace: default
+spec:
+  forProvider:
+    name: e2e-destination-instance-fmt
+    parameters:
+      HTML5Runtime_enabled: false
+    serviceManagerRef:
+      name: e2e-sm-servicebinding-fmt
+    offeringName: destination
+    planName: lite
+    subaccountRef:
+      name: e2e-test-servicebinding-fmt

--- a/test/e2e/testdata/crs/servicebinding/secretformat-env/servicemanager.yaml
+++ b/test/e2e/testdata/crs/servicebinding/secretformat-env/servicemanager.yaml
@@ -1,0 +1,12 @@
+apiVersion: account.btp.sap.crossplane.io/v1alpha1
+kind: ServiceManager
+metadata:
+  name: e2e-sm-servicebinding-fmt
+  namespace: default
+spec:
+  writeConnectionSecretToRef:
+    name: e2e-sm-servicebinding-fmt
+    namespace: default
+  forProvider:
+    subaccountRef:
+      name: e2e-test-servicebinding-fmt

--- a/test/e2e/testdata/crs/servicebinding/secretformat-env/subaccount.yaml
+++ b/test/e2e/testdata/crs/servicebinding/secretformat-env/subaccount.yaml
@@ -1,0 +1,15 @@
+apiVersion: account.btp.sap.crossplane.io/v1alpha1
+kind: Subaccount
+metadata:
+  namespace: default
+  name: e2e-test-servicebinding-fmt
+spec:
+  forProvider:
+    displayName: $BUILD_ID-e2e-test-servicebinding-fmt
+    region: eu10
+    subdomain: $BUILD_ID-e2e-test-sb-fmt-co-12111
+    labels:
+      safe-to-delete: [ "yes" ]
+      BUILD_ID: [ "$BUILD_ID" ]
+    subaccountAdmins:
+       - $TECHNICAL_USER_EMAIL

--- a/test/e2e/testdata/crs/servicebinding/secretformat/servicebinding.yaml
+++ b/test/e2e/testdata/crs/servicebinding/secretformat/servicebinding.yaml
@@ -1,0 +1,17 @@
+apiVersion: account.btp.sap.crossplane.io/v1alpha1
+kind: ServiceBinding
+metadata:
+  name: e2e-destination-binding-fmt
+  namespace: default
+spec:
+  forProvider:
+    name: e2e-destination-binding-fmt
+    serviceInstanceRef:
+      name: e2e-destination-instance-fmt
+    subaccountRef:
+      name: e2e-test-servicebinding-fmt
+  secretFormat: sap-kubernetes
+  secretKey: credentials
+  writeConnectionSecretToRef:
+    name: e2e-destination-binding-fmt
+    namespace: default


### PR DESCRIPTION
This PR adds `__raw` to ServiceBinding (and ServiceManager) secrets. That lets consumers pass the binding data raw into other systems that expect to read it directly. CAP is one such consumer.

## What

Three near-duplicate flatten dialects mapped terraform `attribute.credentials` into Crossplane connection details. Two were identical copies of `flattenSecretData`. The CIS path preserved the original blob under `__raw`. ServiceBinding and ServiceManager threw it away.

This PR consolidates the JSON-aware path into one helper, `internal.FlattenConnectionDetails`. It writes `__raw` everywhere, so ServiceBinding and ServiceManager secrets now carry the original credentials blob too. Same convention CIS already uses.

Also drops the duplicate `ResourceRaw = "__raw"` constant in `apis/environment/v1alpha1/cfenvironment_types.go` and routes its only producer through `providerv1alpha1.RawBindingKey`.

## Why

Downstream consumers that need the full `attribute.credentials` JSON to call back into BTP APIs - CF env, Kyma env, Subscription, KymaEnvironmentBinding - already get it from CIS. External consumers like CAP expect the same: paste the secret into their config, done. Today that only works for CIS bindings. After this PR, the same pattern works for plain ServiceBinding and ServiceManager too.

The consolidation is a side benefit. Less drift, one place to fix bugs.

## Behaviour change

ServiceBinding and ServiceManager secrets now contain an extra `__raw` key with the original credentials JSON. Existing consumers that read individual keys are unaffected. Additive only.

## What's in the diff

Refactor + raw key:
- `internal/utils.go` - new `FlattenConnectionDetails` next to `Flatten`.
- `internal/clients/tfclient/tfcontroller.go` - drops local helper, calls shared one.
- `internal/controller/account/servicebinding/secretformat.go` - same (called via `processConnectionDetails`).
- `internal/clients/servicemanager/service_manager_tf_client.go` - appends `RawBindingKey: bindingAsBytes` to the typed map.
- `internal/clients/cfenvironment/client.go` (+ test) - switches to `providerv1alpha1.RawBindingKey`.
- `apis/environment/v1alpha1/cfenvironment_types.go` - drops duplicate `ResourceRaw` constant.

E2E coverage:
- ServiceManager secret check now asserts `__raw` is valid JSON with the expected fields.
- `TestServiceBinding_CreationFlow` adds an assertion for `__raw` shape.
- New `TestServiceBinding_SecretFormatSAPKubernetes` provisions a binding with `secretFormat: sap-kubernetes` and `secretKey: credentials`, verifies the SAP Kubernetes Service Binding metadata keys, the `.metadata` descriptor, and that the bundle key is marked `container: true`. Uses a dedicated `secretformat-env` to stay decoupled from the no-rotation teardown, mirroring `rotation-env`.

## Test plan

- [x] `go vet ./...` clean.
- [x] `go test ./internal/... ./apis/...` all pass.
- [x] `go vet -tags=e2e ./test/e2e/...` clean.
- [x] `grep -rn "flattenSecretData\|ResourceRaw" --include="*.go"` returns zero hits.
- [ ] CI green.
- [ ] E2E green (long-running, includes new sap-kubernetes flow).

WDYT? Happy to split the e2e additions into a follow-up if reviewers prefer keeping the refactor PR small.
