### PR TITLE
fix: dedicated e2e_long build tag for long-running tests (backport to v1_10_x)

### DIFF
--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -70,7 +70,7 @@ jobs:
       - name: Set matrix with test names
         id: set-matrix
         run: |
-          echo "test-names=$(grep -rh --include='**_test.go' -o -E 'func (Test[A-Za-z0-9_]+)\(t \*testing.T\)' test/e2e | sed 's/func //;s/(t \*testing.T)//' | jq -R . | jq -cs .)" >> $GITHUB_OUTPUT
+          echo "test-names=$(grep -rhl --include='*_test.go' 'go:build e2e' test/e2e | xargs grep -L 'go:build e2e_long' | xargs grep -oh -E 'func (Test[A-Za-z0-9_]+)\(t \*testing\.T\)' | sed 's/func //;s/(t \*testing.T)//' | jq -R . | jq -cs .)" >> $GITHUB_OUTPUT
 
       - name: Print test names
         run: | 

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -70,7 +70,7 @@ jobs:
       - name: Set matrix with test names
         id: set-matrix
         run: |
-          echo "test-names=$(grep -rhl --include='*_test.go' 'go:build e2e' test/e2e | xargs grep -L 'go:build e2e_long' | xargs grep -oh -E 'func (Test[A-Za-z0-9_]+)\(t \*testing\.T\)' | sed 's/func //;s/(t \*testing.T)//' | jq -R . | jq -cs .)" >> $GITHUB_OUTPUT
+          echo "test-names=$(find test/e2e -name '*_test.go' | xargs grep -L 'go:build e2e_long' | xargs grep -oh -E 'func (Test[A-Za-z0-9_]+)\(t \*testing\.T\)' | sed 's/func //;s/(t \*testing.T)//' | jq -R . | jq -cs .)" >> $GITHUB_OUTPUT
 
       - name: Print test names
         run: | 

--- a/Makefile
+++ b/Makefile
@@ -267,7 +267,7 @@ e2e.run: test-acceptance
 #run single test-e2e-long test with <make e2e testFilter=functionNameOfTest>
 test-e2e-long: local-build $(KIND) $(HELM3) generate-test-crs
 	@$(INFO) running integration tests
-	go test -v $(PROJECT_REPO)/test/... -tags=e2e -count=1 -test.v -run '^$(testFilter)$$' -timeout 240m 2>&1 | tee test-output.log
+	go test -v $(PROJECT_REPO)/test/e2e -tags=e2e_long -count=1 -test.v -run '^$(testFilter)$$' -timeout 150m 2>&1 | tee test-output.log
 	@$(OK) integration tests passed
 	@echo "===========Test Summary==========="
 	@grep -E "PASS|FAIL" test-output.log
@@ -281,7 +281,7 @@ test-e2e-long: local-build $(KIND) $(HELM3) generate-test-crs
 test-acceptance: local-build $(KIND) $(HELM3) generate-test-crs
 	@$(INFO) running end-to-end tests
 	@$(INFO) Skipping long running tests
-	go test -v  $(PROJECT_REPO)/test/e2e -tags=e2e -short -count=1 -test.v -run '^$(testFilter)$$' -timeout 120m 2>&1 | tee test-output.log
+	go test -v  $(PROJECT_REPO)/test/e2e -tags=e2e -count=1 -test.v -run '^$(testFilter)$$' -timeout 120m 2>&1 | tee test-output.log
 	@echo "===========Test Summary==========="
 	@grep -E "PASS|FAIL" test-output.log
 	@case `tail -n 1 test-output.log` in \
@@ -294,7 +294,7 @@ test-acceptance-debug: local-build $(KIND) $(HELM3) generate-test-crs
 	@$(INFO) running end-to-end tests
 	@$(INFO) Skipping long running tests
 	go test -gcflags="all=-N -l" -c -v  $(PROJECT_REPO)/test/e2e/ -tags=e2e -o ./test/e2e/test-acceptance-debug.test -timeout 30m
-	dlv exec ./test/e2e/test-acceptance-debug.test --wd ./test/e2e/ --headless --listen=:2345 --log --api-version=2 --accept-multiclient -- -test.short -test.count=1 -test.v -test.run '^$(testFilter)$$'; EXIT_CODE=$$?; rm ./test/e2e/test-acceptance-debug.test; exit $$EXIT_CODE
+	dlv exec ./test/e2e/test-acceptance-debug.test --wd ./test/e2e/ --headless --listen=:2345 --log --api-version=2 --accept-multiclient -- -test.count=1 -test.v -test.run '^$(testFilter)$$'; EXIT_CODE=$$?; rm ./test/e2e/test-acceptance-debug.test; exit $$EXIT_CODE
 	@$(OK) end-to-end tests passed
 
 .PHONY: generate-test-crs

--- a/README.md
+++ b/README.md
@@ -97,6 +97,20 @@ make test-acceptance testFilter=<functionNameOfTest>
 > [!WARNING]
 > Please be aware that as part of the e2e tests a script will be executed which injects the environment configuration (see below) into the test data. Therefor you will see a lot of changes in the directory `test/e2e/testdata`after running the command. Make sure to not commit those changes into git.
 
