### PR TITLE
fix: skip description on SubaccountTrustConfiguration to avoid inconsistent-result error

### DIFF
--- a/apis/security/v1alpha1/zz_subaccounttrustconfiguration_types.go
+++ b/apis/security/v1alpha1/zz_subaccounttrustconfiguration_types.go
@@ -35,7 +35,7 @@ type SubaccountTrustConfigurationInitParameters struct {
 	// Determines that end users can choose the trust configuration for login. If not set, the trust configuration can remain active, however only application users that explicitly specify the origin key can use if for login.
 	AvailableForUserLogon *bool `json:"availableForUserLogon,omitempty" tf:"available_for_user_logon,omitempty"`
 
-	// (String) Description of the trust configuration.
+	// (String) Description of the trust configuration. NOTE: currently ignored due to an upstream bug (see #724); the BTP backend assigns its own default.
 	// Description of the trust configuration.
 	Description *string `json:"description,omitempty" tf:"description,omitempty"`
 
@@ -86,7 +86,7 @@ type SubaccountTrustConfigurationObservation struct {
 	// Determines that end users can choose the trust configuration for login. If not set, the trust configuration can remain active, however only application users that explicitly specify the origin key can use if for login.
 	AvailableForUserLogon *bool `json:"availableForUserLogon,omitempty" tf:"available_for_user_logon,omitempty"`
 
-	// (String) Description of the trust configuration.
+	// (String) Description of the trust configuration. NOTE: currently ignored due to an upstream bug (see #724); the BTP backend assigns its own default.
 	// Description of the trust configuration.
 	Description *string `json:"description,omitempty" tf:"description,omitempty"`
 
@@ -146,7 +146,7 @@ type SubaccountTrustConfigurationParameters struct {
 	// +kubebuilder:validation:Optional
 	AvailableForUserLogon *bool `json:"availableForUserLogon,omitempty" tf:"available_for_user_logon,omitempty"`
 
-	// (String) Description of the trust configuration.
+	// (String) Description of the trust configuration. NOTE: currently ignored due to an upstream bug (see #724); the BTP backend assigns its own default.
 	// Description of the trust configuration.
 	// +kubebuilder:validation:Optional
 	Description *string `json:"description,omitempty" tf:"description,omitempty"`

--- a/config/subaccount_trust_configuration/config.go
+++ b/config/subaccount_trust_configuration/config.go
@@ -23,12 +23,7 @@ func Configure(p *config.Provider) {
 		r.ShortGroup = "security"
 		r.Kind = "SubaccountTrustConfiguration"
 
-		// Workaround for inconsistent description on create, see #724.
-		// TODO: remove when terraform-provider-btp is bumped to >= 1.23.1 (#521).
-		r.TerraformConfigurationInjector = func(jsonMap, tfMap map[string]any) error {
-			delete(tfMap, "description")
-			return nil
-		}
+		applyDescriptionInconsistencyWorkaround(r)
 
 		r.References["subaccount_id"] = config.Reference{
 			Type:              "github.com/sap/crossplane-provider-btp/apis/account/v1alpha1.Subaccount",
@@ -68,6 +63,28 @@ func Configure(p *config.Provider) {
 			return &OriginInitializer{Kube: kube}
 		})
 	})
+}
+
+// applyDescriptionInconsistencyWorkaround works around an upstream bug in
+// terraform-provider-btp (see #724, fixed upstream in v1.23.1) that causes
+// SubaccountTrustConfiguration creation to fail with "Provider produced
+// inconsistent result after apply" when spec.forProvider.description is set.
+//
+// Strips `description` from the params map so terraform sees a nil value;
+// combined with Optional+Computed in the schema, the BTP-computed value is
+// accepted without a consistency violation. Also overrides the field's
+// ArgumentDocs to surface the limitation on the user-facing CR field.
+//
+// TODO: remove when terraform-provider-btp is bumped to >= 1.23.1 (#521).
+func applyDescriptionInconsistencyWorkaround(r *config.Resource) {
+	r.TerraformConfigurationInjector = func(jsonMap, tfMap map[string]any) error {
+		delete(tfMap, "description")
+		return nil
+	}
+	if r.MetaResource != nil && r.MetaResource.ArgumentDocs != nil {
+		r.MetaResource.ArgumentDocs["description"] = "(String) Description of the trust configuration. " +
+			"NOTE: currently ignored due to an upstream bug (see #724); the BTP backend assigns its own default."
+	}
 }
 
 // OriginInitializer copies the origin portion of the compound external-name annotation

--- a/config/subaccount_trust_configuration/config.go
+++ b/config/subaccount_trust_configuration/config.go
@@ -23,6 +23,13 @@ func Configure(p *config.Provider) {
 		r.ShortGroup = "security"
 		r.Kind = "SubaccountTrustConfiguration"
 
+		// Workaround for inconsistent description on create, see #724.
+		// TODO: remove when terraform-provider-btp is bumped to >= 1.23.1 (#521).
+		r.TerraformConfigurationInjector = func(jsonMap, tfMap map[string]any) error {
+			delete(tfMap, "description")
+			return nil
+		}
+
 		r.References["subaccount_id"] = config.Reference{
 			Type:              "github.com/sap/crossplane-provider-btp/apis/account/v1alpha1.Subaccount",
 			Extractor:         "github.com/sap/crossplane-provider-btp/apis/account/v1alpha1.SubaccountUuid()",

--- a/config/subaccount_trust_configuration/config.go
+++ b/config/subaccount_trust_configuration/config.go
@@ -70,21 +70,39 @@ func Configure(p *config.Provider) {
 // SubaccountTrustConfiguration creation to fail with "Provider produced
 // inconsistent result after apply" when spec.forProvider.description is set.
 //
-// Strips `description` from the params map so terraform sees a nil value;
-// combined with Optional+Computed in the schema, the BTP-computed value is
-// accepted without a consistency violation. Also overrides the field's
+// Registers an Initializer that nils spec.forProvider.description (and the
+// initProvider counterpart) in-process on every reconcile, before upjet
+// serializes the spec into main.tf.json. Terraform therefore plans against a
+// nil description; combined with Optional+Computed in the schema, the
+// BTP-computed value is accepted without a consistency violation. The change
+// is not persisted to the API server, so the user's spec value remains intact
+// and the workaround is transparent on removal. Also overrides the field's
 // ArgumentDocs to surface the limitation on the user-facing CR field.
 //
 // TODO: remove when terraform-provider-btp is bumped to >= 1.23.1 (#521).
 func applyDescriptionInconsistencyWorkaround(r *config.Resource) {
-	r.TerraformConfigurationInjector = func(jsonMap, tfMap map[string]any) error {
-		delete(tfMap, "description")
-		return nil
-	}
+	r.InitializerFns = append(r.InitializerFns, func(_ client.Client) managed.Initializer {
+		return &descriptionStripper{}
+	})
 	if r.MetaResource != nil && r.MetaResource.ArgumentDocs != nil {
 		r.MetaResource.ArgumentDocs["description"] = "(String) Description of the trust configuration. " +
 			"NOTE: currently ignored due to an upstream bug (see #724); the BTP backend assigns its own default."
 	}
+}
+
+// descriptionStripper is the Initializer registered by
+// applyDescriptionInconsistencyWorkaround. See that function's godoc for
+// rationale and removal conditions.
+type descriptionStripper struct{}
+
+func (descriptionStripper) Initialize(_ context.Context, mg resource.Managed) error {
+	cr, ok := mg.(*securityv1alpha1.SubaccountTrustConfiguration)
+	if !ok {
+		return errors.New(errTypeAssertion)
+	}
+	cr.Spec.ForProvider.Description = nil
+	cr.Spec.InitProvider.Description = nil
+	return nil
 }
 
 // OriginInitializer copies the origin portion of the compound external-name annotation

--- a/package/crds/security.btp.sap.crossplane.io_subaccounttrustconfigurations.yaml
+++ b/package/crds/security.btp.sap.crossplane.io_subaccounttrustconfigurations.yaml
@@ -88,7 +88,7 @@ spec:
                     type: boolean
                   description:
                     description: |-
-                      (String) Description of the trust configuration.
+                      (String) Description of the trust configuration. NOTE: currently ignored due to an upstream bug (see #724); the BTP backend assigns its own default.
                       Description of the trust configuration.
                     type: string
                   domain:
@@ -223,7 +223,7 @@ spec:
                     type: boolean
                   description:
                     description: |-
-                      (String) Description of the trust configuration.
+                      (String) Description of the trust configuration. NOTE: currently ignored due to an upstream bug (see #724); the BTP backend assigns its own default.
                       Description of the trust configuration.
                     type: string
                   domain:
@@ -442,7 +442,7 @@ spec:
                     type: boolean
                   description:
                     description: |-
-                      (String) Description of the trust configuration.
+                      (String) Description of the trust configuration. NOTE: currently ignored due to an upstream bug (see #724); the BTP backend assigns its own default.
                       Description of the trust configuration.
                     type: string
                   domain:


### PR DESCRIPTION
Fixes #724.
Backport into `release/v1_10_x`: https://github.com/SAP/crossplane-provider-btp/pull/730

## Summary

`SubaccountTrustConfiguration` creation fails with *"Provider produced inconsistent result after apply"* whenever `spec.forProvider.description` is set, due to a bug in `terraform-provider-btp` ≤ v1.22 (fixed upstream in v1.23.1; the corresponding bump is tracked in #521). Until that bump lands, this PR adds a temporary workaround so users can create the resource at all.

See #724 for the full root cause analysis, the upstream references, and the rationale for the workaround mechanism.

## What I changed

- Registered an `Initializer` (`descriptionStripper`) on the `btp_subaccount_trust_configuration` resource configuration that nils `spec.forProvider.description` and `spec.initProvider.description` in-process on every reconcile. The mutation is not persisted to the API server, so the user-provided value remains intact in etcd.
- Overrode the field's `ArgumentDocs` so the limitation is surfaced on the user-facing CRD field description (visible via `kubectl explain` and the published reference docs).
- Both pieces are grouped behind a single `applyDescriptionInconsistencyWorkaround` helper carrying a `TODO` referencing #521 so the workaround is removed in one place when the upstream bump lands.

`GlobalaccountTrustConfiguration` is intentionally untouched — upstream confirmed the single-step Create flow is not affected.

## Test Plan

- [x] `go build ./...` — clean
- [x] `make generate` — generated CRD and Go types pick up the overridden field description on `SubaccountTrustConfiguration` only; `GlobalaccountTrustConfiguration` is unchanged
- [x] e2e `Test_SubaccountTrustConfiguration_v1alpha1` — passes with the fixture's `description: "my-descriptions"` retained