### PR TITLE
fix(cfenvironment): skip tech user when assigning initial org managers

### DIFF
--- a/apis/environment/v1alpha1/cfenvironment_types.go
+++ b/apis/environment/v1alpha1/cfenvironment_types.go
@@ -46,7 +46,7 @@ func (u *User) String() string {
 // CfEnvironmentParameters are the configurable fields of a CloudFoundryEnvironment.
 type CfEnvironmentParameters struct {
 	// A list of users (email) to assign as the Org Manager role.
-	// The technical user referenced in the ProviderConfig is automatically added as Org Manager and can be omitted from this list.
+	// The technical user referenced in the ProviderConfig is automatically added as Org Manager and can be omitted from this list (see https://help.sap.com/docs/btp/sap-business-technology-platform/about-roles-in-cloud-foundry-environment).
 	// Cannot be updated after creation --> initial creation only
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="OrgManagers can't be updated once set"
 	// +optional

--- a/apis/environment/v1alpha1/cfenvironment_types.go
+++ b/apis/environment/v1alpha1/cfenvironment_types.go
@@ -45,7 +45,8 @@ func (u *User) String() string {
 
 // CfEnvironmentParameters are the configurable fields of a CloudFoundryEnvironment.
 type CfEnvironmentParameters struct {
-	// A list of users (with username/email and origin) to assign as the Org Manager role.
+	// A list of users (email) to assign as the Org Manager role.
+	// The technical user referenced in the ProviderConfig is automatically added as Org Manager and can be omitted from this list.
 	// Cannot be updated after creation --> initial creation only
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="OrgManagers can't be updated once set"
 	// +optional

--- a/internal/clients/cfenvironment/cfenvironment.go
+++ b/internal/clients/cfenvironment/cfenvironment.go
@@ -162,6 +162,10 @@ func (c CloudFoundryOrganization) CreateInstance(ctx context.Context, cr v1alpha
 	}
 
 	for _, managerEmail := range cr.Spec.ForProvider.Managers {
+		if managerEmail == adminServiceAccountEmail {
+			// Skip adding the admin service account email as org manager since it's added by default during creation
+			continue
+		}
 		if err := cloudFoundryClient.addManager(ctx, managerEmail, defaultOrigin); err != nil {
 			return "", errors.Wrap(err, instanceCreateFailed)
 		}

--- a/internal/clients/cfenvironment/cfenvironment.go
+++ b/internal/clients/cfenvironment/cfenvironment.go
@@ -161,11 +161,7 @@ func (c CloudFoundryOrganization) CreateInstance(ctx context.Context, cr v1alpha
 		return "", errors.Wrap(err, instanceCreateFailed)
 	}
 
-	for _, managerEmail := range cr.Spec.ForProvider.Managers {
-		if managerEmail == adminServiceAccountEmail {
-			// Skip adding the admin service account email as org manager since it's added by default during creation
-			continue
-		}
+	for _, managerEmail := range filterOutUser(cr.Spec.ForProvider.Managers, adminServiceAccountEmail) {
 		if err := cloudFoundryClient.addManager(ctx, managerEmail, defaultOrigin); err != nil {
 			return "", errors.Wrap(err, instanceCreateFailed)
 		}
@@ -187,6 +183,16 @@ func FormOrgName(orgName string, subaccountId string, crName string) string {
 		return subaccountId + "-" + crName
 	}
 	return orgName
+}
+
+func filterOutUser(users []string, exclude string) []string {
+	result := make([]string, 0, len(users))
+	for _, u := range users {
+		if u != exclude {
+			result = append(result, u)
+		}
+	}
+	return result
 }
 
 type organizationClient struct {

--- a/internal/clients/cfenvironment/cfenvironment_test.go
+++ b/internal/clients/cfenvironment/cfenvironment_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -147,6 +148,48 @@ func TestCloudFoundryOrganization_LegacyFormatHandling(t *testing.T) {
 	actualOrgName := FormOrgName(cr.Spec.ForProvider.OrgName, cr.Spec.SubaccountGuid, cr.Name)
 	if actualOrgName != expectedOrgName {
 		t.Errorf("OrgName mismatch: got %v, want %v", actualOrgName, expectedOrgName)
+	}
+}
+
+func TestFilterOutUser(t *testing.T) {
+	tests := []struct {
+		name    string
+		users   []string
+		exclude string
+		want    []string
+	}{
+		{
+			name:    "TechUserInList_IsFiltered",
+			users:   []string{"other@example.com", "techuser@example.com", "another@example.com"},
+			exclude: "techuser@example.com",
+			want:    []string{"other@example.com", "another@example.com"},
+		},
+		{
+			name:    "TechUserNotInList_NoChange",
+			users:   []string{"other@example.com", "another@example.com"},
+			exclude: "techuser@example.com",
+			want:    []string{"other@example.com", "another@example.com"},
+		},
+		{
+			name:    "OnlyTechUser_ReturnsEmpty",
+			users:   []string{"techuser@example.com"},
+			exclude: "techuser@example.com",
+			want:    []string{},
+		},
+		{
+			name:    "EmptyList_ReturnsEmpty",
+			users:   []string{},
+			exclude: "techuser@example.com",
+			want:    []string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterOutUser(tt.users, tt.exclude)
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("filterOutUser() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/package/crds/environment.btp.sap.crossplane.io_cloudfoundryenvironments.yaml
+++ b/package/crds/environment.btp.sap.crossplane.io_cloudfoundryenvironments.yaml
@@ -168,7 +168,7 @@ spec:
                   initialOrgManagers:
                     description: |-
                       A list of users (email) to assign as the Org Manager role.
-                      The technical user referenced in the ProviderConfig is automatically added as Org Manager and can be omitted from this list.
+                      The technical user referenced in the ProviderConfig is automatically added as Org Manager and can be omitted from this list (see https://help.sap.com/docs/btp/sap-business-technology-platform/about-roles-in-cloud-foundry-environment).
                       Cannot be updated after creation --> initial creation only
                     items:
                       type: string

--- a/package/crds/environment.btp.sap.crossplane.io_cloudfoundryenvironments.yaml
+++ b/package/crds/environment.btp.sap.crossplane.io_cloudfoundryenvironments.yaml
@@ -167,7 +167,8 @@ spec:
                     type: string
                   initialOrgManagers:
                     description: |-
-                      A list of users (with username/email and origin) to assign as the Org Manager role.
+                      A list of users (email) to assign as the Org Manager role.
+                      The technical user referenced in the ProviderConfig is automatically added as Org Manager and can be omitted from this list.
                       Cannot be updated after creation --> initial creation only
                     items:
                       type: string


### PR DESCRIPTION
Do not add the user referenced in the `ProviderConfig` as Org Manager since it's already added when creating the `CloudFoundryEnvironment` (the creating user is added by default).

An alternative would be a filter function which I could test separately.