### PR TITLE
feat: add external-name ADR compliance for DirectoryEntitlement

### DIFF
--- a/apis/account/v1alpha1/directoryentitlement_types.go
+++ b/apis/account/v1alpha1/directoryentitlement_types.go
@@ -1,0 +1,9 @@
+package v1alpha1
+
+// External-Name Configuration:
+//   - Resource: DirectoryEntitlement
+//   - Follows Standard: no (compound key, not a single GUID)
+//   - Format:`<directory-id>/<service-name>/<plan-name>` (e.g. "abc-123-def-456/hana-cloud/hana")
+//   - How to find:
+//     - UI: BTP Cockpit → Global Account → Account Explorer → [Select Directory] → Entitlements → Service Assignments > Service Technical Name and Plan
+//     - CLI: `btp list accounts/entitlement --directory <directory-id>` → `entitledServices[].name` and `entitledServices[].servicePlans[].name`

--- a/config/directory_entitlement/config.go
+++ b/config/directory_entitlement/config.go
@@ -1,7 +1,12 @@
 package subaccount_trust_configuration
 
 import (
+	"context"
+	"fmt"
+	"strings"
+
 	"github.com/crossplane/upjet/v2/pkg/config"
+	"github.com/pkg/errors"
 )
 
 // Configure configures individual resources by adding custom ResourceConfigurators.
@@ -15,6 +20,34 @@ func Configure(p *config.Provider) {
 			Extractor:         "github.com/sap/crossplane-provider-btp/apis/account/v1alpha1.DirectoryUuid()",
 			RefFieldName:      "DirectoryRef",
 			SelectorFieldName: "DirectorySelector",
+		}
+
+		// ADR(external-name): reconstruct compound key "directory_id/service_name/plan_name" (ADR delimiter: "/")
+		// from TF state after Create/Observe so Upjet does not overwrite the annotation with just the plan ID.
+		r.ExternalName.GetExternalNameFn = func(tfstate map[string]any) (string, error) {
+			directoryID, _ := tfstate["directory_id"].(string)
+			serviceName, _ := tfstate["service_name"].(string)
+			planName, _ := tfstate["plan_name"].(string)
+			if directoryID == "" {
+				return "", errors.New("cannot reconstruct external-name: directory_id missing from tfstate")
+			}
+			if serviceName == "" {
+				return "", errors.New("cannot reconstruct external-name: service_name missing from tfstate")
+			}
+			if planName == "" {
+				return "", errors.New("cannot reconstruct external-name: plan_name missing from tfstate")
+			}
+			return fmt.Sprintf("%s/%s/%s", directoryID, serviceName, planName), nil
+		}
+
+		// ADR(external-name): translate ADR compound key "directory_id/service_name/plan_name" to TF import ID
+		// format "directory_id,service_name,plan_name" required by the BTP Terraform provider's ImportState function.
+		r.ExternalName.GetIDFn = func(_ context.Context, externalName string, _ map[string]any, _ map[string]any) (string, error) {
+			parts := strings.SplitN(externalName, "/", 3)
+			if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+				return externalName, nil
+			}
+			return fmt.Sprintf("%s,%s,%s", parts[0], parts[1], parts[2]), nil
 		}
 	})
 }

--- a/docs/end-user-guides/import-landscape/external-name.md
+++ b/docs/end-user-guides/import-landscape/external-name.md
@@ -50,6 +50,15 @@ metadata.annotations.crossplane.io/external-name: <resource_uniq_ID>
   - UI: Global Account → Account Explorer → Directories → [Select Directory] → Directory ID
   - CLI: btp list accounts/directory (field: guid)
 
+### DirectoryEntitlement
+
+- Follows Standard: no (compound key, not a single GUID)
+- Format:`<directory-id>/<service-name>/<plan-name>` (e.g. "abc-123-def-456/hana-cloud/hana")
+- How to find:
+
+  - UI: BTP Cockpit → Global Account → Account Explorer → [Select Directory] → Entitlements → Service Assignments > Service Technical Name and Plan
+  - CLI: `btp list accounts/entitlement --directory <directory-id>` → `entitledServices[].name` and `entitledServices[].servicePlans[].name`
+
 ### KubeConfigGenerator
 
 - Follows Standard: no - This resource does not support external name as it does not represent an external resource. Instead of using external name for importing, you can just create an instance of this resource.

