### PR TITLE
fix: use secrets: inherit in release workflow to access environment secrets

### DIFF
--- a/.github/workflows/custom-upgrade-test.yaml
+++ b/.github/workflows/custom-upgrade-test.yaml
@@ -54,6 +54,7 @@ jobs:
   custom-upgrade-test:
     runs-on: ubuntu-latest
     needs: prepare-matrix
+    environment: pr-e2e-no-approval
     strategy:
       fail-fast: false
       matrix:
@@ -113,6 +114,7 @@ jobs:
 
   cleanup-custom-upgrade-test:
     runs-on: ubuntu-latest
+    environment: pr-e2e-no-approval
     needs: [prepare-matrix, custom-upgrade-test]
     if: always() && needs.prepare-matrix.result == 'success'
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,14 +44,7 @@ jobs:
       - run-make-reviewable-and-check-diff
       with:
         environment: pr-e2e-no-approval
-      secrets:
-        CLI_SERVER_URL: ${{ secrets.CLI_SERVER_URL }}
-        GLOBAL_ACCOUNT: ${{ secrets.GLOBAL_ACCOUNT }}
-        IDP_URL: ${{ secrets.IDP_URL }}
-        SECOND_DIRECTORY_ADMIN_EMAIL: ${{ secrets.SECOND_DIRECTORY_ADMIN_EMAIL }}
-        CIS_CENTRAL_BINDING: ${{ secrets.CIS_CENTRAL_BINDING }}
-        BTP_TECHNICAL_USER: ${{ secrets.BTP_TECHNICAL_USER }}
-        TECHNICAL_USER_EMAIL: ${{ secrets.TECHNICAL_USER_EMAIL }}
+      secrets: inherit
       permissions:
         contents: read
 

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -33,7 +33,7 @@ on:
 jobs:
   upgrade-test:
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
+    environment: pr-e2e-no-approval
     env:
       # hardcoded BTP CLI version
       btp_cli_version: 2.90.2


### PR DESCRIPTION
## Summary
- use `secrets: inherit` for e2e tests triggered from release action
- fix using hardcoded environment in upgrade test actions (base and custom) (wasn't actually passed before)

## Tested 
- [x] Base Upgrade tests pass triggered from this branch (see [run](https://github.com/SAP/crossplane-provider-btp/actions/runs/28093257980/job/83176265511))
- [x] Custom Upgrade tests pass triggered from this branch (see [run](https://github.com/SAP/crossplane-provider-btp/actions/runs/28093918594/job/83178500067))
  - one test failed, but due to another bug unrelated to pipelines, created https://github.com/SAP/crossplane-provider-btp/issues/746 to keep track.
- Release flow will be tested once merged to release branch