### PR TITLE
fix: pull latest state of workflows from main to releasebranch

### DIFF
--- a/.github/workflows/cron_long_e2e_test.yaml
+++ b/.github/workflows/cron_long_e2e_test.yaml
@@ -55,9 +55,6 @@ jobs:
         run: |
           echo "BUILD_ID=${{github.run_number}}-${{github.run_attempt}}" >> $GITHUB_ENV
 
-      - name: Install gettext for envsubst
-        run: sudo apt-get update && sudo apt-get install -y gettext
-
       - name: Run long e2e test
         timeout-minutes: 180
         run: |

--- a/.github/workflows/custom-upgrade-test.yaml
+++ b/.github/workflows/custom-upgrade-test.yaml
@@ -54,7 +54,7 @@ jobs:
   custom-upgrade-test:
     runs-on: ubuntu-latest
     needs: prepare-matrix
-    environment: pr-e2e-no-approval
+    environment: pr-e2e-approval
     strategy:
       fail-fast: false
       matrix:
@@ -93,9 +93,6 @@ jobs:
         run: |
           echo "BUILD_ID=${{github.run_number}}-${{github.run_attempt}}" >> $GITHUB_ENV
 
-      - name: Install gettext for envsubst
-        run: sudo apt-get update && sudo apt-get install -y gettext
-
       - name: Run custom upgrade test
         timeout-minutes: 120
         run: |
@@ -114,8 +111,8 @@ jobs:
 
   cleanup-custom-upgrade-test:
     runs-on: ubuntu-latest
-    environment: pr-e2e-no-approval
     needs: [prepare-matrix, custom-upgrade-test]
+    environment: pr-e2e-no-approval
     if: always() && needs.prepare-matrix.result == 'success'
     steps:
       - name: checkout repo

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -1,3 +1,5 @@
+# Runs e2e tests, potentially requiring approval based on the `environment` input.
+#
 # Enviroment variables/secrets that are needed
 # CLI_SERVER_URL contains the CLI server URL
 # GLOBAL_ACCOUNT contains the subdomain of the global account
@@ -11,7 +13,6 @@
 name: E2E Test
 
 on:
-  workflow_dispatch:
   workflow_call:
     inputs:
       checkout-ref:
@@ -24,27 +25,18 @@ on:
         default: 'pr-e2e-approval'
         required: false
         type: string