--- a/test/e2e/directory_entitlement_v1alpha1_test.go
+++ b/test/e2e/directory_entitlement_v1alpha1_test.go
@@ -42,7 +42,7 @@ func TestDirectoryEntitlementImportFlow(t *testing.T) {
 		importK8sResName,
 		WithWaitCreateTimeout[*v1alpha1.DirectoryEntitlement](wait.WithTimeout(5*time.Minute)),
 		WithWaitDeletionTimeout[*v1alpha1.DirectoryEntitlement](wait.WithTimeout(3*time.Minute)),
-		WithDependentResourceDirectory[*v1alpha1.DirectoryEntitlement]("./testdata/crs/DirectoryEntitlementImport"),
+		WithDependentResourceDirectory[*v1alpha1.DirectoryEntitlement](crsPath("DirectoryEntitlementImport")),
 		WithWaitDependentResourceTimeout[*v1alpha1.DirectoryEntitlement](wait.WithTimeout(15*time.Minute)),
 	)
 

--- a/test/e2e/directory_entitlement_v1alpha1_test.go
+++ b/test/e2e/directory_entitlement_v1alpha1_test.go
@@ -9,15 +9,48 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sap/crossplane-provider-btp/apis/account/v1alpha1"
-
 	"github.com/crossplane-contrib/xp-testing/pkg/resources"
+	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
 	meta_api "github.com/sap/crossplane-provider-btp/apis"
+	"github.com/sap/crossplane-provider-btp/apis/account/v1alpha1"
 	res "sigs.k8s.io/e2e-framework/klient/k8s/resources"
 	"sigs.k8s.io/e2e-framework/klient/wait"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/features"
 )
