### PR TITLE
fix(ci): align long e2e job timeout with Go test timeout

### DIFF
--- a/.github/workflows/cron_long_e2e_test.yaml
+++ b/.github/workflows/cron_long_e2e_test.yaml
@@ -59,7 +59,9 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y gettext
 
       - name: Run long e2e test
-        timeout-minutes: 180
+        # Must be > Go -timeout in `make test-e2e-long` (currently 240m) to allow t.Cleanup to run.
+        # See docs/development/flakiness-pr-plans.md PR-3.
+        timeout-minutes: 260
         run: |
           if [ -n "${{ github.event.inputs.testFilter }}" ]; then
             make test-e2e-long testFilter=${{ github.event.inputs.testFilter }};


### PR DESCRIPTION
## Summary

PR-3 of the flakiness remediation plan ([docs/development/flakiness-pr-plans.md](docs/development/flakiness-pr-plans.md)). Bumps the `Run long e2e test` step's `timeout-minutes` in `cron_long_e2e_test.yaml` from `180` to `260`, so the GitHub runner does not kill the Go test process 60 minutes before Go's own `-timeout 240m` fires.

## Why

The cron Long E2E job had `timeout-minutes: 180` at the step level, but `make test-e2e-long` invokes `go test ... -timeout 240m`. When tests ran long, the runner SIGKILLed the Go process at 180 min — before Go's own deadline — so `t.Cleanup` never ran. That left BTP resources orphaned in the test global account, which is the root cause of the 17 consecutive scheduled-on-main failures described in [docs/development/flakiness-analysis.md](docs/development/flakiness-analysis.md).

Bumping the step timeout to **260** gives Go its full 240-min budget plus a **20-min buffer for `t.Cleanup`** to finish freeing resources before the runner kills the job.

## Changes

- `.github/workflows/cron_long_e2e_test.yaml`: step `timeout-minutes: 180` -> `260`, plus a comment documenting the invariant (must exceed Go `-timeout` in `make test-e2e-long`).
- `Makefile`: **unchanged.** Go `-timeout 240m` stays — we want Go to fail tests cleanly first.

## Coordination with `fix/e2e-long`

Branch [`fix/e2e-long`](https://github.com/SAP/crossplane-provider-btp/tree/fix/e2e-long) is open and overlaps with this change:

- It bumps the same step timeout to `240` (this PR sets `260`, leaving 20 min cleanup headroom over Go's 240m). With `240`, Go and the runner deadlines coincide and `t.Cleanup` still has no time.
- It also bundles unrelated changes (removes `environment: pr-e2e-no-approval`, drops the `local-deploy-prebuilt` target, reverts `ACCEPTANCE_DEPLOY`).

This PR is the minimal, scoped fix for the cleanup-leak bug. If `fix/e2e-long` is preferred for its other content, please update its timeout to `260` (or rebase this PR on top of it). Otherwise this PR can supersede the timeout change in `fix/e2e-long`.

## Test plan

- [x] Workflow YAML is syntactically valid (`yaml.safe_load` via Ruby — pyyaml unavailable locally).
- [x] `go vet ./...` passes.
- [x] Makefile `test-e2e-long` target unchanged; Go `-timeout 240m` still in place.
- [ ] Validate at next scheduled cron run after merge, or trigger manually via `workflow_dispatch` to confirm a long run completes its cleanup before the step timeout fires.