### PR TITLE
feat(test/e2e): install Crossplane from cached chart tarball

### DIFF
--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -76,11 +76,10 @@ jobs:
         run: |
           echo "Test names: ${{ steps.set-matrix.outputs.test-names }}"
 
-  # Build image + xpkg + CLI tools once; the matrix consumes them as artifacts.
-  # NOTE: after the artifact retention window expires (retention-days below),
-  # "Re-run failed jobs" fails — build won't re-run, so its artifacts are gone.
-  # Use "Re-run all jobs" to rebuild them.
-  build:
+  # Pull and verify the Crossplane chart in a dedicated job so that an upstream
+  # CDN blip (charts.crossplane.io 403) does not waste the provider build setup
+  # and runs in parallel with `build` for faster wall-clock.
+  fetch-chart:
     runs-on: ubuntu-latest
     needs: prepare-matrix
     steps:
@@ -88,12 +87,6 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ inputs.checkout-ref }}
-          submodules: true
-
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version: ${{ env.GO_VERSION }}
 
       - name: Install Helm
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
@@ -164,6 +157,25 @@ jobs:
           retention-days: 7
           overwrite: true
           if-no-files-found: error
+
+  # Build image + xpkg + CLI tools once; the matrix consumes them as artifacts.
+  # NOTE: after the artifact retention window expires (retention-days below),
+  # "Re-run failed jobs" fails — build won't re-run, so its artifacts are gone.
+  # Use "Re-run all jobs" to rebuild them.
+  build:
+    runs-on: ubuntu-latest
+    needs: prepare-matrix
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ inputs.checkout-ref }}
+          submodules: true
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Restore CLI tools cache (kind, kubectl, crank)
         id: cli-tools-cache
@@ -242,7 +254,7 @@ jobs:
 
   e2e-test:
     runs-on: ubuntu-latest
-    needs: [prepare-matrix, build] # build provides the prebuilt image/xpkg/tools artifacts
+    needs: [prepare-matrix, fetch-chart, build] # fetch-chart provides crossplane-chart artifact; build provides image/xpkg/tools artifacts
     environment: pr-e2e-no-approval  # approval is on the preceding prepare-matrix job
     strategy:
       fail-fast: false
@@ -408,6 +420,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - prepare-matrix
+      - fetch-chart
       - build
       - e2e-test
     timeout-minutes: 1
@@ -417,6 +430,11 @@ jobs:
         if: |
           needs.prepare-matrix.result == 'failure' ||
           needs.prepare-matrix.result == 'cancelled'
+        run: exit 1
+      - name: Fail for failed fetch-chart job
+        if: |
+          needs.fetch-chart.result == 'failure' ||
+          needs.fetch-chart.result == 'cancelled'
         run: exit 1
       - name: Fail for failed build job
         if: |

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -78,6 +78,60 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
+      - name: Install Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        with:
+          version: v3.14.0
+
+      - name: Set Crossplane chart version
+        run: echo "CROSSPLANE_CHART_VERSION=2.1.3" >> $GITHUB_ENV
+
+      - name: Restore Crossplane chart cache
+        id: crossplane-chart-cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: .cache/charts
+          key: crossplane-chart-${{ env.CROSSPLANE_CHART_VERSION }}-${{ runner.os }}
+
+      - name: Pull Crossplane chart (with retry)
+        if: steps.crossplane-chart-cache.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          mkdir -p .cache/charts
+          retry() {
+            local n=1 max=5
+            until "$@"; do
+              if [ "$n" -ge "$max" ]; then
+                echo "::error::'$*' failed after $max attempts"
+                return 1
+              fi
+              echo "attempt $n failed; backing off $((n * 15))s..."
+              sleep "$((n * 15))"
+              n=$((n + 1))
+            done
+          }
+          retry helm pull crossplane \
+            --repo https://charts.crossplane.io/stable \
+            --version "${CROSSPLANE_CHART_VERSION}" \
+            --destination .cache/charts
+          ls -la .cache/charts
+
+      - name: Save Crossplane chart cache
+        if: success() && steps.crossplane-chart-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: .cache/charts
+          key: ${{ steps.crossplane-chart-cache.outputs.cache-primary-key }}
+
+      - name: Upload Crossplane chart
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: crossplane-chart
+          path: .cache/charts
+          retention-days: 7
+          overwrite: true
+          if-no-files-found: error
+
       - name: Restore CLI tools cache (kind, kubectl, crank)
         id: cli-tools-cache
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
@@ -227,6 +281,19 @@ jobs:
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
           version: v3.14.0