+
+// TestDirectoryEntitlementImportFlow tests the import flow for DirectoryEntitlement.
+// ADR(external-name): uses compound key "<directory-id>/<service-name>/<plan-name>" (e.g. "abc-123/alert-notification/free") as identifier.
+func TestDirectoryEntitlementImportFlow(t *testing.T) {
+	const importK8sResName = "dir-entitlement-import-test"
+
+	serviceName := "cis"
+	planName := "local"
+
+	importTester := NewImportTester(
+		&v1alpha1.DirectoryEntitlement{
+			Spec: v1alpha1.DirectoryEntitlementSpec{
+				ForProvider: v1alpha1.DirectoryEntitlementParameters{
+					ServiceName: &serviceName,
+					PlanName:    &planName,
+					DirectoryRef: &xpv1.Reference{
+						Name: importK8sResName,
+					},
+				},
+			},
+		},
+		importK8sResName,
+		WithWaitCreateTimeout[*v1alpha1.DirectoryEntitlement](wait.WithTimeout(5*time.Minute)),
+		WithWaitDeletionTimeout[*v1alpha1.DirectoryEntitlement](wait.WithTimeout(3*time.Minute)),
+		WithDependentResourceDirectory[*v1alpha1.DirectoryEntitlement]("./testdata/crs/DirectoryEntitlementImport"),
+		WithWaitDependentResourceTimeout[*v1alpha1.DirectoryEntitlement](wait.WithTimeout(15*time.Minute)),
+	)
+
+	testenv.Test(
+		t,
+		importTester.BuildTestFeature("DirectoryEntitlement Import Flow").Feature(),
+	)
+}
 
 func Test_DirectoryEntitlement_v1alpha1(t *testing.T) {
 	resource := resources.ResourceTestConfig{

--- a/test/e2e/testdata/crs/DirectoryEntitlementImport/directory.yaml
+++ b/test/e2e/testdata/crs/DirectoryEntitlementImport/directory.yaml
@@ -1,0 +1,17 @@
+apiVersion: account.btp.sap.crossplane.io/v1alpha1
+kind: Directory
+metadata:
+  namespace: default
+  name: dir-entitlement-import-test
+spec:
+  forProvider:
+    displayName: $BUILD_ID-e2e-dir-entitlement-import
+    directoryFeatures:
+      - DEFAULT
+      - ENTITLEMENTS
+    directoryAdmins:
+      - $SECOND_DIRECTORY_ADMIN_EMAIL
+      - $TECHNICAL_USER_EMAIL
+    labels:
+      safe-to-delete: [ "yes" ]
+      BUILD_ID: [ "$BUILD_ID" ]

--- a/test/upgrade/directoryentitlement_external_name_upgrade_test.go
+++ b/test/upgrade/directoryentitlement_external_name_upgrade_test.go
@@ -1,0 +1,93 @@
+//go:build upgrade
+
+package upgrade
+
+import (
+	"context"
+	"testing"
+
+	accountv1alpha1 "github.com/sap/crossplane-provider-btp/apis/account/v1alpha1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+)
+
+var (
+	directoryEntitlementFromCustomTag             = "v1.3.0"
+	directoryEntitlementToCustomTag               = "local"
+	directoryEntitlementCustomResourceDirectories = []string{
+		"./testdata/customCRs/directoryExternalName",
+		"./testdata/customCRs/directoryEntitlementExternalName",
+	}
+)
+
+// Test_DirectoryEntitlement_External_Name verifies that the external-name is preserved during upgrades.
+// ADR(external-name): uses compound key "<directory-id>/<service-name>/<plan-name>" (e.g. "abc-123/cis/local") as identifier.
+func Test_DirectoryEntitlement_External_Name(t *testing.T) {
+	const directoryEntitlementName = "upgrade-test-extn-dir-ent"
+
+	upgradeTest := NewCustomUpgradeTest("directory-entitlement-external-name-test").
+		FromVersion(directoryEntitlementFromCustomTag).
+		ToVersion(directoryEntitlementToCustomTag).
+		WithResourceDirectories(directoryEntitlementCustomResourceDirectories).
+		WithCustomPreUpgradeAssessment(
+			"verify external name before upgrade",
+			func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+				dirEnt := &accountv1alpha1.DirectoryEntitlement{}
+				r := cfg.Client().Resources()
+
+				if err := r.Get(ctx, directoryEntitlementName, cfg.Namespace(), dirEnt); err != nil {
+					t.Fatalf("Failed to get DirectoryEntitlement resource: %v", err)
+				}
+
+				annotations := dirEnt.GetAnnotations()
+				externalName, exists := annotations["crossplane.io/external-name"]
+				if !exists {
+					t.Fatal("External name annotation does not exist before upgrade")
+				}
+				if externalName == "" {
+					t.Fatal("External name annotation is empty before upgrade")
+				}
+
+				klog.V(4).Infof("Pre-upgrade DirectoryEntitlement external name: %s", externalName)
+				return context.WithValue(ctx, "preUpgradeDirEntExternalName", externalName)
+			},
+		).
+		WithCustomPostUpgradeAssessment(
+			"verify external name after upgrade",
+			func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+				dirEnt := &accountv1alpha1.DirectoryEntitlement{}
+				r := cfg.Client().Resources()
+
+				if err := r.Get(ctx, directoryEntitlementName, cfg.Namespace(), dirEnt); err != nil {
+					t.Fatalf("Failed to get DirectoryEntitlement resource after upgrade: %v", err)
+				}
+
+				annotations := dirEnt.GetAnnotations()
+				externalName, exists := annotations["crossplane.io/external-name"]
+				if !exists {
+					t.Fatal("External name annotation does not exist after upgrade")
+				}
+
+				klog.V(4).Infof("Post-upgrade DirectoryEntitlement external name: %s", externalName)
+
+				preUpgradeExternalName, ok := ctx.Value("preUpgradeDirEntExternalName").(string)
+				if !ok {
+					t.Fatal("Could not retrieve pre-upgrade external name from context")
+				}
+
+				// ADR(external-name): compound key "<directory-id>/<service-name>/<plan-name>" must be preserved during upgrade — must not be migrated to plan-id format.
+				if externalName != preUpgradeExternalName {
+					t.Fatalf(
+						"External name changed during upgrade: before=%q, after=%q (expected no change)",
+						preUpgradeExternalName,
+						externalName,
+					)
+				}
+
+				klog.V(4).Info("External name correctly preserved after upgrade")
+				return ctx
+			},
+		)
+
+	testenv.Test(t, upgradeTest.Feature())
+}

--- a/test/upgrade/directoryentitlement_external_name_upgrade_test.go
+++ b/test/upgrade/directoryentitlement_external_name_upgrade_test.go
@@ -6,24 +6,26 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	accountv1alpha1 "github.com/sap/crossplane-provider-btp/apis/account/v1alpha1"
 	"github.com/sap/crossplane-provider-btp/internal"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 )
 
 var (
-	directoryEntitlementFromCustomTag             = "v1.3.0"
+	directoryEntitlementFromCustomTag             = "v1.10.0"
 	directoryEntitlementToCustomTag               = "local"
 	directoryEntitlementCustomResourceDirectories = []string{
-		"./testdata/customCRs/directoryExternalName",
 		"./testdata/customCRs/directoryEntitlementExternalName",
 	}
 )
 
 // Test_DirectoryEntitlement_External_Name verifies that the external-name is migrated to the new format during upgrades.
