### PR TITLE
fix: move subaccountRef inside forProvider in upgrade test data

### DIFF
--- a/test/upgrade/testdata/customCRs/subaccountApiCredentialExternalName/subaccountapicredential.yaml
+++ b/test/upgrade/testdata/customCRs/subaccountApiCredentialExternalName/subaccountapicredential.yaml
@@ -10,5 +10,5 @@ spec:
   forProvider:
     name: $BUILD_ID-upgrade-test-extn-sac
     readOnly: true
-  subaccountRef:
-    name: upgrade-test-extn-sa
+    subaccountRef:
+      name: upgrade-test-extn-sa


### PR DESCRIPTION
relates to #746 

## Problem
There was some indention error in the crs of the upgrade test.

## Scope
Fixes the issue for the release branch.