-    secrets:
-      CLI_SERVER_URL:
-        description: contains the CLI server URL
-        required: true
-      GLOBAL_ACCOUNT:
-        description: contains the subdomain of the global account
-        required: true
-      IDP_URL:
-        description: contains the URL of an IDP that can be connected to the global account
-        required: true
-      SECOND_DIRECTORY_ADMIN_EMAIL:
-        description: contains a second email (different from the technical user's email) for the directory
-        required: true
-      CIS_CENTRAL_BINDING:
-        description: contents from the service binding of a `cis-central` service
-        required: true
-      BTP_TECHNICAL_USER:
-        required: true
-      TECHNICAL_USER_EMAIL:
-        description: contains the email of the BTP_TECHNICAL_USER
-        required: true
+  workflow_dispatch:
+    inputs:
+      checkout-ref:
+        description: 'the ref for the repo checkout step (defaults to the dispatched ref when empty)'
+        default: ''
+        required: false
+        type: string
+      environment:
+        description: 'the environment to run in'
+        default: 'pr-e2e-approval'
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -53,59 +45,303 @@ env:
   # hardcoded BTP CLI version
   btp_cli_version: 2.90.2
   GO_VERSION: '1.25'
+  E2E_BUILD_REGISTRY: index.docker.io/e2e
+  E2E_PROVIDER_IMAGE: index.docker.io/e2e/provider-btp-amd64
+  CROSSPLANE_CLI_VERSION: v2.0.2
+  # renovate: datasource=helm depName=crossplane registryUrl=https://charts.crossplane.io/stable
+  CROSSPLANE_CHART_VERSION: '2.1.3'
+  # SHA256 of crossplane-2.1.3.tgz from upstream charts.crossplane.io/stable
+  # index.yaml's `digest:` field. Update on every Crossplane version bump.
+  CROSSPLANE_CHART_SHA256: '1059cc4b87167ba7e1b837a8e6bd787691bc9f84c5a29a7e91dbd0122086c682'
 
 jobs:
   prepare-matrix:
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
+    environment: ${{ inputs.environment }}  # approval here for the entire workflow, later jobs use no approval environment
     outputs:
       test-names: ${{ steps.set-matrix.outputs.test-names }}
     steps:
       - name: checkout repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           #use inputs.checkout-ref to be able to call it from a pull_request_target workflow, since there it needs to be github.event.pull_request.merge_commit_sha and not the default
           ref: ${{ inputs.checkout-ref }}
-          
+
       - name: Set matrix with test names
         id: set-matrix
         run: |
           echo "test-names=$(find test/e2e -name '*_test.go' | xargs grep -L 'go:build e2e_long' | xargs grep -oh -E 'func (Test[A-Za-z0-9_]+)\(t \*testing\.T\)' | sed 's/func //;s/(t \*testing.T)//' | jq -R . | jq -cs .)" >> $GITHUB_OUTPUT
 
       - name: Print test names
-        run: | 
+        run: |
           echo "Test names: ${{ steps.set-matrix.outputs.test-names }}"
+
+  # Pull and verify the Crossplane chart in a dedicated job so that an upstream
+  # CDN blip (charts.crossplane.io 403) does not waste the provider build setup
+  # and runs in parallel with `build` for faster wall-clock.
+  fetch-chart:
+    runs-on: ubuntu-latest
+    needs: prepare-matrix
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ inputs.checkout-ref }}
+
+      - name: Install Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        with:
+          version: v3.14.0
+
+      - name: Restore Crossplane chart cache
+        id: crossplane-chart-cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: .cache/charts
+          key: crossplane-chart-${{ env.CROSSPLANE_CHART_VERSION }}-${{ runner.os }}
+
+      - name: Pull Crossplane chart (with retry)
+        if: steps.crossplane-chart-cache.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          mkdir -p .cache/charts
+          retry() {
+            local n=1 max=5
+            until "$@"; do
+              if [ "$n" -ge "$max" ]; then
+                echo "::error::'$*' failed after $max attempts"
+                return 1
+              fi
+              echo "attempt $n failed; backing off $((n * 15))s..."
+              sleep "$((n * 15))"
+              n=$((n + 1))
+            done
+          }
+          retry helm pull crossplane \
+            --repo https://charts.crossplane.io/stable \
+            --version "${CROSSPLANE_CHART_VERSION}" \
+            --destination .cache/charts
+          ls -la .cache/charts
+
+      # Defense-in-depth against artifact poisoning (CodeQL alert #64). The `build`
+      # job's `helm pull` step is workflow-mutable; a malicious PR could rewrite
+      # it to upload a poisoned chart for matrix legs to install. Pinning the
+      # expected SHA256 (sourced from upstream charts.crossplane.io/stable
+      # index.yaml's `digest:` field) means a poisoned tarball fails the build
+      # before reaching matrix legs. Update the constant on every Crossplane
+      # version bump.
+      - name: Verify Crossplane chart integrity
+        run: |
+          set -euo pipefail
+          cd .cache/charts
+          EXPECTED="${CROSSPLANE_CHART_SHA256}"
+          ACTUAL="$(sha256sum "crossplane-${CROSSPLANE_CHART_VERSION}.tgz" | awk '{print $1}')"
+          if [ "$ACTUAL" != "$EXPECTED" ]; then
+            echo "::error::Crossplane chart SHA256 mismatch: expected $EXPECTED, got $ACTUAL"
+            exit 1
+          fi
+          echo "Crossplane chart SHA256 verified: $ACTUAL"
+
+      - name: Save Crossplane chart cache
+        if: success() && steps.crossplane-chart-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: .cache/charts
+          key: ${{ steps.crossplane-chart-cache.outputs.cache-primary-key }}
+
+      - name: Upload Crossplane chart
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: crossplane-chart
+          path: .cache/charts
+          retention-days: 7
+          overwrite: true
+          if-no-files-found: error
+
+  # Build image + xpkg + CLI tools once; the matrix consumes them as artifacts.
+  # NOTE: after the artifact retention window expires (retention-days below),
+  # "Re-run failed jobs" fails — build won't re-run, so its artifacts are gone.
+  # Use "Re-run all jobs" to rebuild them.
+  build:
+    runs-on: ubuntu-latest
+    needs: prepare-matrix
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ inputs.checkout-ref }}
+          submodules: true
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Restore CLI tools cache (kind, kubectl, crank)
+        id: cli-tools-cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: .cache/tools
+          key: e2e-tools-${{ runner.os }}-${{ runner.arch }}-crank-${{ env.CROSSPLANE_CLI_VERSION }}-${{ hashFiles('build/makelib/k8s_tools.mk') }}
+
+      - name: Fetch CLI tools once (kind, kubectl, crank)
+        run: |
+          set -euo pipefail
+          retry() {
+            local n=1 max=5
+            until "$@"; do
+              if [ "$n" -ge "$max" ]; then
+                echo "::error::'$*' failed after $max attempts"
+                return 1
+              fi
+              echo "attempt $n failed; backing off $((n * 15))s..."
+              sleep "$((n * 15))"
+              n=$((n + 1))
+            done
+          }
+          vars="$(make --no-print-directory build.vars | grep -E '^(KIND|KUBECTL)=')"
+          eval "$vars"
+          : "${KIND:?}" "${KUBECTL:?}" "${CROSSPLANE_CLI_VERSION:?}"
+          CRANK=".cache/tools/linux_x86_64/crossplane-cli-${CROSSPLANE_CLI_VERSION}"
+          retry make "$KIND" "$KUBECTL"
+          if [ ! -x "$CRANK" ]; then
+            retry curl -fsSL --create-dirs -o "$CRANK" "https://releases.crossplane.io/stable/${CROSSPLANE_CLI_VERSION}/bin/linux_amd64/crank"
+            chmod +x "$CRANK"
+          fi
+
+      - name: Save CLI tools cache (kind, kubectl, crank)
+        if: success() && steps.cli-tools-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: .cache/tools
+          key: ${{ steps.cli-tools-cache.outputs.cache-primary-key }}
+
+      - name: Build provider image
+        run: make build BUILD_REGISTRY=${{ env.E2E_BUILD_REGISTRY }} PLATFORMS=linux_amd64
+
+      - name: Build provider xpkg
+        run: make xpkg.build.provider-btp BUILD_REGISTRY=${{ env.E2E_BUILD_REGISTRY }} PLATFORMS=linux_amd64
+
+      - name: Export provider image
+        run: docker save "${{ env.E2E_PROVIDER_IMAGE }}" -o provider-image.tar
+
+      - name: Upload provider image
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: provider-image
+          path: provider-image.tar
+          retention-days: 7
+          overwrite: true
+          if-no-files-found: error
+
+      - name: Upload provider xpkg
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: provider-xpkg
+          path: _output/xpkg
+          retention-days: 7
+          overwrite: true
+          if-no-files-found: error
+
+      - name: Upload CLI tools
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: e2e-tools
+          path: .cache/tools
+          retention-days: 7
+          overwrite: true
+          if-no-files-found: error
 
   e2e-test:
     runs-on: ubuntu-latest