+
+      - name: Download Crossplane chart
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: crossplane-chart
+          path: .cache/charts
+
+      - name: Resolve Crossplane chart path
+        run: |
+          set -euo pipefail
+          CHART="$(ls .cache/charts/crossplane-*.tgz | head -n 1)"
+          test -f "$CHART" || { echo "::error::no chart at .cache/charts/crossplane-*.tgz"; exit 1; }
+          echo "CROSSPLANE_CHART_PATH=$(realpath "$CHART")" >> $GITHUB_ENV
 
       - name: Install BTP CLI
         #hardcoded version

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -36,6 +36,10 @@ env:
   E2E_BUILD_REGISTRY: index.docker.io/e2e
   E2E_PROVIDER_IMAGE: index.docker.io/e2e/provider-btp-amd64
   CROSSPLANE_CLI_VERSION: v2.0.2
+  CROSSPLANE_CHART_VERSION: '2.1.3'
+  # SHA256 of crossplane-2.1.3.tgz from upstream charts.crossplane.io/stable
+  # index.yaml's `digest:` field. Update on every Crossplane version bump.
+  CROSSPLANE_CHART_SHA256: '1059cc4b87167ba7e1b837a8e6bd787691bc9f84c5a29a7e91dbd0122086c682'
 
 jobs:
   prepare-matrix:
@@ -83,9 +87,6 @@ jobs:
         with:
           version: v3.14.0
 
-      - name: Set Crossplane chart version
-        run: echo "CROSSPLANE_CHART_VERSION=2.1.3" >> $GITHUB_ENV
-
       - name: Restore Crossplane chart cache
         id: crossplane-chart-cache
         uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
@@ -115,6 +116,25 @@ jobs:
             --version "${CROSSPLANE_CHART_VERSION}" \
             --destination .cache/charts
           ls -la .cache/charts
+
+      # Defense-in-depth against artifact poisoning (CodeQL alert #64). The `build`
+      # job's `helm pull` step is workflow-mutable; a malicious PR could rewrite
+      # it to upload a poisoned chart for matrix legs to install. Pinning the
+      # expected SHA256 (sourced from upstream charts.crossplane.io/stable
+      # index.yaml's `digest:` field) means a poisoned tarball fails the build
+      # before reaching matrix legs. Update the constant on every Crossplane
+      # version bump.
+      - name: Verify Crossplane chart integrity
+        run: |
+          set -euo pipefail
+          cd .cache/charts
+          EXPECTED="${CROSSPLANE_CHART_SHA256}"
+          ACTUAL="$(sha256sum "crossplane-${CROSSPLANE_CHART_VERSION}.tgz" | awk '{print $1}')"
+          if [ "$ACTUAL" != "$EXPECTED" ]; then
+            echo "::error::Crossplane chart SHA256 mismatch: expected $EXPECTED, got $ACTUAL"
+            exit 1
+          fi
+          echo "Crossplane chart SHA256 verified: $ACTUAL"
 
       - name: Save Crossplane chart cache
         if: success() && steps.crossplane-chart-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -25,6 +25,18 @@ on:
         default: 'pr-e2e-approval'
         required: false
         type: string
