### PR TITLE
fix: skip ResourceUsage tracking when MR is being deleted

### DIFF
--- a/internal/controller/account/cloudmanagement/cloudmanagement.go
+++ b/internal/controller/account/cloudmanagement/cloudmanagement.go
@@ -67,8 +67,14 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 		return nil, errors.Wrap(err, errTrackPCUsage)
 	}
 
-	if err := c.resourcetracker.Track(ctx, mg); err != nil {
-		return nil, errors.Wrap(err, errTrackRUsage)
+	// Skip ResourceUsage tracking when the MR is being deleted: Track() walks
+	// references and Gets each upstream MR; if any was deleted out from under
+	// us, that Get returns NotFound and Connect would abort before Delete()
+	// runs, leaving the BTP-side instance and the finalizer in place forever.
+	if !meta.WasDeleted(mg) {
+		if err := c.resourcetracker.Track(ctx, mg); err != nil {
+			return nil, errors.Wrap(err, errTrackRUsage)
+		}
 	}
 
 	if cr.Spec.ForProvider.ServiceManagerSecret == "" || cr.Spec.ForProvider.ServiceManagerSecretNamespace == "" {

--- a/internal/controller/account/cloudmanagement/cloudmanagement_test.go
+++ b/internal/controller/account/cloudmanagement/cloudmanagement_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sap/crossplane-provider-btp/internal"
 	cmclient "github.com/sap/crossplane-provider-btp/internal/clients/cis"
 	"github.com/sap/crossplane-provider-btp/internal/clients/servicemanager"
+	"github.com/sap/crossplane-provider-btp/internal/testutils"
 	test2 "github.com/sap/crossplane-provider-btp/internal/tracking/test"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -268,6 +269,60 @@ func TestConnect(t *testing.T) {
 				t.Errorf("\ne.Observe(): expected cr after operation -want, +got:\n%s\n", diff)
 			}
 		})
+	}
+}
+
+// TestConnect_SkipTrackingWhenDeleted is a regression test for the case where
+// a CloudManagement MR is being deleted and its referenced ServiceManager MR
+// has already been removed from the cluster. Before the fix, Connect() would
+// abort with "cannot track ResourceUsage: servicemanager … not found", which
+// kept Delete() from ever running — leaving the BTP-side CIS instance and the
+// finalizer in place forever.
+func TestConnect_SkipTrackingWhenDeleted(t *testing.T) {
+	now := metav1.Now()
+	cr := NewCloudManagement("test",
+		WithData(v1beta1.CloudManagementParameters{
+			ServiceManagerSecretNamespace: "someNamespace",
+			ServiceManagerSecret:          "someSecret",
+		}),
+	)
+	cr.SetDeletionTimestamp(&now)
+
+	tracker := testutils.NewResourceTrackerMockWithError(errors.New("servicemanager … not found"))
+
+	uua := &connector{
+		kube: &test.MockClient{
+			MockGet:          test.NewMockGetFn(nil),
+			MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
+		},
+		usage:           test2.NoOpLegacyTracker{},
+		resourcetracker: tracker,
+		newPlanIdResolverFn: func(ctx context.Context, secretData map[string][]byte) (servicemanager.PlanIdResolver, error) {
+			return PlanIDFake{
+				func(ctx context.Context, offeringName string, servicePlanName string, dataCenter string) (string, error) {
+					return "planID", nil
+				},
+			}, nil
+		},
+		newClientInitalizerFn: func() cmclient.ITfClientInitializer {
+			return &ClientInitializerFake{
+				ConnectResourcesFn: func(ctx context.Context, cr *v1beta1.CloudManagement) (cmclient.ITfClient, error) {
+					return &TfClientFake{}, nil
+				},
+			}
+		},
+	}
+
+	_, err := uua.Connect(context.TODO(), cr)
+
+	// The Track error must NOT bubble up — Connect should skip Track when the
+	// MR is being deleted. Other errors past that point (secret resolution,
+	// client init, …) are independently exercised by TestConnect's other cases.
+	if err != nil && errors.Cause(err).Error() == "servicemanager … not found" {
+		t.Fatalf("Connect returned the tracking error during deletion: %v", err)
+	}
+	if tracker.TrackCalled {
+		t.Errorf("expected Track() to be skipped during deletion, but it was called")
 	}
 }
 