-    needs: prepare-matrix #required to depend on prepare-matrix to be able to use its outputs and its environment manual approval
+    needs: [prepare-matrix, fetch-chart, build] # fetch-chart provides crossplane-chart artifact; build provides image/xpkg/tools artifacts
+    environment: pr-e2e-no-approval  # approval is on the preceding prepare-matrix job
     strategy:
       fail-fast: false
       matrix:
         testName: ${{ fromJson(needs.prepare-matrix.outputs.test-names) }}
     steps:
       - name: checkout repo
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           #use inputs.checkout-ref to be able to call it from a pull_request_target workflow, since there it needs to be github.event.pull_request.merge_commit_sha and not the default
           ref: ${{ inputs.checkout-ref }}
           submodules: true
 
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ env.GO_VERSION }}
       - run: go version
 
-      - name: Install Helm
+      - name: Download CLI tools
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: e2e-tools
+          path: .cache/tools
+
+      - name: Restore tool executable bits
+        # upload-artifact drops the +x bit
+        run: find .cache/tools -type f -exec chmod +x {} +
+
+      - name: Download provider xpkg
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: provider-xpkg
+          path: _output/xpkg
+
+      - name: Download provider image
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: provider-image
+          path: ${{ runner.temp }}/artifacts/provider-image
+
+      - name: Validate provider image artifact
+        run: test -f "${{ runner.temp }}/artifacts/provider-image/provider-image.tar"
+
+      - name: Route Docker Hub pulls through mirror.gcr.io
+        # Routing docker.io through Google's pull-through cache for kindest/node.
         run: |
