### PR TITLE
ci: drop gettext install step from e2e workflows

### DIFF
--- a/.github/workflows/cron_long_e2e_test.yaml
+++ b/.github/workflows/cron_long_e2e_test.yaml
@@ -55,9 +55,6 @@ jobs:
         run: |
           echo "BUILD_ID=${{github.run_number}}-${{github.run_attempt}}" >> $GITHUB_ENV
 
-      - name: Install gettext for envsubst
-        run: sudo apt-get update && sudo apt-get install -y gettext
-
       - name: Run long e2e test
         timeout-minutes: 180
         run: |

--- a/.github/workflows/custom-upgrade-test.yaml
+++ b/.github/workflows/custom-upgrade-test.yaml
@@ -93,9 +93,6 @@ jobs:
         run: |
           echo "BUILD_ID=${{github.run_number}}-${{github.run_attempt}}" >> $GITHUB_ENV
 
-      - name: Install gettext for envsubst
-        run: sudo apt-get update && sudo apt-get install -y gettext
-
       - name: Run custom upgrade test
         timeout-minutes: 120
         run: |

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -352,9 +352,6 @@ jobs:
         run: |
           echo "BUILD_ID=${{github.run_number}}-${{github.run_attempt}}" >> $GITHUB_ENV
 
-      - name: Install gettext for envsubst
-        run: sudo apt-get update && sudo apt-get install -y gettext
-
       - name: Run e2e test
         timeout-minutes: 120
         run: |

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -82,9 +82,6 @@ jobs:
         run: |
           echo "BUILD_ID=${{github.run_number}}-${{github.run_attempt}}" >> $GITHUB_ENV
 
-      - name: Install gettext for envsubst
-        run: sudo apt-get update && sudo apt-get install -y gettext
-
       - name: Run upgrade test
         timeout-minutes: 120
         run: |


### PR DESCRIPTION
## Summary
- `envsubst` ships in `gettext-base`, which is preinstalled on the `ubuntu-24.04` runner image used by every `runs-on: ubuntu-latest` job in this repo, so the dedicated install step is dead weight.
- The step ran `sudo apt-get update && sudo apt-get install -y gettext`. `apt-get update` exits non-zero whenever any third-party apt source fails — recently seen as `403 Forbidden` against `packages.microsoft.com/repos/azure-cli`, almost certainly rate-limiting against GitHub-hosted runners. Because of `&&`, the install never runs and the whole step fails.
- Example: https://github.com/SAP/crossplane-provider-btp/actions/runs/28226470852/job/83627061013?pr=744
- Removing the step decouples e2e/upgrade jobs from external apt repos entirely. If a future runner image ever drops `gettext-base`, the test that calls `envsubst` will fail loudly with `command not found` — easy to spot.

Files touched:
- `.github/workflows/e2e_test.yaml`
- `.github/workflows/cron_long_e2e_test.yaml`
- `.github/workflows/upgrade-test.yaml`
- `.github/workflows/custom-upgrade-test.yaml`

## Test plan
- [ ] e2e workflow runs to completion on this PR without an install step
- [ ] `envsubst` is exercised somewhere in the e2e flow (sanity-checks the assumption that it is still preinstalled)