--- a/internal/controller/account/servicebinding/servicebinding.go
+++ b/internal/controller/account/servicebinding/servicebinding.go
@@ -89,9 +89,15 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 		return nil, errors.New(errNotServiceBinding)
 	}
 
-	// Track resource references for dependency management
-	if err := c.resourcetracker.Track(ctx, cr); err != nil {
-		return nil, errors.Wrap(err, "cannot track resource references")
+	// Track resource references for dependency management. Skip when the MR is
+	// being deleted: Track() walks references and Gets each upstream MR; if any
+	// was deleted out from under us, that Get returns NotFound and Connect
+	// would abort before Delete() runs, leaving the BTP-side binding and the
+	// finalizer in place forever.
+	if !meta.WasDeleted(cr) {
+		if err := c.resourcetracker.Track(ctx, cr); err != nil {
+			return nil, errors.Wrap(err, "cannot track resource references")
+		}
 	}
 
 	var targetName string

--- a/internal/controller/account/serviceinstance/serviceinstance.go
+++ b/internal/controller/account/serviceinstance/serviceinstance.go
@@ -99,8 +99,14 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 	if !ok {
 		return nil, errors.New(errNotServiceInstance)
 	}
-	if err := c.resourcetracker.Track(ctx, mg); err != nil {
-		return nil, errors.Wrap(err, errTrackRUsage)
+	// Skip ResourceUsage tracking when the MR is being deleted: Track() walks
+	// references and Gets each upstream MR; if any was deleted out from under
+	// us, that Get returns NotFound and Connect would abort before Delete()
+	// runs, leaving the BTP-side instance and the finalizer in place forever.
+	if !meta.WasDeleted(mg) {
+		if err := c.resourcetracker.Track(ctx, mg); err != nil {
+			return nil, errors.Wrap(err, errTrackRUsage)
+		}
 	}
 
 	// we need to resolve the plan ID here, since at crossplanes initialize stage the required references for the sm secret are not resolved yet

--- a/internal/controller/account/serviceinstance/serviceinstance_test.go
+++ b/internal/controller/account/serviceinstance/serviceinstance_test.go
@@ -108,6 +108,32 @@ func TestConnect_ResourceTracking(t *testing.T) {
 				trackCalled: true,
 			},
 		},
+		"SkipTrackingWhenDeleted": {
+			// Regression: an MR being deleted whose upstream reference has
+			// already been removed used to fail Connect() with a "not found"
+			// from Track(), which prevented Delete() from ever running and
+			// left the BTP-side instance and the finalizer in place forever.
+			reason: "should skip Track when the MR is being deleted, even if Track would error",
+			fields: fields{
+				creator:         &TfProxyClientCreatorMock{},
+				initializer:     &InitializerMock{},
+				resourcetracker: testutils.NewResourceTrackerMockWithError(errTracking),
+			},
+			args: args{
+				mg: func() *v1alpha1.ServiceInstance {
+					now := metav1.Now()
+					return &v1alpha1.ServiceInstance{
+						ObjectMeta: metav1.ObjectMeta{
+							DeletionTimestamp: &now,
+						},
+					}
+				}(),
+			},
+			want: want{
+				err:         nil,
+				trackCalled: false,
+			},
+		},
 	}
 
 	for name, tc := range cases {

--- a/internal/controller/account/servicemanager/servicemanager.go
+++ b/internal/controller/account/servicemanager/servicemanager.go
@@ -52,8 +52,14 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 	if !ok {
 		return nil, errors.New(errNotServiceManager)
 	}
-	if err := c.resourcetracker.Track(ctx, mg); err != nil {
-		return nil, errors.Wrap(err, errTrack)
+	// Skip ResourceUsage tracking when the MR is being deleted: Track() walks
+	// references and Gets each upstream MR; if any was deleted out from under
+	// us, that Get returns NotFound and Connect would abort before Delete()
+	// runs, leaving the BTP-side instance and the finalizer in place forever.
+	if !meta.WasDeleted(mg) {
+		if err := c.resourcetracker.Track(ctx, mg); err != nil {
+			return nil, errors.Wrap(err, errTrack)
+		}
 	}
 
 	if err := c.InitializeServicePlanId(ctx, cr); err != nil {

--- a/internal/controller/account/servicemanager/servicemanager_test.go
+++ b/internal/controller/account/servicemanager/servicemanager_test.go
@@ -24,6 +24,9 @@ var (
 	errTracking = errors.New("trackingError")
 )
 
+// ptrTime returns a pointer to a metav1.Time for use as DeletionTimestamp in tests.
+func ptrTime(t metav1.Time) *metav1.Time { return &t }
+
 // ====================================================================================
 // Resource Tracking Tests
 // ====================================================================================
@@ -111,6 +114,45 @@ func TestConnect_ResourceTracking(t *testing.T) {
 			want: want{
 				err:         nil,
 				trackCalled: true,
+			},
+		},
+		"SkipTrackingWhenDeleted": {
+			// Regression: an MR being deleted whose upstream reference has
+			// already been removed used to fail Connect() with a "not found"
+			// from Track(), which prevented Delete() from ever running and
+			// left the BTP-side instance and the finalizer in place forever.
+			reason: "should skip Track when the MR is being deleted, even if Track would error",
+			fields: fields{
+				resourcetracker: testutils.NewResourceTrackerMockWithError(errTracking),
+				newPlanIdInitializerFn: func(ctx context.Context, cr *apisv1beta1.ServiceManager) (ServiceManagerPlanIdInitializer, error) {
+					return &PlanIdInitializerMock{}, nil
+				},
+				newClientInitalizerFn: func() sm.ITfClientInitializer {
+					return &TfClientInitializerMock{}
+				},
+			},
+			args: args{
+				mg: &apisv1beta1.ServiceManager{
+					ObjectMeta: metav1.ObjectMeta{
+						DeletionTimestamp: ptrTime(metav1.Now()),
+					},
+					Spec: apisv1beta1.ServiceManagerSpec{
+						ForProvider: apisv1beta1.ServiceManagerParameters{
+							SubaccountGuid: "test-guid",
+						},
+					},
+					Status: apisv1beta1.ServiceManagerStatus{
+						AtProvider: apisv1beta1.ServiceManagerObservation{
+							DataSourceLookup: &apisv1beta1.DataSourceLookup{
+								ServiceManagerPlanID: "plan-id",
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				err:         nil,
+				trackCalled: false,
 			},
 		},
 	}

--- a/internal/controller/account/subscription/subscription.go
+++ b/internal/controller/account/subscription/subscription.go
@@ -83,8 +83,14 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 		return nil, errors.Wrap(err, errTrackPCUsage)
 	}
 
-	if err := c.resourcetracker.Track(ctx, mg); err != nil {
-		return nil, errors.Wrap(err, errTrackRUsage)
+	// Skip ResourceUsage tracking when the MR is being deleted: Track() walks
+	// references and Gets each upstream MR; if any was deleted out from under
+	// us, that Get returns NotFound and Connect would abort before Delete()
+	// runs, leaving the BTP-side subscription and the finalizer in place forever.
+	if !meta.WasDeleted(mg) {
+		if err := c.resourcetracker.Track(ctx, mg); err != nil {
+			return nil, errors.Wrap(err, errTrackRUsage)
+		}
 	}
 
 	secretName := cr.Spec.CloudManagementSecret

--- a/internal/controller/environment/cloudfoundry/cfenvironment.go
+++ b/internal/controller/environment/cloudfoundry/cfenvironment.go
@@ -72,8 +72,14 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 		return nil, errors.Wrap(err, errTrackPCUsage)
 	}
 
-	if err := c.resourcetracker.Track(ctx, mg); err != nil {
-		return nil, errors.Wrap(err, errTrackRUsage)
+	// Skip ResourceUsage tracking when the MR is being deleted: Track() walks
+	// references and Gets each upstream MR; if any was deleted out from under
+	// us, that Get returns NotFound and Connect would abort before Delete()
+	// runs, leaving the CF environment and the finalizer in place forever.
+	if !meta.WasDeleted(mg) {
+		if err := c.resourcetracker.Track(ctx, mg); err != nil {
+			return nil, errors.Wrap(err, errTrackRUsage)
+		}
 	}
 
 	if cr.Spec.CloudManagementSecret == "" || cr.Spec.CloudManagementSecretNamespace == "" {

--- a/internal/controller/environment/kyma/zz_connect.go
+++ b/internal/controller/environment/kyma/zz_connect.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/crossplane/crossplane-runtime/v2/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
 	"github.com/pkg/errors"
@@ -38,8 +39,14 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 		return nil, errors.Wrap(err, errTrackPCUsage)
 	}
 
-	if err := c.resourcetracker.Track(ctx, mg); err != nil {
-		return nil, errors.Wrap(err, errTrackRUsage)
+	// Skip ResourceUsage tracking when the MR is being deleted: Track() walks
+	// references and Gets each upstream MR; if any was deleted out from under
+	// us, that Get returns NotFound and Connect would abort before Delete()
+	// runs, leaving the BTP-side environment and the finalizer in place forever.
+	if !meta.WasDeleted(mg) {
+		if err := c.resourcetracker.Track(ctx, mg); err != nil {
+			return nil, errors.Wrap(err, errTrackRUsage)
+		}
 	}
 
 	if cr.Spec.CloudManagementSecret == "" || cr.Spec.CloudManagementSecretNamespace == "" {

--- a/internal/controller/kymaenvironmentbinding/zz_connect.go
+++ b/internal/controller/kymaenvironmentbinding/zz_connect.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/crossplane/crossplane-runtime/v2/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
 	"github.com/pkg/errors"
@@ -34,8 +35,14 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 		return nil, errors.Wrap(err, errTrackPCUsage)
 	}
 
-	if err := c.resourcetracker.Track(ctx, mg); err != nil {
-		return nil, errors.Wrap(err, errTrackRUsage)
+	// Skip ResourceUsage tracking when the MR is being deleted: Track() walks
+	// references and Gets each upstream MR; if any was deleted out from under
+	// us, that Get returns NotFound and Connect would abort before Delete()
+	// runs, leaving the BTP-side binding and the finalizer in place forever.
+	if !meta.WasDeleted(mg) {
+		if err := c.resourcetracker.Track(ctx, mg); err != nil {
+			return nil, errors.Wrap(err, errTrackRUsage)
+		}
 	}
 
 	if cr.Spec.CloudManagementSecret == "" || cr.Spec.CloudManagementSecretNamespace == "" {

--- a/internal/controller/kymamodule/kymamodule.go
+++ b/internal/controller/kymamodule/kymamodule.go
@@ -57,8 +57,14 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 		return nil, errors.New(errNotKymaModule)
 	}
 
-	if err := c.resourcetracker.Track(ctx, mg); err != nil {
-		return nil, errors.Wrap(err, errTrackRUsage)
+	// Skip ResourceUsage tracking when the MR is being deleted: Track() walks
+	// references and Gets each upstream MR; if any was deleted out from under
+	// us, that Get returns NotFound and Connect would abort before Delete()
+	// runs, leaving the Kyma module and the finalizer in place forever.
+	if !meta.WasDeleted(mg) {
+		if err := c.resourcetracker.Track(ctx, mg); err != nil {
+			return nil, errors.Wrap(err, errTrackRUsage)
+		}
 	}
 
 	secretfetcher := &SecretFetcher{

--- a/internal/controller/security/rolecollection/rolecollection.go
+++ b/internal/controller/security/rolecollection/rolecollection.go
@@ -75,8 +75,14 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 		return nil, errors.Wrap(err, errTrackPCUsage)
 	}
 
-	if err := c.resourcetracker.Track(ctx, mg); err != nil {
-		return nil, errors.Wrap(err, errTrackRCUsage)
+	// Skip ResourceUsage tracking when the MR is being deleted: Track() walks
+	// references and Gets each upstream MR; if any was deleted out from under
+	// us, that Get returns NotFound and Connect would abort before Delete()
+	// runs, leaving the role collection and the finalizer in place forever.
+	if !meta.WasDeleted(mg) {
+		if err := c.resourcetracker.Track(ctx, mg); err != nil {
+			return nil, errors.Wrap(err, errTrackRCUsage)
+		}
 	}
 
 	binding, err := v1alpha1.CreateBindingFromSource(&cr.Spec.XSUAACredentialsReference, ctx, c.kube)

--- a/internal/controller/security/rolecollectionassignment/rolecollectionassignment.go
+++ b/internal/controller/security/rolecollectionassignment/rolecollectionassignment.go
@@ -84,8 +84,14 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 		return nil, errors.Wrap(err, errTrackPCUsage)
 	}
 
-	if err := c.resourcetracker.Track(ctx, mg); err != nil {
-		return nil, errors.Wrap(err, errTrackRCUsage)
+	// Skip ResourceUsage tracking when the MR is being deleted: Track() walks
+	// references and Gets each upstream MR; if any was deleted out from under
+	// us, that Get returns NotFound and Connect would abort before Delete()
+	// runs, leaving the assignment and the finalizer in place forever.
+	if !meta.WasDeleted(mg) {
+		if err := c.resourcetracker.Track(ctx, mg); err != nil {
+			return nil, errors.Wrap(err, errTrackRCUsage)
+		}
 	}
 
 	binding, err := v1alpha1.CreateBindingFromSource(&cr.Spec.XSUAACredentialsReference, ctx, c.kube)


### PR DESCRIPTION
### What this fixes

When an MR is being deleted and one of its referenced upstream MRs has already been removed, `Connect()` aborts with:

> `connect failed: cannot track ResourceUsage: servicemanager.account.btp.sap.crossplane.io "sm-…" not found`

Because `Connect()` errors, `Delete()` is never called. The BTP-side resource stays alive, the Crossplane finalizer is never removed, and the MR is stuck on the cluster indefinitely. We hit this in canary with a `CloudManagement` MR after its `ServiceManager` was removed.

### The fix

Wrap each `resourcetracker.Track(ctx, mg)` call in `Connect()` with a `!meta.WasDeleted(mg)` guard. Applied to 11 controllers (`cloudmanagement`, `servicemanager`, `serviceinstance`, `servicebinding`, `subscription`, `rolecollection`, `rolecollectionassignment`, `kymamodule`, `kymaenvironmentbinding`, `environment/kyma`, `environment/cloudfoundry`).

### Why the guard is safe

`Track()` exists to *maintain* "we depend on X" `ResourceUsage` objects. During deletion we're tearing the dependency down, not strengthening it. Existing `ResourceUsage` records are owned by the MR with `BlockOwnerDeletion: false`, so they're garbage-collected by Kubernetes when the MR finally goes. The reverse direction ("we are depended upon by Y") is enforced by `DeleteShouldBeBlocked` reading the `InUse` condition (`internal/tracking/resourcetracker.go:303-308`), unchanged by this PR.

### Recovery for already-stuck CRs

Re-create the missing upstream MR with the existing external-name annotation so `Connect()` succeeds → `Delete()` fires → finalizer is removed.

### Tests

- Regression test `TestConnect_SkipTrackingWhenDeleted` in `cloudmanagement` reproducing the exact reported failure mode (Track set to return an error, MR with DeletionTimestamp → Connect must not propagate the error, and Track must not be called).
- `SkipTrackingWhenDeleted` cases added to existing `TestConnect_ResourceTracking` tables in `servicemanager` and `serviceinstance`.

### Note on generated files

Two of the patched files (`internal/controller/environment/kyma/zz_connect.go`, `internal/controller/kymaenvironmentbinding/zz_connect.go`) are upjet-generated. The same delete-loop bug occurs there, so the guard belongs in those files for now. A follow-up should push the pattern into the upjet template so it isn't lost on regeneration.

### Verification

- `go build ./...` clean
- `go vet ./...` clean
- `go test ./...` all green