-// ADR(external-name): before upgrade (v1.3.0) the external-name is the raw TF id (e.g. "cis-local");
+// ADR(external-name): before upgrade (v1.10.0) the external-name is the raw TF id (e.g. "cis-local");
 // after upgrade it must be the compound key "<directory-id>/<service-name>/<plan-name>" (e.g. "abc-123/cis/local").
 func Test_DirectoryEntitlement_External_Name(t *testing.T) {
 	const directoryEntitlementName = "upgrade-test-extn-dir-ent"
@@ -50,7 +52,7 @@ func Test_DirectoryEntitlement_External_Name(t *testing.T) {
 
 				klog.V(4).Infof("Pre-upgrade DirectoryEntitlement external name: %q", externalName)
 
-				// Before upgrade (v1.3.0): external-name is the raw TF id "<service-name>-<plan-name>" (e.g. "cis-local")
+				// Before upgrade (v1.10.0): external-name is the raw TF id "<service-name>-<plan-name>" (e.g. "cis-local")
 				expectedOldFormat := *dirEnt.Spec.ForProvider.ServiceName + "-" + *dirEnt.Spec.ForProvider.PlanName
 				if externalName != expectedOldFormat {
 					t.Fatalf("Pre-upgrade external-name %q does not match expected old format %q", externalName, expectedOldFormat)
@@ -104,6 +106,26 @@ func Test_DirectoryEntitlement_External_Name(t *testing.T) {
 				}
 
 				klog.V(4).Infof("External name migrated from %q to compound-key %q", preUpgradeExternalName, externalName)
+
+				// Delete the DirectoryEntitlement before teardown so the Directory is not deleted
+				// while the entitlement still references it.
+				//
+				// The 20-minute timeout accounts for the worst-case Upjet backoff: after upgrade,
+				// Crossplane immediately starts a `terraform apply -refresh-only`. If the delete
+				// arrives while this is running, Upjet blocks destroy ("apply operation still
+				// running") and Crossplane retries with exponential backoff capping at ~10 minutes.
+				klog.V(4).Info("Deleting DirectoryEntitlement before teardown")
+				if err := r.Delete(ctx, dirEnt); err != nil {
+					t.Fatalf("Failed to delete DirectoryEntitlement: %v", err)
+				}
+				if err := wait.For(
+					conditions.New(r).ResourceDeleted(dirEnt),
+					wait.WithTimeout(20*time.Minute),
+				); err != nil {
+					t.Fatalf("DirectoryEntitlement was not deleted within timeout: %v", err)
+				}
+				klog.V(4).Info("DirectoryEntitlement deleted before teardown")
+
 				return ctx
 			},
 		)

--- a/test/upgrade/directoryentitlement_external_name_upgrade_test.go
+++ b/test/upgrade/directoryentitlement_external_name_upgrade_test.go
@@ -4,10 +4,11 @@ package upgrade
 
 import (
 	"context"
-	"regexp"
+	"strings"
 	"testing"
 
 	accountv1alpha1 "github.com/sap/crossplane-provider-btp/apis/account/v1alpha1"
+	"github.com/sap/crossplane-provider-btp/internal"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 )
@@ -21,8 +22,9 @@ var (
 	}
 )
 