-          curl -fsSL https://packages.buildkite.com/helm-linux/helm-debian/gpgkey | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
-          sudo apt-get install apt-transport-https --yes
-          echo "deb [signed-by=/usr/share/keyrings/helm.gpg] https://packages.buildkite.com/helm-linux/helm-debian/any/ any main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
-          sudo apt-get update
-          sudo apt-get install -y helm
+          set -euo pipefail
+          sudo mkdir -p /etc/docker
+          if sudo test -s /etc/docker/daemon.json; then
+            sudo jq '. + {"registry-mirrors":["https://mirror.gcr.io"]}' /etc/docker/daemon.json \
+              | sudo tee /etc/docker/daemon.json.tmp >/dev/null
+            sudo mv /etc/docker/daemon.json.tmp /etc/docker/daemon.json
+          else
+            printf '%s\n' '{"registry-mirrors":["https://mirror.gcr.io"]}' | sudo tee /etc/docker/daemon.json >/dev/null
+          fi
+          sudo systemctl reload docker
+          for _ in $(seq 1 10); do
+            case "$(docker info --format '{{.RegistryConfig.Mirrors}}')" in
+              *mirror.gcr.io*) echo "registry mirror applied"; exit 0 ;;
+            esac
+            sleep 1
+          done
+          echo "::error::mirror.gcr.io not applied to docker daemon"; exit 1
+
+      - name: Load provider image
+        run: docker load -i "${{ runner.temp }}/artifacts/provider-image/provider-image.tar"
+
+      - name: Install Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        with:
+          version: v3.14.0
+
+      - name: Download Crossplane chart
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: crossplane-chart
+          path: .cache/charts
+
+      - name: Resolve Crossplane chart path
+        run: |
+          set -euo pipefail
+          CHART="$(ls .cache/charts/crossplane-*.tgz | head -n 1)"
+          test -f "$CHART" || { echo "::error::no chart at .cache/charts/crossplane-*.tgz"; exit 1; }
+          echo "CROSSPLANE_CHART_PATH=$(realpath "$CHART")" >> $GITHUB_ENV
 
       - name: Install BTP CLI
-      #hardcoded version
+        #hardcoded version
         run: |
           curl -LJO https://tools.hana.ondemand.com/additional/btp-cli-linux-amd64-$btp_cli_version.tar.gz --cookie "eula_3_2_agreed=tools.hana.ondemand.com/developer-license-3_2.txt"
           tar -xzf btp-cli-linux-amd64-$btp_cli_version.tar.gz
@@ -116,13 +352,19 @@ jobs:
         run: |
           echo "BUILD_ID=${{github.run_number}}-${{github.run_attempt}}" >> $GITHUB_ENV
 
-      - name: Install gettext for envsubst
-        run: sudo apt-get update && sudo apt-get install -y gettext
-
       - name: Run e2e test
         timeout-minutes: 120
         run: |
-          make e2e testFilter=${{ matrix.testName }}
+          set -uo pipefail
+          for attempt in 1 2 3; do
+            rm -f test-output.log
+            make test-acceptance ACCEPTANCE_DEPLOY=local-deploy-prebuilt BUILD_REGISTRY=${{ env.E2E_BUILD_REGISTRY }} testFilter=${{ matrix.testName }} && exit 0
+            rc=$?
+            grep -qE 'crossplane helm chart repo|upgrade helm repo|install crossplane Helm chart|not a valid chart repository or cannot be reached|failed to pull image' test-output.log 2>/dev/null || exit "$rc"
+            echo "::warning::transient setup flake (helm/node-image); retry $attempt/3"
+            sleep $((attempt * 15))
+          done
+          exit "$rc"
         env:
           BUILD_ID: ${{ env.BUILD_ID }}
           CIS_CENTRAL_BINDING: ${{ secrets.CIS_CENTRAL_BINDING }}
