### PR TITLE
fix(ci): cache Crossplane CDN deps and add retry/timeouts

### DIFF
--- a/.github/workflows/cron_long_e2e_test.yaml
+++ b/.github/workflows/cron_long_e2e_test.yaml
@@ -43,13 +43,26 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y helm
 
+      - name: Cache BTP CLI binary
+        id: cache-btp-cli
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: /tmp/btp-cli/btp
+          key: btp-cli-${{ env.btp_cli_version }}-${{ runner.os }}
+
       - name: Install BTP CLI
       #hardcoded version
         run: |
-          curl -LJO https://tools.hana.ondemand.com/additional/btp-cli-linux-amd64-$btp_cli_version.tar.gz --cookie "eula_3_2_agreed=tools.hana.ondemand.com/developer-license-3_2.txt"
-          tar -xzf btp-cli-linux-amd64-$btp_cli_version.tar.gz
-          cd linux-amd64
-          mv btp /usr/local/bin
+          if [ ! -f /tmp/btp-cli/btp ]; then
+            mkdir -p /tmp/btp-cli
+            curl -LJO --retry 5 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 300 \
+              https://tools.hana.ondemand.com/additional/btp-cli-linux-amd64-$btp_cli_version.tar.gz \
+              --cookie "eula_3_2_agreed=tools.hana.ondemand.com/developer-license-3_2.txt"
+            tar -xzf btp-cli-linux-amd64-$btp_cli_version.tar.gz
+            mv linux-amd64/btp /tmp/btp-cli/btp
+          fi
+          sudo cp /tmp/btp-cli/btp /usr/local/bin/btp
+          sudo chmod +x /usr/local/bin/btp
 
       - name: Set BUILD_ID
         run: |

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -70,13 +70,26 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y helm
 
+      - name: Cache BTP CLI binary
+        id: cache-btp-cli
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: /tmp/btp-cli/btp
+          key: btp-cli-${{ env.btp_cli_version }}-${{ runner.os }}
+
       - name: Install BTP CLI
         #hardcoded version
         run: |
-          curl -LJO https://tools.hana.ondemand.com/additional/btp-cli-linux-amd64-$btp_cli_version.tar.gz --cookie "eula_3_2_agreed=tools.hana.ondemand.com/developer-license-3_2.txt"
-          tar -xzf btp-cli-linux-amd64-$btp_cli_version.tar.gz
-          cd linux-amd64
-          mv btp /usr/local/bin
+          if [ ! -f /tmp/btp-cli/btp ]; then
+            mkdir -p /tmp/btp-cli
+            curl -LJO --retry 5 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 300 \
+              https://tools.hana.ondemand.com/additional/btp-cli-linux-amd64-$btp_cli_version.tar.gz \
+              --cookie "eula_3_2_agreed=tools.hana.ondemand.com/developer-license-3_2.txt"
+            tar -xzf btp-cli-linux-amd64-$btp_cli_version.tar.gz
+            mv linux-amd64/btp /tmp/btp-cli/btp
+          fi
+          sudo cp /tmp/btp-cli/btp /usr/local/bin/btp
+          sudo chmod +x /usr/local/bin/btp
 
       - name: Set BUILD_ID
         run: |


### PR DESCRIPTION
## Summary

Reduces flakiness from upstream BTP CLI download (`tools.hana.ondemand.com`) in the cron and upgrade workflows.

- Adds `actions/cache@v4.3.0` (SHA-pinned) for the BTP CLI binary keyed on `btp-cli-<version>-<runner.os>` so subsequent runs skip the upstream download entirely.
- Adds curl retry/timeout flags (`--retry 5 --retry-delay 5 --retry-all-errors --connect-timeout 30 --max-time 300`) so a single transient 4xx/5xx no longer collapses the job.

## Scope reduction

This PR was originally opened with parallel changes in `e2e_test.yaml`. After it was opened, **#707 (`ci/e2e-flake-hardening`)** merged to `main` and shipped equivalent (and more comprehensive) hardening for `e2e_test.yaml` — `crank` curl retry, `.cache/tools` cache, Docker Hub mirror routing, action version bumps. To avoid duplication and drift, the `e2e_test.yaml` changes were dropped from this PR.

The remaining scope covers **only** `cron_long_e2e_test.yaml` and `upgrade-test.yaml`, which #707 did not touch and which still hit `tools.hana.ondemand.com` directly on every run with no caching or retry. `pr-e2e.yaml` was never modified (pure dispatcher into `e2e_test.yaml`).

This is **PR-1** of the flakiness remediation plan; see `docs/development/flakiness-pr-plans.md` and root cause in `docs/development/flakiness-analysis.md` (Pattern A: BTP CLI 403 from `tools.hana.ondemand.com`).

Note: `helm repo add charts.crossplane.io/stable` lives in `cluster/local/integration_tests.sh` and the `build/` submodule, both out of scope for this PR — tracked as a follow-up.

## Validation

- `actionlint` finds zero new issues vs. base ref (9 pre-existing info-level shellcheck/property findings before and after across the two files).
- `go vet ./...` passes.
- Both touched workflow YAMLs parse cleanly.
- Cache hit/miss behavior is a GitHub Actions runtime feature; the real validation is observing this PR's own CI runs (first run: cache miss → download with retry; subsequent runs: cache hit → skip download).

## Test plan

- [ ] First run on this PR populates the cache (cache miss; logs show download with retry flags).
- [ ] Re-run a cron / upgrade workflow; logs show "Cache restored" for `btp-cli-2.90.2-Linux` and the `Install BTP CLI` step skips the curl path.
- [ ] BTP CLI is on `PATH` and functional in the cron and upgrade jobs.
- [ ] No regression in the cron / upgrade workflow completion rate.