-// Test_DirectoryEntitlement_External_Name verifies that the external-name is preserved during upgrades.
-// ADR(external-name): uses compound key "<directory-id>/<service-name>/<plan-name>" (e.g. "abc-123/cis/local") as identifier.
+// Test_DirectoryEntitlement_External_Name verifies that the external-name is migrated to the new format during upgrades.
+// ADR(external-name): before upgrade (v1.3.0) the external-name is the raw TF id (e.g. "cis-local");
+// after upgrade it must be the compound key "<directory-id>/<service-name>/<plan-name>" (e.g. "abc-123/cis/local").
 func Test_DirectoryEntitlement_External_Name(t *testing.T) {
 	const directoryEntitlementName = "upgrade-test-extn-dir-ent"
 
@@ -45,14 +47,14 @@ func Test_DirectoryEntitlement_External_Name(t *testing.T) {
 				if !exists {
 					t.Fatal("External name annotation does not exist before upgrade")
 				}
-				if externalName == "" {
-					t.Fatal("External name annotation is empty before upgrade")
-				}
-				if matched, _ := regexp.MatchString(`^[^/]+/[^/]+/[^/]+$`, externalName); !matched {
-					t.Fatalf("External name %q does not match expected format <directory-id>/<service-name>/<plan-name> before upgrade", externalName)
-				}
 
-				klog.V(4).Infof("Pre-upgrade DirectoryEntitlement external name: %s", externalName)
+				klog.V(4).Infof("Pre-upgrade DirectoryEntitlement external name: %q", externalName)
+
+				// Before upgrade (v1.3.0): external-name is the raw TF id "<service-name>-<plan-name>" (e.g. "cis-local")
+				expectedOldFormat := *dirEnt.Spec.ForProvider.ServiceName + "-" + *dirEnt.Spec.ForProvider.PlanName
+				if externalName != expectedOldFormat {
+					t.Fatalf("Pre-upgrade external-name %q does not match expected old format %q", externalName, expectedOldFormat)
+				}
 				return context.WithValue(ctx, "preUpgradeDirEntExternalName", externalName)
 			},
 		).
@@ -72,23 +74,36 @@ func Test_DirectoryEntitlement_External_Name(t *testing.T) {
 					t.Fatal("External name annotation does not exist after upgrade")
 				}
 
-				klog.V(4).Infof("Post-upgrade DirectoryEntitlement external name: %s", externalName)
+				klog.V(4).Infof("Post-upgrade DirectoryEntitlement external name: %q", externalName)
+
+				// After upgrade: external-name must be compound key "<directory-id>/<service-name>/<plan-name>"
+				if !strings.Contains(externalName, "/") {
+					t.Fatalf("Post-upgrade external-name %q is not in compound-key format", externalName)
+				}
+				parts := strings.Split(externalName, "/")
+				if len(parts) != 3 {
+					t.Fatalf("Post-upgrade external-name %q must have 3 segments, got %d", externalName, len(parts))
+				}
+				if !internal.IsValidUUID(parts[0]) {
+					t.Fatalf("Compound-key directory ID %q is not a valid UUID", parts[0])
+				}
+				if parts[1] != *dirEnt.Spec.ForProvider.ServiceName {
+					t.Fatalf("Compound-key service name %q does not match spec %q", parts[1], *dirEnt.Spec.ForProvider.ServiceName)
+				}
+				if parts[2] != *dirEnt.Spec.ForProvider.PlanName {
+					t.Fatalf("Compound-key plan name %q does not match spec %q", parts[2], *dirEnt.Spec.ForProvider.PlanName)
+				}
 
 				preUpgradeExternalName, ok := ctx.Value("preUpgradeDirEntExternalName").(string)
 				if !ok {
 					t.Fatal("Could not retrieve pre-upgrade external name from context")
 				}
 
-				// ADR(external-name): compound key "<directory-id>/<service-name>/<plan-name>" must be preserved during upgrade — must not be migrated to plan-id format.
-				if externalName != preUpgradeExternalName {
-					t.Fatalf(
-						"External name changed during upgrade: before=%q, after=%q (expected no change)",
-						preUpgradeExternalName,
-						externalName,
-					)
+				if preUpgradeExternalName == externalName {
+					t.Fatalf("Expected external-name to be migrated; before and after both equal %q", externalName)
 				}
 
-				klog.V(4).Info("External name correctly preserved after upgrade")
+				klog.V(4).Infof("External name migrated from %q to compound-key %q", preUpgradeExternalName, externalName)
 				return ctx
 			},
 		)

