### PR TITLE
fix: pass secrets explicitly in release pipeline e2e call

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,14 @@ jobs:
       - run-make-reviewable-and-check-diff
       with:
         environment: pr-e2e-no-approval
-      secrets: inherit
+      secrets:
+        CLI_SERVER_URL: ${{ secrets.CLI_SERVER_URL }}
+        GLOBAL_ACCOUNT: ${{ secrets.GLOBAL_ACCOUNT }}
+        IDP_URL: ${{ secrets.IDP_URL }}
+        SECOND_DIRECTORY_ADMIN_EMAIL: ${{ secrets.SECOND_DIRECTORY_ADMIN_EMAIL }}
+        CIS_CENTRAL_BINDING: ${{ secrets.CIS_CENTRAL_BINDING }}
+        BTP_TECHNICAL_USER: ${{ secrets.BTP_TECHNICAL_USER }}
+        TECHNICAL_USER_EMAIL: ${{ secrets.TECHNICAL_USER_EMAIL }}
       permissions:
         contents: read
 


### PR DESCRIPTION
Passes secrets to e2e tests in release pipeline correctly. 

**Whats wrong?**
`secrets: inherit` does not work if secrets are explicitly defined as inputs in called action.