### PR TITLE
fix: inherit secrets in release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,6 +44,7 @@ jobs:
       - run-make-reviewable-and-check-diff
       with:
         environment: pr-e2e-no-approval
+      secrets: inherit
       permissions:
         contents: read
 


### PR DESCRIPTION
## Fxied Problem
The release action failed the e2e tests, because of missing `CIS_CENTRAL_BINDING`. It turned out that this was not actually passed down to the e2e tests, because the secrets of the environment were not inherit. 