--- a/test/upgrade/directoryentitlement_external_name_upgrade_test.go
+++ b/test/upgrade/directoryentitlement_external_name_upgrade_test.go
@@ -20,7 +20,7 @@ var (
 	directoryEntitlementFromCustomTag             = "v1.10.0"
 	directoryEntitlementToCustomTag               = "local"
 	directoryEntitlementCustomResourceDirectories = []string{
-		"./testdata/customCRs/directoryEntitlementExternalName",
+		upgradeCRsPath("customCRs/directoryEntitlementExternalName"),
 	}
 )
 

--- a/test/upgrade/directoryentitlement_external_name_upgrade_test.go
+++ b/test/upgrade/directoryentitlement_external_name_upgrade_test.go
@@ -4,6 +4,7 @@ package upgrade
 
 import (
 	"context"
+	"regexp"
 	"testing"
 
 	accountv1alpha1 "github.com/sap/crossplane-provider-btp/apis/account/v1alpha1"
@@ -46,6 +47,9 @@ func Test_DirectoryEntitlement_External_Name(t *testing.T) {
 				}
 				if externalName == "" {
 					t.Fatal("External name annotation is empty before upgrade")
+				}
+				if matched, _ := regexp.MatchString(`^[^/]+/[^/]+/[^/]+$`, externalName); !matched {
+					t.Fatalf("External name %q does not match expected format <directory-id>/<service-name>/<plan-name> before upgrade", externalName)
 				}
 
 				klog.V(4).Infof("Pre-upgrade DirectoryEntitlement external name: %s", externalName)

--- a/test/upgrade/testdata/customCRs/directoryEntitlementExternalName/directory.yaml
+++ b/test/upgrade/testdata/customCRs/directoryEntitlementExternalName/directory.yaml
@@ -1,0 +1,17 @@
+apiVersion: account.btp.sap.crossplane.io/v1alpha1
+kind: Directory
+metadata:
+  name: upgrade-test-extn-dir-fts-ent
+spec:
+  forProvider:
+    description: "$BUILD_ID-created by external name upgrade tests"
+    directoryAdmins:
+      - "$SECOND_DIRECTORY_ADMIN_EMAIL"
+      - "$TECHNICAL_USER_EMAIL"
+    directoryFeatures:
+      - "DEFAULT"
+      - "ENTITLEMENTS"
+    displayName: $BUILD_ID-upgrade-test-extn-dir
+    labels:
+      safe-to-delete: ["yes"]
+      BUILD_ID: ["$BUILD_ID"]

--- a/test/upgrade/testdata/customCRs/directoryEntitlementExternalName/directoryentitlement.yaml
+++ b/test/upgrade/testdata/customCRs/directoryEntitlementExternalName/directoryentitlement.yaml
@@ -1,0 +1,11 @@
+apiVersion: account.btp.sap.crossplane.io/v1alpha1
+kind: DirectoryEntitlement
+metadata:
+  name: upgrade-test-extn-dir-ent
+  namespace: default
+spec:
+  forProvider:
+    serviceName: cis
+    planName: local
+    directoryRef:
+      name: upgrade-test-extn-dir

--- a/test/upgrade/testdata/customCRs/directoryEntitlementExternalName/directoryentitlement.yaml
+++ b/test/upgrade/testdata/customCRs/directoryEntitlementExternalName/directoryentitlement.yaml
@@ -8,4 +8,4 @@ spec:
     serviceName: cis
     planName: local
     directoryRef:
-      name: upgrade-test-extn-dir
+      name: upgrade-test-extn-dir-fts-ent


### PR DESCRIPTION
Implements ADR-compliant external-name handling for DirectoryEntitlement as part of https://github.com/SAP/crossplane-provider-btp/issues/427.

Note that the external name might change with https://github.com/SAP/terraform-provider-btp/issues/1587.