@@ -136,16 +378,17 @@ jobs:
   cleanup-e2e:
     runs-on: ubuntu-latest
     needs: [prepare-matrix, e2e-test]
+    environment: pr-e2e-no-approval
     if: always() && needs.prepare-matrix.result == 'success'  # only run if prepare-matrix was successful (requires manual approval) and then always run after e2e-test
     steps:
       - name: checkout repo
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # use github.base_ref to checkout the base branch, since the cleanup should always run on the base branch to make it harder for malicious code execution. Consequently, this will not pick up changes to the cleanup.go file in the PR, but that is accebtable.
           ref: ${{ github.base_ref }}
           submodules: true
 
-      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ env.GO_VERSION }}
 
@@ -170,21 +413,33 @@ jobs:
           GLOBAL_ACCOUNT: ${{ secrets.GLOBAL_ACCOUNT }}
 
   # required for test matrix status reporting. Ignores cleanup-e2e job failure/success.
-  e2e-test-success:
+  e2e-tests:
     runs-on: ubuntu-latest
-    needs: 
+    needs:
       - prepare-matrix
+      - fetch-chart
+      - build
       - e2e-test
     timeout-minutes: 1
     if: always()
     steps:
       - name: Fail for failed prepare-matrix job
         if: |
-          needs.prepare-matrix.result == 'failure' || 
+          needs.prepare-matrix.result == 'failure' ||
           needs.prepare-matrix.result == 'cancelled'
+        run: exit 1
+      - name: Fail for failed fetch-chart job
+        if: |
+          needs.fetch-chart.result == 'failure' ||
+          needs.fetch-chart.result == 'cancelled'
+        run: exit 1
+      - name: Fail for failed build job
+        if: |
+          needs.build.result == 'failure' ||
+          needs.build.result == 'cancelled'
         run: exit 1
       - name: Fail for failed matrix jobs
         if: |
-          needs.e2e-test.result == 'failure' || 
+          needs.e2e-test.result == 'failure' ||
           needs.e2e-test.result == 'cancelled'
         run: exit 1

--- a/.github/workflows/pr-e2e.yaml
+++ b/.github/workflows/pr-e2e.yaml
@@ -1,9 +1,11 @@
+# Runs e2e tests on PRs that are not solely markdown changes.
+#
 # The on.pull_request_target runs on changes to a pull request. Contrary to the on.pull_request, this pipeline has access to secrets and can therefore run e2e tests.
 # DANGEROUS: 1) with access to secrets it is possible to steal those by a pull request that executes code that reads the secrets and exfiltrates those.
 # DANGEROUS: 2) the GITHUB_TOKEN has read and write permissions by default. Therefore, restrict the permissions with the permissions field
 # To adress (1), we use an environment pr-e2e-approval that will only execute the job after an explicit approval from team member (after inspecting the code for non-malicious activity).
 
-# Requiremenets: 
+# Requirements:
 # 1) pr-e2e-approval environment configured to require approval before running
 # 2) pr-e2e-no-approval environment configured that does not require approval.
 
@@ -18,17 +20,10 @@ on:
 permissions:
   contents: read
 
-jobs:    
+jobs:
   run-e2e-test:
     uses: ./.github/workflows/e2e_test.yaml
     with:
       checkout-ref: ${{ github.event.pull_request.head.sha }}
       environment: pr-e2e-approval # environment that requires approval for execution
