### PR TITLE
fix: skip description on SubaccountTrustConfiguration to avoid inconsistent-result error (backport to v1_10_x)

### DIFF
--- a/apis/security/v1alpha1/zz_subaccounttrustconfiguration_types.go
+++ b/apis/security/v1alpha1/zz_subaccounttrustconfiguration_types.go
@@ -35,7 +35,7 @@ type SubaccountTrustConfigurationInitParameters struct {
 	// Determines that end users can choose the trust configuration for login. If not set, the trust configuration can remain active, however only application users that explicitly specify the origin key can use if for login.
 	AvailableForUserLogon *bool `json:"availableForUserLogon,omitempty" tf:"available_for_user_logon,omitempty"`
 
-	// (String) Description of the trust configuration.
+	// (String) Description of the trust configuration. NOTE: currently ignored due to an upstream bug (see #724); the BTP backend assigns its own default.
 	// Description of the trust configuration.
 	Description *string `json:"description,omitempty" tf:"description,omitempty"`
 
@@ -86,7 +86,7 @@ type SubaccountTrustConfigurationObservation struct {
 	// Determines that end users can choose the trust configuration for login. If not set, the trust configuration can remain active, however only application users that explicitly specify the origin key can use if for login.
 	AvailableForUserLogon *bool `json:"availableForUserLogon,omitempty" tf:"available_for_user_logon,omitempty"`
 
-	// (String) Description of the trust configuration.
+	// (String) Description of the trust configuration. NOTE: currently ignored due to an upstream bug (see #724); the BTP backend assigns its own default.
 	// Description of the trust configuration.
 	Description *string `json:"description,omitempty" tf:"description,omitempty"`
 
@@ -146,7 +146,7 @@ type SubaccountTrustConfigurationParameters struct {
 	// +kubebuilder:validation:Optional
 	AvailableForUserLogon *bool `json:"availableForUserLogon,omitempty" tf:"available_for_user_logon,omitempty"`
 
-	// (String) Description of the trust configuration.
+	// (String) Description of the trust configuration. NOTE: currently ignored due to an upstream bug (see #724); the BTP backend assigns its own default.
 	// Description of the trust configuration.
 	// +kubebuilder:validation:Optional
 	Description *string `json:"description,omitempty" tf:"description,omitempty"`

--- a/config/subaccount_trust_configuration/config.go
+++ b/config/subaccount_trust_configuration/config.go
@@ -1,14 +1,26 @@
 package subaccount_trust_configuration
 
 import (
+	"context"
+
+	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/upjet/pkg/config"
+	"github.com/pkg/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	securityv1alpha1 "github.com/sap/crossplane-provider-btp/apis/security/v1alpha1"
 )
+
+const errTypeAssertion = "managed resource is not of type SubaccountTrustConfiguration"
 
 // Configure configures individual resources by adding custom ResourceConfigurators.
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("btp_subaccount_trust_configuration", func(r *config.Resource) {
 		r.ShortGroup = "security"
 		r.Kind = "SubaccountTrustConfiguration"
+
+		applyDescriptionInconsistencyWorkaround(r)
 
 		r.References["subaccount_id"] = config.Reference{
 			Type:              "github.com/sap/crossplane-provider-btp/apis/account/v1alpha1.Subaccount",
@@ -18,4 +30,44 @@ func Configure(p *config.Provider) {
 		}
 
 	})
+}
+
+// applyDescriptionInconsistencyWorkaround works around an upstream bug in
+// terraform-provider-btp (see #724, fixed upstream in v1.23.1) that causes
+// SubaccountTrustConfiguration creation to fail with "Provider produced
+// inconsistent result after apply" when spec.forProvider.description is set.
+//
+// Registers an Initializer that nils spec.forProvider.description (and the
+// initProvider counterpart) in-process on every reconcile, before upjet
+// serializes the spec into main.tf.json. Terraform therefore plans against a
+// nil description; combined with Optional+Computed in the schema, the
+// BTP-computed value is accepted without a consistency violation. The change
+// is not persisted to the API server, so the user's spec value remains intact
+// and the workaround is transparent on removal. Also overrides the field's
+// ArgumentDocs to surface the limitation on the user-facing CR field.
+//
+// TODO: remove when terraform-provider-btp is bumped to >= 1.23.1 (#521).
+func applyDescriptionInconsistencyWorkaround(r *config.Resource) {
+	r.InitializerFns = append(r.InitializerFns, func(_ client.Client) managed.Initializer {
+		return &descriptionStripper{}
+	})
+	if r.MetaResource != nil && r.MetaResource.ArgumentDocs != nil {
+		r.MetaResource.ArgumentDocs["description"] = "(String) Description of the trust configuration. " +
+			"NOTE: currently ignored due to an upstream bug (see #724); the BTP backend assigns its own default."
+	}
+}
+
+// descriptionStripper is the Initializer registered by
+// applyDescriptionInconsistencyWorkaround. See that function's godoc for
+// rationale and removal conditions.
+type descriptionStripper struct{}
+
+func (descriptionStripper) Initialize(_ context.Context, mg resource.Managed) error {
+	cr, ok := mg.(*securityv1alpha1.SubaccountTrustConfiguration)
+	if !ok {
+		return errors.New(errTypeAssertion)
+	}
+	cr.Spec.ForProvider.Description = nil
+	cr.Spec.InitProvider.Description = nil
+	return nil
 }

--- a/internal/controller/security/subaccounttrustconfiguration/zz_controller.go
+++ b/internal/controller/security/subaccounttrustconfiguration/zz_controller.go
@@ -32,8 +32,8 @@ import (
 	"github.com/crossplane/upjet/pkg/controller/handler"
 	"github.com/crossplane/upjet/pkg/terraform"
 	"github.com/pkg/errors"
-	internalopts "github.com/sap/crossplane-provider-btp/internal/controller/options"
 	ctrl "sigs.k8s.io/controller-runtime"
+	internalopts "github.com/sap/crossplane-provider-btp/internal/controller/options"
 
 	v1alpha1 "github.com/sap/crossplane-provider-btp/apis/security/v1alpha1"
 	features "github.com/sap/crossplane-provider-btp/internal/features"

--- a/internal/controller/security/subaccounttrustconfiguration/zz_controller.go
+++ b/internal/controller/security/subaccounttrustconfiguration/zz_controller.go
@@ -32,8 +32,8 @@ import (
 	"github.com/crossplane/upjet/pkg/controller/handler"
 	"github.com/crossplane/upjet/pkg/terraform"
 	"github.com/pkg/errors"
-	ctrl "sigs.k8s.io/controller-runtime"
 	internalopts "github.com/sap/crossplane-provider-btp/internal/controller/options"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	v1alpha1 "github.com/sap/crossplane-provider-btp/apis/security/v1alpha1"
 	features "github.com/sap/crossplane-provider-btp/internal/features"
@@ -43,6 +43,9 @@ import (
 func Setup(mgr ctrl.Manager, o internalopts.UpjetOptions) error {
 	name := managed.ControllerName(v1alpha1.SubaccountTrustConfiguration_GroupVersionKind.String())
 	var initializers managed.InitializerChain
+	for _, i := range o.Provider.Resources["btp_subaccount_trust_configuration"].InitializerFns {
+		initializers = append(initializers, i(mgr.GetClient()))
+	}
 	cps := []managed.ConnectionPublisher{managed.NewAPISecretPublisher(mgr.GetClient(), mgr.GetScheme())}
 	if o.SecretStoreConfigGVK != nil {
 		cps = append(cps, connection.NewDetailsManager(mgr.GetClient(), *o.SecretStoreConfigGVK, connection.WithTLSConfig(o.ESSOptions.TLSConfig)))

--- a/package/crds/security.btp.sap.crossplane.io_subaccounttrustconfigurations.yaml
+++ b/package/crds/security.btp.sap.crossplane.io_subaccounttrustconfigurations.yaml
@@ -88,7 +88,7 @@ spec:
                     type: boolean
                   description:
                     description: |-
-                      (String) Description of the trust configuration.
+                      (String) Description of the trust configuration. NOTE: currently ignored due to an upstream bug (see #724); the BTP backend assigns its own default.
                       Description of the trust configuration.
                     type: string
                   domain:
@@ -223,7 +223,7 @@ spec:
                     type: boolean
                   description:
                     description: |-
-                      (String) Description of the trust configuration.
+                      (String) Description of the trust configuration. NOTE: currently ignored due to an upstream bug (see #724); the BTP backend assigns its own default.
                       Description of the trust configuration.
                     type: string
                   domain:
@@ -523,7 +523,7 @@ spec:
                     type: boolean
                   description:
                     description: |-
-                      (String) Description of the trust configuration.
+                      (String) Description of the trust configuration. NOTE: currently ignored due to an upstream bug (see #724); the BTP backend assigns its own default.
                       Description of the trust configuration.
                     type: string
                   domain:


### PR DESCRIPTION
Backport of #725 into `release/v1_10_x`

Relates to #724