### PR TITLE
fix(subaccount): surface BTP error bodies; treat 409 on delete as soft

### DIFF
--- a/internal/controller/account/subaccount/subaccount.go
+++ b/internal/controller/account/subaccount/subaccount.go
@@ -3,6 +3,7 @@ package subaccount
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -334,16 +335,49 @@ func deleteBTPSubaccount(
 
 	_, raw, err := accountsServiceClient.AccountsServiceClient.SubaccountOperationsAPI.DeleteSubaccount(ctx, subaccountId).Execute()
 	// 404 not found means already deleted - not considered as error case
-	if raw.StatusCode == 404 {
+	if raw != nil && raw.StatusCode == 404 {
 		ctrl.Log.Info("associated BTP subaccount not found, continue deletion")
 		return nil
 	}
 
+	if raw != nil && raw.StatusCode == 409 {
+		// 409 Conflict: delete already in progress, or blocked by child resources
+		// (entitlements, subscriptions, environments, trust configs). Return nil so
+		// the controller polls Observe on the next reconcile instead of retrying
+		// DELETE — repeated DELETEs amplify the conflict and pollute the error log.
+		// The BTP-side state will eventually become DELETING, at which point the
+		// guard in Delete() short-circuits, and Observe will detect the final
+		// 404 (deleted).
+		ctrl.Log.Info("subaccount delete returned 409 Conflict (in-progress or blocked by children), waiting for next reconcile",
+			"subaccountId", subaccountId, "body", string(readBodySafe(err, raw)))
+		return nil
+	}
+
 	if err != nil {
-		return errors.Wrap(err, "deletion of subaccount failed")
+		return errors.Wrap(specifyAPIError(err), "deletion of subaccount failed")
 	}
 
 	return nil
+}
+
+// readBodySafe extracts the response body for diagnostic logging. It prefers the
+// already-read body on a *accountclient.GenericOpenAPIError (the OpenAPI client
+// drains raw.Body into err.Body() before returning). As a fallback, it reads at
+// most 1 KiB from raw.Body so a buggy server response can't blow the log.
+func readBodySafe(err error, raw *http.Response) []byte {
+	if genericErr, ok := err.(*accountclient.GenericOpenAPIError); ok {
+		if body := genericErr.Body(); len(body) > 0 {
+			return body
+		}
+	}
+	if raw == nil || raw.Body == nil {
+		return nil
+	}
+	body, readErr := io.ReadAll(io.LimitReader(raw.Body, 1024))
+	if readErr != nil {
+		return nil
+	}
+	return body
 }
 
 func (c *external) updateBTPSubaccount(
@@ -367,7 +401,7 @@ func (c *external) moveSubaccountAPI(ctx context.Context, subaccount *apisv1alph
 
 	err := c.accountsAccessor.MoveSubaccount(ctx, guid, targetID)
 	if err != nil {
-		return errors.Wrap(err, errMoveSubaccount)
+		return errors.Wrap(specifyAPIError(err), errMoveSubaccount)
 	}
 	return nil
 }
@@ -387,7 +421,7 @@ func (c *external) updateSubaccountAPI(ctx context.Context, subaccount *apisv1al
 
 	err := c.accountsAccessor.UpdateSubaccount(ctx, guid, params)
 	if err != nil {
-		return errors.Wrap(err, errUpdateAPI)
+		return errors.Wrap(specifyAPIError(err), errUpdateAPI)
 	}
 	return nil
 }
@@ -437,7 +471,7 @@ func (c *external) migrateExternalName(ctx context.Context, subaccount *apisv1al
 
 	response, _, err := c.btp.AccountsServiceClient.SubaccountOperationsAPI.GetSubaccounts(ctx).Execute()
 	if err != nil {
-		return errors.Wrap(err, errGetSubaccounts)
+		return errors.Wrap(specifyAPIError(err), errGetSubaccounts)
 	}
 
 	btpSubaccounts := response.Value

--- a/internal/controller/account/subaccount/subaccount_test.go
+++ b/internal/controller/account/subaccount/subaccount_test.go
@@ -2,8 +2,10 @@ package subaccount
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 	"unsafe"
 
@@ -1630,6 +1632,51 @@ func TestDelete(t *testing.T) {
 				err: nil, // 404 should not be treated as error
 			},
 		},
+		"DeleteAPI409SoftHandled": {
+			reason: "409 Conflict on delete (in-progress or blocked by children) is soft-handled: log and return nil so the controller polls Observe on the next reconcile",
+			args: args{
+				cr: NewSubaccount("unittest-sa",
+					WithExternalName(SAMPLE_GUID),
+					WithStatus(v1alpha1.SubaccountObservation{
+						SubaccountGuid: internal.Ptr(SAMPLE_GUID),
+						Status:         internal.Ptr(subaccountStateOk),
+					})),
+				mockClient: &MockSubaccountClient{
+					returnSubaccount: &accountclient.SubaccountResponseObject{Guid: SAMPLE_GUID},
+					mockDeleteSubaccountExecute: func(r accountclient.ApiDeleteSubaccountRequest) (*accountclient.SubaccountResponseObject, *http.Response, error) {
+						return &accountclient.SubaccountResponseObject{}, &http.Response{
+							StatusCode: 409,
+							Body:       io.NopCloser(strings.NewReader(`{"error":{"code":409,"message":"subaccount has child resources"}}`)),
+						}, create409Error()
+					},
+				},
+				tracker: trackingtest.NoOpReferenceResolverTracker{},
+			},
+			want: want{
+				err: nil,
+			},
+		},
+		"DeleteAPI5xxWrappedWithSpecifyAPIError": {
+			reason: "5xx errors must produce a wrapped error containing 'API Error:' prefix from specifyAPIError when the error is a GenericOpenAPIError",
+			args: args{
+				cr: NewSubaccount("unittest-sa",
+					WithExternalName(SAMPLE_GUID),
+					WithStatus(v1alpha1.SubaccountObservation{
+						SubaccountGuid: internal.Ptr(SAMPLE_GUID),
+						Status:         internal.Ptr(subaccountStateOk),
+					})),
+				mockClient: &MockSubaccountClient{
+					returnSubaccount: &accountclient.SubaccountResponseObject{Guid: SAMPLE_GUID},
+					mockDeleteSubaccountExecute: func(r accountclient.ApiDeleteSubaccountRequest) (*accountclient.SubaccountResponseObject, *http.Response, error) {
+						return &accountclient.SubaccountResponseObject{}, &http.Response{StatusCode: 500}, create500Error()
+					},
+				},
+				tracker: trackingtest.NoOpReferenceResolverTracker{},
+			},
+			want: want{
+				err: errors.New("API Error"),
+			},
+		},
 	}
 
 	for name, tc := range tests {
@@ -1982,6 +2029,36 @@ func create409Error() error {
 	if errorField.IsValid() {
 		reflect.NewAt(errorField.Type(), unsafe.Pointer(errorField.UnsafeAddr())).
 			Elem().SetString("409 Conflict")
+	}
+
+	return err
+}
+
+// create500Error creates a GenericOpenAPIError with a 500 status code
+// that wraps an ApiExceptionResponseObject with code 500. This mimics
+// the actual API behavior for "internal server error" responses, used
+// to assert that specifyAPIError surfaces the API body in the wrapped
+// error message.
+func create500Error() error {
+	apiExceptionError := accountclient.NewApiExceptionResponseObjectError()
+	apiExceptionError.SetCode(500)
+	apiExceptionError.SetMessage("internal server error")
+
+	apiException := accountclient.NewApiExceptionResponseObject(*apiExceptionError)
+
+	err := &accountclient.GenericOpenAPIError{}
+	errValue := reflect.ValueOf(err).Elem()
+
+	modelField := errValue.FieldByName("model")
+	if modelField.IsValid() {
+		reflect.NewAt(modelField.Type(), unsafe.Pointer(modelField.UnsafeAddr())).
+			Elem().Set(reflect.ValueOf(*apiException))
+	}
+
+	errorField := errValue.FieldByName("error")
+	if errorField.IsValid() {
+		reflect.NewAt(errorField.Type(), unsafe.Pointer(errorField.UnsafeAddr())).
+			Elem().SetString("500 Internal Server Error")
 	}
 
 	return err


### PR DESCRIPTION
## Summary

- `Delete` on `Subaccount` previously wrapped a bare 409 from the BTP API without surfacing the response body, so logs could not distinguish *"delete already in progress"* from *"blocked by child resources"*. All BTP API error sites in this controller (`deleteBTPSubaccount`, `moveSubaccountAPI`, `updateSubaccountAPI`, `migrateExternalName`/`listSubaccounts`) now route through the existing `specifyAPIError` helper, which extracts the structured `ApiExceptionResponseObject` or raw body from `*accountclient.GenericOpenAPIError`.
- HTTP 409 on `DeleteSubaccount` is now soft-handled: the controller logs the body (capped at 1 KiB via a new `readBodySafe` helper) and returns `nil` so the next reconcile re-runs `Observe`. Repeated `DELETE`s amplify the conflict and pollute the error log; the BTP-side status will eventually flip to `DELETING` (the guard in `Delete` already short-circuits that) and `Observe` will eventually detect the final 404.
- Defensive nil-check added to the existing 404 guard (`raw != nil && raw.StatusCode == 404`) so a transport-level error that returns `(nil, nil, err)` no longer panics.

Addresses Pattern E in `docs/development/flakiness-analysis.md` (`TestCloudFoundryEnvironment` 409 on subaccount delete).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race -count=1 ./internal/controller/account/subaccount/...` — all existing tests pass; new `DeleteAPI409SoftHandled` and `DeleteAPI5xxWrappedWithSpecifyAPIError` cases pass.
- [x] `go test -race -count=1 ./...` — full suite green.
- [x] `gofmt -l` clean on both modified files.
- [ ] CI must exercise the real-BTP path; the actual 409-on-delete scenario can only be reproduced against a live global account.