### PR TITLE
fix: deprecate KymaEnvironmentBindingId and remove broken reference resolver

### DIFF
--- a/apis/environment/v1alpha1/kymamodule_types.go
+++ b/apis/environment/v1alpha1/kymamodule_types.go
@@ -38,9 +38,8 @@ type KymaModuleParameters struct {
 type KymaModuleSpec struct {
 	xpv1.ResourceSpec `json:",inline"`
 	ForProvider       KymaModuleParameters `json:"forProvider"`
-	// +crossplane:generate:reference:type=github.com/sap/crossplane-provider-btp/apis/environment/v1alpha1.KymaEnvironmentBinding
-	// +crossplane:generate:reference:refFieldName=KymaEnvironmentBindingRef
-	// +crossplane:generate:reference:selectorFieldName=KymaEnvironmentBindingSelector
+	// Deprecated: This id is not required anymore, will be ignored
+	// +kubebuilder:validation:Optional
 	KymaEnvironmentBindingId string `json:"kymaEnvironmentBindingId,omitempty"`
 	// +kubebuilder:validation:Optional
 	KymaEnvironmentBindingSelector *xpv1.Selector `json:"kymaEnvironmentBindingSelector,omitempty"`

--- a/apis/environment/v1alpha1/zz_generated.resolvers.go
+++ b/apis/environment/v1alpha1/zz_generated.resolvers.go
@@ -268,23 +268,6 @@ func (mg *KymaModule) ResolveReferences(ctx context.Context, c client.Reader) er
 	var err error
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
-		CurrentValue: mg.Spec.KymaEnvironmentBindingId,
-		Extract:      reference.ExternalName(),
-		Namespace:    mg.GetNamespace(),
-		Reference:    mg.Spec.KymaEnvironmentBindingRef,
-		Selector:     mg.Spec.KymaEnvironmentBindingSelector,
-		To: reference.To{
-			List:    &KymaEnvironmentBindingList{},
-			Managed: &KymaEnvironmentBinding{},
-		},
-	})
-	if err != nil {
-		return errors.Wrap(err, "mg.Spec.KymaEnvironmentBindingId")
-	}
-	mg.Spec.KymaEnvironmentBindingId = rsp.ResolvedValue
-	mg.Spec.KymaEnvironmentBindingRef = rsp.ResolvedReference
-
-	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: mg.Spec.KymaEnvironmentBindingSecret,
 		Extract:      KymaEnvironmentBindingSecret(),
 		Namespace:    mg.GetNamespace(),

--- a/package/crds/environment.btp.sap.crossplane.io_kymamodules.yaml
+++ b/package/crds/environment.btp.sap.crossplane.io_kymamodules.yaml
@@ -95,6 +95,8 @@ spec:
                 - name
                 type: object
               kymaEnvironmentBindingId:
+                description: 'Deprecated: This id is not required anymore, will be
+                  ignored'
                 type: string
               kymaEnvironmentBindingRef:
                 description: A Reference to a named object.


### PR DESCRIPTION
## Summary

Fixes #727

- Removes the `+crossplane:generate:reference` annotations from `KymaEnvironmentBindingId` in `KymaModuleSpec`, which were missing the required extractor and caused the resource to fail during init due to a broken cross-reference resolution
- Marks the field as `Deprecated` — it is no longer needed; use `kymaEnvironmentBindingSecret` and `kymaEnvironmentBindingSecretNamespace` instead
- Removes the broken resolver block from `zz_generated.resolvers.go` (regenerated)


## Test plan

- [x] run e2e_long tests and verify they are fixed by this