+  workflow_dispatch:
+    inputs:
+      checkout-ref:
+        description: 'the ref for the repo checkout step (defaults to the dispatched ref when empty)'
+        default: ''
+        required: false
+        type: string
+      environment:
+        description: 'the environment to run in'
+        default: 'pr-e2e-approval'
+        required: false
+        type: string
 
 permissions:
   contents: read

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -36,6 +36,7 @@ env:
   E2E_BUILD_REGISTRY: index.docker.io/e2e
   E2E_PROVIDER_IMAGE: index.docker.io/e2e/provider-btp-amd64
   CROSSPLANE_CLI_VERSION: v2.0.2
+  # renovate: datasource=helm depName=crossplane registryUrl=https://charts.crossplane.io/stable
   CROSSPLANE_CHART_VERSION: '2.1.3'
   # SHA256 of crossplane-2.1.3.tgz from upstream charts.crossplane.io/stable
   # index.yaml's `digest:` field. Update on every Crossplane version bump.

--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,16 @@
       "datasourceTemplate": "terraform-provider",
       "versioningTemplate": "hashicorp",
       "depNameTemplate": "SAP/btp"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^\\.github/workflows/e2e_test\\.yaml$"],
+      "matchStrings": [
+        "# renovate: datasource=helm depName=crossplane registryUrl=https://charts\\.crossplane\\.io/stable\\s*\\n\\s*CROSSPLANE_CHART_VERSION:\\s*['\"]?(?<currentValue>[^'\"\\s]+)['\"]?(?:\\s*\\n[^\\n]*)*?\\s*\\n\\s*CROSSPLANE_CHART_SHA256:\\s*['\"]?(?<currentDigest>[a-f0-9]{64})['\"]?"
+      ],
+      "datasourceTemplate": "helm",
+      "depNameTemplate": "crossplane",
+      "registryUrlTemplate": "https://charts.crossplane.io/stable"
     }
   ]
 }

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -33,14 +33,22 @@ var (
 
 const (
 	// crossplaneChartPathEnv names the env var that points at a local
-	// Crossplane chart tarball (e.g. /path/to/crossplane-2.1.3.tgz). CI
-	// populates this from a workflow artifact built once per run; local
-	// developers can `helm pull crossplane --repo
-	// https://charts.crossplane.io/stable --version <ver> -d /tmp` and
-	// export the resulting path. This bypasses the
-	// `helm repo add https://charts.crossplane.io/stable` flow that has
-	// been throwing intermittent 403 Forbidden errors. See
-	// docs/development/flakiness-analysis.md (Pattern A).
+	// Crossplane chart tarball (e.g. /path/to/crossplane-2.1.3.tgz). When
+	// set, the test installs from the local file (avoiding the per-test
+	// `helm repo add charts.crossplane.io/stable` network call which has
+	// been throwing intermittent 403 Forbidden errors; see
+	// docs/development/flakiness-analysis.md, Pattern A). When unset, the
+	// test falls back to xp-testing's bundled helm-repo install
+	// (xpenvfuncs.InstallCrossplane).
+	//
+	// The fallback is required because this PR's workflow uses
+	// `pull_request_target`, which means GitHub runs the workflow file
+	// from the BASE branch (main), not from the PR head — so the
+	// chart-tarball export step doesn't run on this PR's own CI. Once the
+	// PR merges and main's `Resolve Crossplane chart path` step in
+	// `e2e_test.yaml` exports the env var, every matrix leg automatically
+	// switches to the chart-tarball path. The fallback also lets local
+	// developers run e2e tests without pre-staging the chart.
 	crossplaneChartPathEnv = "CROSSPLANE_CHART_PATH"
 	// crossplaneVersion is the Crossplane chart version. Must match the
 	// version that was pulled into the tarball at CROSSPLANE_CHART_PATH.
@@ -117,7 +125,8 @@ func SetupClusterWithCrossplane(namespace string) {
 	// Replicate the slice of setup.ClusterSetup.Configure that we need, swapping
 	// xp-testing's bundled InstallCrossplane (which goes through
 	// `helm repo add https://charts.crossplane.io/stable`) for an install from
-	// a chart reference passed via CROSSPLANE_CHART_PATH.
+	// a chart reference passed via CROSSPLANE_CHART_PATH when available, and
+	// falling back to the bundled helm-repo install when it's not.
 	//
 	// xp-testing v1.9.2's setup.ClusterSetup.Configure pinned to the helm-repo
 	// install path with no opt-out. PR crossplane-contrib/xp-testing#134 adds a
@@ -126,11 +135,24 @@ func SetupClusterWithCrossplane(namespace string) {
 	// Replicating inline keeps the dep tree intact.
 	clusterName := resolveClusterName()
 	reuseCluster := envvar.CheckEnvVarExists(reuseClusterEnv)
-	// Only required when we will actually install Crossplane (fresh cluster).
-	// On reuse runs the cluster already has Crossplane wired up.
-	var chartRef string
+	// Resolve the install func to use on a fresh cluster. On reuse runs the
+	// cluster already has Crossplane wired up, so we skip both paths via the
+	// xpenvfuncs.Conditional below.
+	var installCrossplaneFunc env.Func
 	if !reuseCluster {
-		chartRef = envvar.GetOrPanic(crossplaneChartPathEnv)
+		if chartRef := os.Getenv(crossplaneChartPathEnv); chartRef != "" {
+			installCrossplaneFunc = testutil.InstallCrossplaneFromChart(clusterName, chartRef, crossplaneVersion)
+		} else {
+			// Fallback: xp-testing's bundled helm-repo install. Used (a) on
+			// this PR's own CI before the chart-tarball workflow lands on
+			// main (pull_request_target runs base-branch workflows, so the
+			// PR's chart-export step doesn't run), and (b) for local dev
+			// when the chart isn't pre-staged.
+			installCrossplaneFunc = xpenvfuncs.InstallCrossplane(
+				clusterName,
+				xpenvfuncs.Version(crossplaneVersion),
+			)
+		}
 	}
 
 	testenv.Setup(
@@ -146,7 +168,7 @@ func SetupClusterWithCrossplane(namespace string) {
 		// reuseCluster on => skip and trust the previous run wired things up.
 		xpenvfuncs.Conditional(
 			xpenvfuncs.Compose(
-				testutil.InstallCrossplaneFromChart(clusterName, chartRef, crossplaneVersion),
+				installCrossplaneFunc,
 				xpenvfuncs.InstallCrossplaneProvider(
 					clusterName, xpenvfuncs.InstallCrossplaneProviderOptions{
 						Name:                    "btp-account",

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -8,9 +8,8 @@ import (
 	"testing"
 
 	"github.com/crossplane-contrib/xp-testing/pkg/envvar"
-	"github.com/crossplane-contrib/xp-testing/pkg/images"
-	"github.com/crossplane-contrib/xp-testing/pkg/setup"
 	"github.com/crossplane-contrib/xp-testing/pkg/vendored"
+	"github.com/crossplane-contrib/xp-testing/pkg/xpenvfuncs"
 	testutil "github.com/sap/crossplane-provider-btp/test"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -30,6 +29,33 @@ var (
 	SECONDARY_DIRC_ADMIN_ENV_KEY = "SECOND_DIRECTORY_ADMIN_EMAIL"
 
 	UUT_BUILD_ID_KEY = "BUILD_ID"
+)
+
+const (
+	// crossplaneChartPathEnv names the env var that points at a local
+	// Crossplane chart tarball (e.g. /path/to/crossplane-2.1.3.tgz). CI
+	// populates this from a workflow artifact built once per run; local
+	// developers can `helm pull crossplane --repo
+	// https://charts.crossplane.io/stable --version <ver> -d /tmp` and
+	// export the resulting path. This bypasses the
+	// `helm repo add https://charts.crossplane.io/stable` flow that has
+	// been throwing intermittent 403 Forbidden errors. See
+	// docs/development/flakiness-analysis.md (Pattern A).
+	crossplaneChartPathEnv = "CROSSPLANE_CHART_PATH"
+	// crossplaneVersion is the Crossplane chart version. Must match the
+	// version that was pulled into the tarball at CROSSPLANE_CHART_PATH.
+	crossplaneVersion = "2.1.3"
+
+	// reuseClusterEnv mirrors xp-testing's E2E_REUSE_CLUSTER semantics: when
+	// set, the cluster, Crossplane, and provider are reused across runs and
+	// the cluster is not destroyed at teardown.
+	reuseClusterEnv = "E2E_REUSE_CLUSTER"
+	// clusterNameEnv mirrors xp-testing's E2E_CLUSTER_NAME: when set, it
+	// overrides the generated cluster name.
+	clusterNameEnv = "E2E_CLUSTER_NAME"
+	// defaultClusterPrefix matches xp-testing's defaultPrefix used for the
+	// reused-cluster name.
+	defaultClusterPrefix = "e2e"
 )
 
 var (
@@ -88,21 +114,50 @@ func SetupClusterWithCrossplane(namespace string) {
 		},
 	}
 
-	cfg := setup.ClusterSetup{
-		ProviderName: "btp-account",
-		Images: images.ProviderImages{
-			Package:         uutConfig,
-			ControllerImage: &uutController,
-		},
-		CrossplaneSetup: setup.CrossplaneSetup{
-			Version: "2.1.3",
-		},
-		DeploymentRuntimeConfig: &deploymentRuntimeConfig,
+	// Replicate the slice of setup.ClusterSetup.Configure that we need, swapping
+	// xp-testing's bundled InstallCrossplane (which goes through
+	// `helm repo add https://charts.crossplane.io/stable`) for an install from
+	// a chart reference passed via CROSSPLANE_CHART_PATH.
+	//
+	// xp-testing v1.9.2's setup.ClusterSetup.Configure pinned to the helm-repo
+	// install path with no opt-out. PR crossplane-contrib/xp-testing#134 adds a
+	// ChartRef field, but it sits on xp-testing main which has bumped k8s deps
+	// to v0.36 incompatibly with this repo's crossplane-runtime/v2 v2.2.0-rc.0.
+	// Replicating inline keeps the dep tree intact.
+	clusterName := resolveClusterName()
+	reuseCluster := envvar.CheckEnvVarExists(reuseClusterEnv)
+	// Only required when we will actually install Crossplane (fresh cluster).
+	// On reuse runs the cluster already has Crossplane wired up.
+	var chartRef string
+	if !reuseCluster {
+		chartRef = envvar.GetOrPanic(crossplaneChartPathEnv)
 	}
 
-	cfg.Configure(testenv, &kind.Cluster{})
-
 	testenv.Setup(
+		xpenvfuncs.ValidateTestSetup(xpenvfuncs.ValidateTestSetupOptions{
+			CrossplaneVersion: crossplaneVersion,
+		}),
+		envfuncs.CreateCluster(&kind.Cluster{}, clusterName),
+		// Conditional matches Configure's behavior: when reusing an existing
+		// cluster we skip the install steps. We always install on a fresh
+		// cluster (firstSetup=true) and skip when reusing. We do not have a
+		// cheap way to detect "cluster exists" without the gexe shell out
+		// xp-testing uses, so we approximate: reuseCluster off => install,
+		// reuseCluster on => skip and trust the previous run wired things up.
+		xpenvfuncs.Conditional(
+			xpenvfuncs.Compose(
+				testutil.InstallCrossplaneFromChart(clusterName, chartRef, crossplaneVersion),
+				xpenvfuncs.InstallCrossplaneProvider(
+					clusterName, xpenvfuncs.InstallCrossplaneProviderOptions{
+						Name:                    "btp-account",
+						Package:                 uutConfig,
+						ControllerImage:         &uutController,
+						DeploymentRuntimeConfig: &deploymentRuntimeConfig,
+					}),
+			), !reuseCluster),
+		xpenvfuncs.ApplyProviderConfigFromDir("./provider"),
+		xpenvfuncs.LoadSchemas(),
+		xpenvfuncs.AwaitCRDsEstablished,
 		envfuncs.CreateNamespace(namespace),
 		func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
 			cfg.WithNamespace(namespace)
@@ -112,4 +167,21 @@ func SetupClusterWithCrossplane(namespace string) {
 		testutil.ApplySecretInCrossplaneNamespace(SERVICE_USER_SECRET_NAME, userSecretData),
 		testutil.CreateProviderConfigEnvFn(namespace, globalAccount, cliServerUrl, CIS_SECRET_NAME, SERVICE_USER_SECRET_NAME),
 	)
+
+	testenv.Finish(
+		xpenvfuncs.DumpLogs(clusterName, "post-tests"),
+		xpenvfuncs.Conditional(envfuncs.DestroyCluster(clusterName), !reuseCluster),
+	)
+}
+
+// resolveClusterName mirrors xp-testing's setup.clusterName logic so that the
+// E2E_CLUSTER_NAME / E2E_REUSE_CLUSTER environment variables continue to work.
+func resolveClusterName() string {
+	if envvar.CheckEnvVarExists(clusterNameEnv) {
+		return os.Getenv(clusterNameEnv)
+	}
+	if envvar.CheckEnvVarExists(reuseClusterEnv) {
+		return defaultClusterPrefix
+	}
+	return envconf.RandomName(defaultClusterPrefix, 10)
 }

--- a/test/test_utils.go
+++ b/test/test_utils.go
@@ -19,6 +19,7 @@ import (
 	"github.com/crossplane-contrib/xp-testing/pkg/vendored"
 	"github.com/crossplane-contrib/xp-testing/pkg/xpenvfuncs"
 	v1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
+	"github.com/pkg/errors"
 	metaApi "github.com/sap/crossplane-provider-btp/apis"
 	apiV1Alpha1 "github.com/sap/crossplane-provider-btp/apis/v1alpha1"
 	"github.com/vladimirvivien/gexe"
@@ -37,7 +38,9 @@ import (
 	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
 	"sigs.k8s.io/e2e-framework/pkg/features"
+	"sigs.k8s.io/e2e-framework/third_party/helm"
 )
 
 const (
@@ -59,6 +62,41 @@ func SetupLogging(verbosity int) {
 	logging.EnableVerboseLogging(&verbosity)
 	zl := zap.New(zap.UseDevMode(true))
 	ctrl.SetLogger(zl)
+}
+
+// InstallCrossplaneFromChart returns an env.Func that installs Crossplane
+// from a caller-supplied chart reference, bypassing the
+// `helm repo add https://charts.crossplane.io/stable` flow that has been
+// throwing intermittent 403 Forbidden errors. See
+// docs/development/flakiness-analysis.md (Pattern A) for context.
+//
+// chartRef is anything `helm.WithChart` accepts: a local tarball path
+// (e.g. /path/to/crossplane-2.1.3.tgz), an OCI URL
+// (e.g. oci://example.com/crossplane), or a `repo/name` reference (legacy).
+// version is the chart version tag.
+func InstallCrossplaneFromChart(clusterName, chartRef, version string) env.Func {
+	return xpenvfuncs.Compose(
+		envfuncs.CreateNamespace(xpenvfuncs.CrossplaneNamespace),
+		func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
+			cluster, ok := envfuncs.GetClusterFromContext(ctx, clusterName)
+			if !ok {
+				return ctx, fmt.Errorf("install crossplane from chart: cluster %q missing from context", clusterName)
+			}
+			mgr := helm.New(cluster.GetKubeconfig())
+			err := mgr.RunInstall(
+				helm.WithName("crossplane"),
+				helm.WithNamespace(xpenvfuncs.CrossplaneNamespace),
+				helm.WithChart(chartRef),
+				helm.WithVersion(version),
+				helm.WithTimeout("10m"),
+				helm.WithWait(),
+			)
+			if err != nil {
+				return ctx, errors.Wrap(err, "install crossplane from chart: helm install failed")
+			}
+			return ctx, nil
+		},
+	)
 }
 
 func ApplySecretInCrossplaneNamespace(name string, data map[string]string) env.Func {

--- a/test/test_utils.go
+++ b/test/test_utils.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -64,6 +65,95 @@ func SetupLogging(verbosity int) {
 	ctrl.SetLogger(zl)
 }
 
+// crossplaneCacheMount is the host-path directory on the kind control-plane
+// container that backs the package-cache PVC. This must match the path
+// xp-testing's InstallCrossplaneProvider docker-cps the xpkg into:
+// /cache/xpkg/<name>.gz in xp-testing v1.9.2 (xpenvfuncs.go:326-327). The
+// Crossplane helm chart mounts the PVC at /cache in the pod, so a host
+// hostPath of /cache/xpkg surfaces files at /cache/<name>.gz inside the pod —
+// which is where Crossplane's package manager looks.
+const crossplaneCacheMount = "/cache/xpkg"
+
+// crossplaneCacheVolumeTemplate is the PV+PVC manifest pair that backs the
+// helm chart's `--set packageCache.pvc=<name>` reference. Format args:
+//  1. PV name
+//  2. PV hostPath
+//  3. PVC name
+//  4. PVC volumeName
+const crossplaneCacheVolumeTemplate = `apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: %s
+  labels:
+    type: local
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 5Mi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "%s"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: %s
+  namespace: crossplane-system
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeName: %s
+  storageClassName: manual
+  resources:
+    requests:
+      storage: 1Mi
+`
+
+// setupCrossplanePackageCache prepares the Crossplane package-cache on the
+// given kind cluster's control-plane node:
+//  1. `docker exec <cluster>-control-plane mkdir -m 777 -p /cache` to create
+//     the host-path directory the PV binds to.
+//  2. Applies a PV (hostPath: /cache) + PVC (in crossplane-system) named
+//     cacheName, which the helm chart references via
+//     `--set packageCache.pvc=<cacheName>`.
+//
+// Inline replicates xp-testing v1.9.2's unexported helper of the same name
+// (pkg/xpenvfuncs/xpenvfuncs.go). When that helper becomes exportable
+// upstream (see crossplane-contrib/xp-testing#134 and follow-ups), this
+// implementation can be removed in favor of the upstream entry point.
+func setupCrossplanePackageCache(clusterName, cacheName string) env.Func {
+	return func(ctx context.Context, cfg *envconf.Config) (context.Context, error) {
+		controlPlane := clusterName + "-control-plane"
+
+		// Step 1: ensure the host-path dir exists on the kind container.
+		cmd := exec.CommandContext(ctx, "docker", "exec", controlPlane,
+			"mkdir", "-m", "777", "-p", crossplaneCacheMount)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			return ctx, errors.Wrapf(err, "setupCrossplanePackageCache: docker exec mkdir on %s failed: %s", controlPlane, string(out))
+		}
+
+		// Step 2: apply PV + PVC.
+		manifest := fmt.Sprintf(crossplaneCacheVolumeTemplate,
+			cacheName,            // PV name
+			crossplaneCacheMount, // PV hostPath
+			cacheName,            // PVC name
+			cacheName,            // PVC volumeName
+		)
+
+		r, err := res.New(cfg.Client().RESTConfig())
+		if err != nil {
+			return ctx, errors.Wrap(err, "setupCrossplanePackageCache: resources.New failed")
+		}
+		if err := decoder.DecodeEach(ctx, strings.NewReader(manifest),
+			decoder.CreateHandler(r),
+		); err != nil {
+			return ctx, errors.Wrap(err, "setupCrossplanePackageCache: apply PV/PVC failed")
+		}
+		return ctx, nil
+	}
+}
+
 // InstallCrossplaneFromChart returns an env.Func that installs Crossplane
 // from a caller-supplied chart reference, bypassing the
 // `helm repo add https://charts.crossplane.io/stable` flow that has been
@@ -75,8 +165,10 @@ func SetupLogging(verbosity int) {
 // (e.g. oci://example.com/crossplane), or a `repo/name` reference (legacy).
 // version is the chart version tag.
 func InstallCrossplaneFromChart(clusterName, chartRef, version string) env.Func {
+	const cacheName = "package-cache"
 	return xpenvfuncs.Compose(
 		envfuncs.CreateNamespace(xpenvfuncs.CrossplaneNamespace),
+		setupCrossplanePackageCache(clusterName, cacheName),
 		func(ctx context.Context, _ *envconf.Config) (context.Context, error) {
 			cluster, ok := envfuncs.GetClusterFromContext(ctx, clusterName)
 			if !ok {
@@ -88,6 +180,7 @@ func InstallCrossplaneFromChart(clusterName, chartRef, version string) env.Func 
 				helm.WithNamespace(xpenvfuncs.CrossplaneNamespace),
 				helm.WithChart(chartRef),
 				helm.WithVersion(version),
+				helm.WithArgs("--set", fmt.Sprintf("packageCache.pvc=%s", cacheName)),
 				helm.WithTimeout("10m"),
 				helm.WithWait(),
 			)


### PR DESCRIPTION
Trial PR — replaces `helm repo add https://charts.crossplane.io/stable` (per matrix leg) with a single `helm pull` in the `build` job, cached via `actions/cache`, distributed to matrix legs as a workflow artifact, and installed from the local file path.

## Why

The `charts.crossplane.io` CDN throws intermittent 403 Forbidden errors that collapse entire e2e matrix shards (see `docs/development/flakiness-analysis.md` Pattern A). With this change, only the `build` job ever touches the CDN — and only on cache miss.

Earlier attempt on this branch tried `oci://xpkg.crossplane.io/crossplane/crossplane` but Crossplane's chart is not OCI-distributed (only the helm repo). That approach has been replaced with the cached-tarball flow described below.

## What changes

- **`.github/workflows/e2e_test.yaml`**:
  - `build` job: install helm, restore `actions/cache` keyed on chart version, on cache miss `helm pull crossplane --repo .../stable --version X.Y.Z` (5-attempt retry with backoff), save cache, upload as workflow artifact `crossplane-chart`.
  - `e2e-test` matrix: download `crossplane-chart` artifact and export `CROSSPLANE_CHART_PATH` to the test env.
- **`test/test_utils.go`**: renamed `InstallCrossplaneOCI` → `InstallCrossplaneFromChart`, doc comment updated to reflect file-path/OCI/repo flexibility.
- **`test/e2e/main_test.go`**: reads `CROSSPLANE_CHART_PATH` env var; passes it to the helper.
- `go.mod` / `go.sum` unchanged.

## Why not bump xp-testing

crossplane-contrib/xp-testing#134 adds a `ChartRef` field that would let us drop the inline `setup.ClusterSetup.Configure` replication. But xp-testing main has bumped k8s deps to v0.36 incompatibly with this repo's `crossplane-runtime/v2 v2.2.0-rc.0` (missing `SubResourceWriter.Apply`). Bumping xp-testing here would cascade. Once the dep skew is resolved separately, this repo can switch to the upstream API.

## What's NOT changing

- CI retry / Docker Hub mirror / `e2e-tools` cache scaffolding from #707 stays in place. If the chart-tarball approach proves reliable, a follow-up PR can strip the now-redundant helm-related retry logic.
- Cluster reuse (`E2E_REUSE_CLUSTER` / `E2E_CLUSTER_NAME`) replicated inline.

## Test plan

- [x] `go build ./...`, `go vet ./...` pass
- [x] Unit tests pass
- [x] `go.mod`, `go.sum` unchanged
- [ ] PR E2E matrix run on this branch — expect significant green-up vs baseline (no per-leg `helm repo add` to flake)

## Reference

- Flakiness analysis: `docs/development/flakiness-analysis.md` (Pattern A)
- Remediation plan: `docs/development/flakiness-pr-plans.md`
- Upstream attempt: `crossplane-contrib/xp-testing#134` (blocked by k8s dep skew)