-    secrets:
-      CLI_SERVER_URL: ${{ secrets.CLI_SERVER_URL }}
-      GLOBAL_ACCOUNT: ${{ secrets.GLOBAL_ACCOUNT }}
-      IDP_URL: ${{ secrets.IDP_URL }}
-      SECOND_DIRECTORY_ADMIN_EMAIL: ${{ secrets.SECOND_DIRECTORY_ADMIN_EMAIL }}
-      CIS_CENTRAL_BINDING: ${{ secrets.CIS_CENTRAL_BINDING }}
-      BTP_TECHNICAL_USER: ${{ secrets.BTP_TECHNICAL_USER }}
-      TECHNICAL_USER_EMAIL: ${{ secrets.TECHNICAL_USER_EMAIL }}
+    secrets: inherit

--- a/.github/workflows/release-candidate.yaml
+++ b/.github/workflows/release-candidate.yaml
@@ -58,7 +58,7 @@ jobs:
           make build PLATFORM=linux_arm64 VERSION=${{ steps.version.outputs.version }}
 
       - name: Login to Container Registry
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ vars.REGISTRY_URL }}
           username: ${{ github.actor }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -112,7 +112,7 @@ jobs:
           make build PLATFORM=linux_arm64 VERSION=${{ github.event.inputs.nextVersion }}
 
       - name: Login to Container Registry
-        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ${{ vars.REGISTRY_URL }}
           username: ${{ github.actor }}
@@ -135,3 +135,6 @@ jobs:
         env:
           # GitHub sets the GITHUB_TOKEN secret automatically.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Index CRD documentation
+        run: curl -sL "https://doc.crds.dev/github.com/SAP/crossplane-provider-btp@${{ github.event.inputs.nextVersion }}"

--- a/.github/workflows/reviewable_check_diff.yaml
+++ b/.github/workflows/reviewable_check_diff.yaml
@@ -9,7 +9,6 @@ on:
 
 env:
   GO_VERSION: '1.25'
-  GO_IMPORT_VERSION: 'v0.16.1'
 
 jobs:
   reviewable-checkdiff:
@@ -17,17 +16,15 @@ jobs:
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
-        submodules: true 
+        submodules: true
 
     - name: Set up Go
       uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
       with:
         go-version: ${{ env.GO_VERSION }}
 
-    - name: Install goimports
-      run: |
-        cd /tmp
-        go install golang.org/x/tools/cmd/goimports@${{ env.GO_IMPORT_VERSION }}
+    - name: Install Go tools
+      run: go install tool
 
     - name: Make Reviewable
       run: make reviewable

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -33,7 +33,7 @@ on:
 jobs:
   upgrade-test:
     runs-on: ubuntu-latest
-    environment: pr-e2e-no-approval
+    environment: pr-e2e-approval
     env:
       # hardcoded BTP CLI version
       btp_cli_version: 2.90.2
@@ -81,9 +81,6 @@ jobs:
       - name: Set BUILD_ID
         run: |
           echo "BUILD_ID=${{github.run_number}}-${{github.run_attempt}}" >> $GITHUB_ENV
-
-      - name: Install gettext for envsubst
-        run: sudo apt-get update && sudo apt-get install -y gettext
 
       - name: Run upgrade test
         timeout-minutes: 120

--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,6 @@ PLATFORMS ?= linux_amd64
 VERSION ?= $(shell git describe --tags --exact-match 2>/dev/null || echo "v0.0.0-$$(git rev-parse HEAD)")
 $(info VERSION is $(VERSION))
 
-# Override to be Crossplane v2 compatible
-ROOT_DIR := $(shell pwd)
-export BUILD_REGISTRY := index.docker.io/build-$(shell echo $(HOSTNAME)-$(ROOT_DIR) | sha256sum | cut -c1-8)
-
 -include build/makelib/common.mk
 
 # Setup Output
@@ -71,19 +67,11 @@ testFilter ?= .*
 
 .PHONY: local-build
 local-build: build xpkg.build.provider-btp
-	$(INFO) "Loading xpkg into docker as $(UUT_XPKG)"
-	@XPKG_FILE=$(XPKG_OUTPUT_DIR)/$(PLATFORM)/provider-btp-$(VERSION).xpkg && \
+	$(INFO) "Loading xpkg into docker as $(UUT_XPKG)"; \
+	XPKG_FILE=$(XPKG_OUTPUT_DIR)/$(PLATFORM)/provider-btp-$(VERSION).xpkg && \
 	XPKG_SHA=$$(docker load -i $$XPKG_FILE | sed -n 's/.*ID: //p') && \
-	docker tag $$XPKG_SHA $(UUT_XPKG);
-	$(OK) "Built local images: $(UUT_CONFIG) $(UUT_XPKG)"
-
-.PHONY: local-deploy-prebuilt
-local-deploy-prebuilt:
-	$(INFO) "Loading prebuilt xpkg into docker as $(UUT_XPKG)"
-	@XPKG_FILE=$$(find $(XPKG_OUTPUT_DIR)/$(PLATFORM) -name "*.xpkg" | head -1) && \
-	XPKG_SHA=$$(docker load -i $$XPKG_FILE | sed -n 's/.*ID: //p') && \
-	docker tag $$XPKG_SHA $(UUT_XPKG)
-	$(OK) "Prebuilt xpkg loaded as $(UUT_XPKG)"
+	docker tag $$XPKG_SHA $(UUT_XPKG); \
+	$(OK) "Built local images: $(UUT_CONFIG) $(UUT_XPKG)"; \
 
 # ====================================================================================
 # Setup XPKG
@@ -295,12 +283,8 @@ test-e2e-long: local-build $(KIND) $(HELM3) generate-test-crs
      esac
 
 #run single e2e test with <make e2e testFilter=functionNameOfTest>
-# Deploy mechanism for test-acceptance. Default rebuilds locally (local dev);
-# CI overrides to local-deploy-prebuilt to consume artifacts from the build job.
-ACCEPTANCE_DEPLOY ?= local-build
-
 .PHONY: test-acceptance
-test-acceptance: $(ACCEPTANCE_DEPLOY) $(KIND) generate-test-crs
+test-acceptance: local-build $(KIND) $(HELM3) generate-test-crs
 	@$(INFO) running end-to-end tests
 	@$(INFO) Skipping long running tests
 	go test -v  $(PROJECT_REPO)/test/e2e -tags=e2e -count=1 -test.v -run '^$(testFilter)$$' -timeout 120m 2>&1 | tee test-output.log

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,10 @@ PLATFORMS ?= linux_amd64
 VERSION ?= $(shell git describe --tags --exact-match 2>/dev/null || echo "v0.0.0-$$(git rev-parse HEAD)")
 $(info VERSION is $(VERSION))
 
+# Override to be Crossplane v2 compatible
+ROOT_DIR := $(shell pwd)
+export BUILD_REGISTRY := index.docker.io/build-$(shell echo $(HOSTNAME)-$(ROOT_DIR) | sha256sum | cut -c1-8)
+
 -include build/makelib/common.mk
 
 # Setup Output
@@ -67,11 +71,19 @@ testFilter ?= .*
 
 .PHONY: local-build
 local-build: build xpkg.build.provider-btp
-	$(INFO) "Loading xpkg into docker as $(UUT_XPKG)"; \
-	XPKG_FILE=$(XPKG_OUTPUT_DIR)/$(PLATFORM)/provider-btp-$(VERSION).xpkg && \
+	$(INFO) "Loading xpkg into docker as $(UUT_XPKG)"
+	@XPKG_FILE=$(XPKG_OUTPUT_DIR)/$(PLATFORM)/provider-btp-$(VERSION).xpkg && \
 	XPKG_SHA=$$(docker load -i $$XPKG_FILE | sed -n 's/.*ID: //p') && \
-	docker tag $$XPKG_SHA $(UUT_XPKG); \
-	$(OK) "Built local images: $(UUT_CONFIG) $(UUT_XPKG)"; \
+	docker tag $$XPKG_SHA $(UUT_XPKG);
+	$(OK) "Built local images: $(UUT_CONFIG) $(UUT_XPKG)"
+
+.PHONY: local-deploy-prebuilt
+local-deploy-prebuilt:
+	$(INFO) "Loading prebuilt xpkg into docker as $(UUT_XPKG)"
+	@XPKG_FILE=$$(find $(XPKG_OUTPUT_DIR)/$(PLATFORM) -name "*.xpkg" | head -1) && \
+	XPKG_SHA=$$(docker load -i $$XPKG_FILE | sed -n 's/.*ID: //p') && \
+	docker tag $$XPKG_SHA $(UUT_XPKG)
+	$(OK) "Prebuilt xpkg loaded as $(UUT_XPKG)"
 
 # ====================================================================================
 # Setup XPKG
@@ -153,7 +165,13 @@ clean-work:
 	@$(INFO) cleaning work directory
 	@rm -rf .work
 
-generate.init: clean-work $(TERRAFORM_PROVIDER_SCHEMA) pull-docs
+.PHONY: install-tools
+install-tools:
+	@$(INFO) installing Go tools from go.mod
+	@$(GO) install tool
+	@$(OK) installing Go tools from go.mod
+
+generate.init: install-tools clean-work $(TERRAFORM_PROVIDER_SCHEMA) pull-docs
 
 .PHONY: $(TERRAFORM_PROVIDER_SCHEMA) pull-docs terraform.buildvars
 
@@ -277,8 +295,12 @@ test-e2e-long: local-build $(KIND) $(HELM3) generate-test-crs
      esac
 
 #run single e2e test with <make e2e testFilter=functionNameOfTest>
+# Deploy mechanism for test-acceptance. Default rebuilds locally (local dev);
+# CI overrides to local-deploy-prebuilt to consume artifacts from the build job.
+ACCEPTANCE_DEPLOY ?= local-build
+
 .PHONY: test-acceptance
-test-acceptance: local-build $(KIND) $(HELM3) generate-test-crs
+test-acceptance: $(ACCEPTANCE_DEPLOY) $(KIND) generate-test-crs
 	@$(INFO) running end-to-end tests
 	@$(INFO) Skipping long running tests
 	go test -v  $(PROJECT_REPO)/test/e2e -tags=e2e -count=1 -test.v -run '^$(testFilter)$$' -timeout 120m 2>&1 | tee test-output.log

--- a/go.mod
+++ b/go.mod
@@ -224,6 +224,7 @@ require (
 	golang.org/x/mod v0.34.0 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
+	golang.org/x/telemetry v0.0.0-20260209163413-e7419c687ee4 // indirect
 	golang.org/x/term v0.40.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 	golang.org/x/time v0.14.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/sap/crossplane-provider-btp
 
 go 1.25.6
 
+tool golang.org/x/tools/cmd/goimports
+
 // Module conflict in Go dependencies. The package google.golang.org/genproto/googleapis/api/httpbody exists in two different modules:
 // - google.golang.org/genproto (older version)
 // - google.golang.org/genproto/googleapis/api (newer, split module)

--- a/go.sum
+++ b/go.sum
@@ -2327,6 +2327,8 @@ golang.org/x/telemetry v0.0.0-20251008203120-078029d740a8/go.mod h1:Pi4ztBfryZoJ
 golang.org/x/telemetry v0.0.0-20251111182119-bc8e575c7b54/go.mod h1:hKdjCMrbv9skySur+Nek8Hd0uJ0GuxJIoIX2payrIdQ=
 golang.org/x/telemetry v0.0.0-20251203150158-8fff8a5912fc/go.mod h1:hKdjCMrbv9skySur+Nek8Hd0uJ0GuxJIoIX2payrIdQ=
 golang.org/x/telemetry v0.0.0-20260109210033-bd525da824e2/go.mod h1:b7fPSJ0pKZ3ccUh8gnTONJxhn3c/PS6tyzQvyqw4iA8=
+golang.org/x/telemetry v0.0.0-20260209163413-e7419c687ee4 h1:bTLqdHv7xrGlFbvf5/TXNxy/iUwwdkjhqQTJDjW7aj0=
+golang.org/x/telemetry v0.0.0-20260209163413-e7419c687ee4/go.mod h1:g5NllXBEermZrmR51cJDQxmJUHUOfRAaNyWBM+R+548=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=


### PR DESCRIPTION
We did a lot of changes to the github workflows recently. 
Some of which have been backported to the release branch, but there is still some diff. 

This PR moves all changes from main to the release branch.