### PR TITLE
fix(test/e2e): bump import wait timeouts to 10 minutes

### DIFF
--- a/test/e2e/import_utils_test.go
+++ b/test/e2e/import_utils_test.go
@@ -90,8 +90,8 @@ func NewImportTester[T resource.Managed](baseResource T, baseName string, o ...I
 		BaseResource:                 baseResource,
 		BaseName:                     baseName,
 		WaitDependentResourceTimeout: wait.WithTimeout(5 * time.Minute),
-		WaitCreateTimeout:            wait.WithTimeout(3 * time.Minute),
-		WaitDeletionTimeout:          wait.WithTimeout(3 * time.Minute),
+		WaitCreateTimeout:            wait.WithTimeout(10 * time.Minute),
+		WaitDeletionTimeout:          wait.WithTimeout(10 * time.Minute),
 	}
 	it.BaseResource.SetName(it.GetPrefixedName())
 


### PR DESCRIPTION
## Summary

PR-2 of the flakiness remediation plan (`docs/development/flakiness-pr-plans.md`).

The original bug was `wait.WithInterval(3 * time.Minute)` being passed where `wait.WithTimeout` was expected — `WithInterval` sets the poll cadence, not the deadline, so the framework's default ~3 min timeout still fired and readiness was only detected every 3 min. That API-level fix already landed on `main` (`wait.WithTimeout(3 * time.Minute)`), but 3 min is still too tight for BTP-backed Available conditions, which is what the original `WithInterval` value happened to mask.

This PR bumps both `WaitCreateTimeout` and `WaitDeletionTimeout` defaults in `NewImportTester` from 3 min to 10 min, matching the plan's prescribed value. `WaitDependentResourceTimeout` (5 min, separately configurable) is left as-is.

Audit of other call sites (`rg 'wait\.WithInterval' .`) confirmed no remaining `WithInterval`-as-timeout misuses.

## Test plan

- [x] `gofmt -l test/e2e/import_utils_test.go` — clean
- [x] `go build -tags=e2e ./test/e2e/...` — passes
- [x] `go vet -tags=e2e ./test/e2e/...` — passes
- [ ] CI e2e import flow green on this branch — requires live BTP; verified by CI on PR
- [ ] Confirm test logs show poll cadence at framework default (~5–10 s), not 3 min, and overall wait bounded by 10 min

## Risk

None — the existing 3 min timeout is the framework default and was demonstrably too tight; raising it strictly increases tolerance for slow BTP responses without changing test correctness.