### PR TITLE
fix(servicemanager): surface BTP error bodies in api_plan_resolver

### DIFF
--- a/internal/clients/servicemanager/api_plan_resolver.go
+++ b/internal/clients/servicemanager/api_plan_resolver.go
@@ -124,7 +124,7 @@ func (sm *ServiceManagerClient) PlanIDByName(ctx context.Context, offeringName, 
 
 	execute, _, err := sm.GetServiceOfferings(ctx).FieldQuery(offeringQuery).Execute()
 	if err != nil {
-		return "", err
+		return "", specifyAPIError(err)
 	}
 	if len(execute.Items) == 0 {
 		if dataCenter != "" {
@@ -136,7 +136,7 @@ func (sm *ServiceManagerClient) PlanIDByName(ctx context.Context, offeringName, 
 	planQuery := fmt.Sprintf("catalog_name eq '%s' and service_offering_id eq '%s'", planName, *execute.Items[0].Id)
 	object, _, err := sm.GetAllServicePlans(ctx).FieldQuery(planQuery).Execute()
 	if err != nil {
-		return "", err
+		return "", specifyAPIError(err)
 	}
 
 	if len(object.Items) == 0 {

--- a/internal/clients/servicemanager/errors.go
+++ b/internal/clients/servicemanager/errors.go
@@ -1,0 +1,25 @@
+package servicemanager
+
+import (
+	"fmt"
+
+	"github.com/sap/crossplane-provider-btp/internal"
+	smclient "github.com/sap/crossplane-provider-btp/internal/openapi_clients/btp-service-manager-api-go/pkg"
+)
+
+// specifyAPIError unwraps a *smclient.GenericOpenAPIError so the BTP-side message
+// (structured smclient.Error model when present, raw body otherwise) is surfaced
+// in the returned error. Non-OpenAPI errors are returned unchanged.
+func specifyAPIError(err error) error {
+	genericErr, ok := err.(*smclient.GenericOpenAPIError)
+	if !ok {
+		return err
+	}
+	if smErr, ok := genericErr.Model().(smclient.Error); ok {
+		return fmt.Errorf("API Error: %s, Description: %s", internal.Val(smErr.Error), internal.Val(smErr.Description))
+	}
+	if body := genericErr.Body(); len(body) > 0 {
+		return fmt.Errorf("API Error: %s", string(body))
+	}
+	return err
+}

--- a/internal/clients/servicemanager/errors_test.go
+++ b/internal/clients/servicemanager/errors_test.go
@@ -1,0 +1,81 @@
+package servicemanager
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"unsafe"
+
+	"github.com/sap/crossplane-provider-btp/internal"
+	smclient "github.com/sap/crossplane-provider-btp/internal/openapi_clients/btp-service-manager-api-go/pkg"
+	"github.com/stretchr/testify/assert"
+)
+
+// newSMOpenAPIError builds a *smclient.GenericOpenAPIError with model/body set
+// via reflection, since the struct fields are unexported in the generated client.
+func newSMOpenAPIError(model any, body []byte, msg string) *smclient.GenericOpenAPIError {
+	e := &smclient.GenericOpenAPIError{}
+	v := reflect.ValueOf(e).Elem()
+
+	if model != nil {
+		f := v.FieldByName("model")
+		reflect.NewAt(f.Type(), unsafe.Pointer(f.UnsafeAddr())).Elem().Set(reflect.ValueOf(model))
+	}
+	if body != nil {
+		f := v.FieldByName("body")
+		reflect.NewAt(f.Type(), unsafe.Pointer(f.UnsafeAddr())).Elem().SetBytes(body)
+	}
+	if msg != "" {
+		f := v.FieldByName("error")
+		reflect.NewAt(f.Type(), unsafe.Pointer(f.UnsafeAddr())).Elem().SetString(msg)
+	}
+	return e
+}
+
+func TestSpecifyAPIError(t *testing.T) {
+	tests := []struct {
+		name string
+		in   error
+		want string
+	}{
+		{
+			name: "nil passes through",
+			in:   nil,
+			want: "",
+		},
+		{
+			name: "non-OpenAPI error passes through",
+			in:   errors.New("plain transport error"),
+			want: "plain transport error",
+		},
+		{
+			name: "structured model surfaces error and description",
+			in: newSMOpenAPIError(
+				smclient.Error{Error: internal.Ptr("BadRequest"), Description: internal.Ptr("plan not found")},
+				nil,
+				"400 Bad Request",
+			),
+			want: "API Error: BadRequest, Description: plan not found",
+		},
+		{
+			name: "raw body fallback when no model",
+			in:   newSMOpenAPIError(nil, []byte(`{"error":"Unauthorized"}`), "401 Unauthorized"),
+			want: `API Error: {"error":"Unauthorized"}`,
+		},
+		{
+			name: "no model, no body returns original",
+			in:   newSMOpenAPIError(nil, nil, "503 Service Unavailable"),
+			want: "503 Service Unavailable",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := specifyAPIError(tc.in)
+			if tc.in == nil {
+				assert.NoError(t, got)
+				return
+			}
+			assert.EqualError(t, got, tc.want)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `PlanIDByName` in `internal/clients/servicemanager/api_plan_resolver.go` returned the bare transport error from `GetServiceOfferings` and `GetAllServicePlans`, hiding the BTP-side message carried in `*smclient.GenericOpenAPIError`. Both call-sites now route through a new SM-flavoured `specifyAPIError` helper.
- New `internal/clients/servicemanager/errors.go` mirrors the subaccount helper landed in #716: prefer the structured `smclient.Error` model, fall back to raw body, otherwise return the original error untouched. The helper lives in its own file (not next to `PlanIDByName`) so PR5 (`service_instance_proxy_client.go`, same package) can reuse it without an import cycle or a copy.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race -count=1 ./internal/clients/servicemanager/...` — new `TestSpecifyAPIError` covers nil, non-OpenAPI passthrough, structured-model surfacing, raw-body fallback, and no-model/no-body passthrough.
- [x] `gofmt -l internal/clients/servicemanager/` clean.