+#### Long-Running Tests
+
+Some tests (e.g. Kyma environment, service binding rotation) are excluded from `make test-acceptance` because they can take 10 minutes or more. These tests carry the `e2e_long` build tag and must be run explicitly:
+
+```bash
+make test-e2e-long testFilter=<functionNameOfTest>
+```
+
+To run the full long-running suite, omit the filter:
+
+```bash
+make test-e2e-long
+```
+
 Please note that when running multiple times you might want to delete the kind cluster again to avoid conflicts:
 
 ```bash

--- a/test/e2e/directory_test.go
+++ b/test/e2e/directory_test.go
@@ -133,10 +133,6 @@ func createK8sResources(ctx context.Context, t *testing.T, cfg *envconf.Config, 
 	}
 }
 
-func NewID(oldId string, buildId string) string {
-	return buildId + "-" + oldId
-}
-
 // TestDirectoryImport tests importing an existing Directory resource using external-name annotation
 // Uses ImportTester utility to follow the standard import test pattern
 func TestDirectoryImport(t *testing.T) {

--- a/test/e2e/entitlement_test.go
+++ b/test/e2e/entitlement_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	meta "github.com/sap/crossplane-provider-btp/apis"
 	"github.com/sap/crossplane-provider-btp/apis/account/v1alpha1"
+	entApi "github.com/sap/crossplane-provider-btp/apis/account/v1alpha1"
+	"github.com/sap/crossplane-provider-btp/internal"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
@@ -80,6 +82,9 @@ func TestEntitlements(t *testing.T) {
 										func(object k8s.Object) bool {
 											entlmt := object.(*v1alpha1.Entitlement)
 											expectedAmount := expectedAssignAmount(ctx, cfg, entlmt.Spec.ForProvider.ServiceName)
+
+											logAwaitedDiff(expectedAmount, entlmt.Status.AtProvider.Assigned)
+
 											if entlmt.Status.AtProvider.Assigned == nil {
 												return false
 											}
@@ -89,7 +94,7 @@ func TestEntitlements(t *testing.T) {
 											}
 											return true
 										},
-										wait.WithTimeout(time.Second*90),
+										wait.WithTimeout(time.Minute*3),
 									)
 								}
 								return ctx
@@ -180,4 +185,16 @@ func newEntitlementResource(cfg *envconf.Config, entitlementName string) *v1alph
 			Name: entitlementName, Namespace: cfg.Namespace(),
 		},
 	}
+}
+
+func logAwaitedDiff(expected int, assignable *entApi.Assignable) {
+	amount := "nil"
+	if assignable != nil {
+		amount = fmt.Sprintf("%v", internal.Val(assignable.Amount))
+	}
+	klog.V(4).Infof(
+		"Checking Diff on Amount: Expected %v, Got %v",
+		expected,
+		amount,
+	)
 }

--- a/test/e2e/import_utils_test.go
+++ b/test/e2e/import_utils_test.go
@@ -1,4 +1,4 @@
-//go:build e2e
+//go:build e2e || e2e_long
 
 package e2e
 

--- a/test/e2e/kyma_env_test.go
+++ b/test/e2e/kyma_env_test.go
@@ -1,5 +1,4 @@
-//go:build e2e
-// +build e2e
+//go:build e2e_long
 
 package e2e
 
@@ -24,10 +23,6 @@ import (
 )
 
 func TestKymaEnvironment(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping kyma in short mode")
-		return
-	}
 	var manifestDir = "testdata/crs/kyma_env"
 	crudFeature := features.New("BTP Kyma Environment Controller").
 		Setup(
@@ -66,11 +61,6 @@ func TestKymaEnvironment(t *testing.T) {
 }
 
 func TestKymaEnvironmentImportFlow(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping kyma import in short mode")
-		return
-	}
-
 	kymaImportName := "e2e-kyma-import-test"
 
 	importTester := NewImportTester(

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -1,4 +1,4 @@
-//go:build e2e
+//go:build e2e || e2e_long
 
 package e2e
 

--- a/test/e2e/resource_utils.go
+++ b/test/e2e/resource_utils.go
@@ -1,5 +1,4 @@
-//go:build e2e
-// +build e2e
+//go:build e2e || e2e_long
 
 package e2e
 
@@ -28,6 +27,10 @@ type mockList struct {
 	client.ObjectList
 
 	Items []k8s.Object
+}
+
+func NewID(oldId string, buildId string) string {
+	return buildId + "-" + oldId
 }
 
 func waitForResource(res k8s.Object, cfg *envconf.Config, t *testing.T, opts ...wait.Option) {

--- a/test/e2e/servicebinding_rotation_test.go
+++ b/test/e2e/servicebinding_rotation_test.go
@@ -1,5 +1,4 @@
-//go:build e2e
-// +build e2e
+//go:build e2e_long
 
 package e2e
 
@@ -26,11 +25,6 @@ var (
 
 func TestServiceBinding_RotationLifecycle(t *testing.T) {
 	// When watchting the test, it took around 600s (10 min). So for now only running it if in "long mode"
-	if testing.Short() {
-		t.Skip("skipping rotation tests in short mode - use 'make e2e-long' to run rotation tests")
-		return
-	}
-
 	rotationLifecycleFeature := features.New("ServiceBinding Complete Rotation Lifecycle").
 		Setup(
 			func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {


### PR DESCRIPTION
Backport of #728 into `release/v1_10_x`

Relates to #726 
