### PR TITLE
fix: don't use shared subaccount for api crdential upgrade test

### DIFF
--- a/test/upgrade/subaccount_api_credential_external_name_upgrade_test.go
+++ b/test/upgrade/subaccount_api_credential_external_name_upgrade_test.go
@@ -15,7 +15,6 @@ var (
 	sacFromCustomTag             = "v1.3.0"
 	sacToCustomTag               = "local"
 	sacCustomResourceDirectories = []string{
-		"./testdata/customCRs/subaccountExternalName",
 		"./testdata/customCRs/subaccountApiCredentialExternalName",
 	}
 )
@@ -31,7 +30,7 @@ var (
 // 2. After upgrade, the external-name is unchanged
 // 3. The resource remains healthy after upgrade
 func Test_SubaccountApiCredential_External_Name(t *testing.T) {
-	const sacName = "upgrade-test-extn-sac"
+	const sacName = "upgrade-test-extn-sa-api-credential"
 
 	upgradeTest := NewCustomUpgradeTest("subaccount-api-credential-external-name-test").
 		FromVersion(sacFromCustomTag).

--- a/test/upgrade/testdata/customCRs/subaccountApiCredentialExternalName/subaccount.yaml
+++ b/test/upgrade/testdata/customCRs/subaccountApiCredentialExternalName/subaccount.yaml
@@ -1,0 +1,15 @@
+apiVersion: account.btp.sap.crossplane.io/v1alpha1
+kind: Subaccount
+metadata:
+  namespace: default
+  name: upgrade-test-extn-sa-api-credential
+spec:
+  forProvider:
+    displayName: $BUILD_ID-upgrade-test-extn-sa-api-credential
+    region: eu10
+    subdomain: $BUILD_ID-upgrade-test-extn-sa-api-credential
+    labels:
+      safe-to-delete: [ "yes" ]
+      BUILD_ID: [ "$BUILD_ID" ]
+    subaccountAdmins:
+      - $TECHNICAL_USER_EMAIL

--- a/test/upgrade/testdata/customCRs/subaccountApiCredentialExternalName/subaccountapicredential.yaml
+++ b/test/upgrade/testdata/customCRs/subaccountApiCredentialExternalName/subaccountapicredential.yaml
@@ -1,14 +1,14 @@
 apiVersion: security.btp.sap.crossplane.io/v1alpha1
 kind: SubaccountApiCredential
 metadata:
-  name: upgrade-test-extn-sac
+  name: upgrade-test-extn-sa-api-credential
   namespace: default
 spec:
   writeConnectionSecretToRef:
-    name: upgrade-test-extn-sac-secret
+    name: upgrade-test-extn-sa-api-credential-secret
     namespace: default
   forProvider:
-    name: $BUILD_ID-upgrade-test-extn-sac
+    name: $BUILD_ID-upgrade-test-extn-sa-api-credential
     readOnly: true
     subaccountRef:
-      name: upgrade-test-extn-sa
+      name: upgrade-test-extn-sa-api-credential


### PR DESCRIPTION
relates to #746 

## Problem
SubaccountApiCredential upgrade test is failing when running in parallel with subaccount upgrade tests.

## Solution
Don't share subaccount between them