### PR TITLE
fix(ci): bump long e2e job step timeout from 180m to 260m

### DIFF
--- a/.github/workflows/cron_long_e2e_test.yaml
+++ b/.github/workflows/cron_long_e2e_test.yaml
@@ -59,7 +59,9 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y gettext
 
       - name: Run long e2e test
-        timeout-minutes: 180
+        # Must exceed Go -timeout in `make test-e2e-long` (currently 240m) so
+        # t.Cleanup gets to run before the runner SIGKILLs the job.
+        timeout-minutes: 260
         run: |
           if [ -n "${{ github.event.inputs.testFilter }}" ]; then
             make test-e2e-long testFilter=${{ github.event.inputs.testFilter }};


### PR DESCRIPTION
## Summary

Bumps the `Run long e2e test` step in `.github/workflows/cron_long_e2e_test.yaml` from `timeout-minutes: 180` to `260`, so the GitHub runner does not kill Go before its own `-timeout 240m` fires.

## Why

The cron Long E2E job had `timeout-minutes: 180` at the step level, but `make test-e2e-long` runs `go test ... -timeout 240m`. When tests ran long, the runner SIGKILLed Go at 180 min — before Go's own deadline — so `t.Cleanup` never ran. That orphaned BTP resources in the test global account and is the root cause of the consecutive scheduled-on-main failures captured in `docs/development/flakiness-analysis.md`.

Bumping the step timeout to **260** gives Go its full 240-min budget plus a **20-min buffer** for `t.Cleanup` to finish.

## Changes

- `.github/workflows/cron_long_e2e_test.yaml`: step `timeout-minutes: 180` → `260`, plus a comment documenting the invariant (must exceed Go `-timeout` in `make test-e2e-long`).
- `Makefile`: **unchanged.** Go `-timeout 240m` stays — we want Go to fail tests cleanly first.

## Replaces #717

#717 bundled an unrelated subaccount change that was already landed via #716. This PR is the timeout fix only, rebased on current `main`.

## Test plan

- [ ] Validate at next scheduled cron run after merge, or trigger manually via `workflow_dispatch` to confirm a long run completes its cleanup before the step timeout fires.