### PR TITLE
fix(entitlement): retry and surface PROCESSING_FAILED with no assigned quota

### DIFF
--- a/internal/controller/account/entitlement/entitlement.go
+++ b/internal/controller/account/entitlement/entitlement.go
@@ -139,14 +139,28 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	switch cr.Status.AtProvider.Assigned.EntityState { //nolint:exhaustive
 	case apisv1alpha1.EntitlementStatusOk:
 		cr.Status.SetConditions(xpv1.Available())
-	// the state relates to the last operation, not the current state
-	// at this point we already verified that the entity does match the desired state for all we know
-	// so we will ignore this state to avoid blocking healthy resources
-	// example case: attempting to delete an entitlement which is already consumed will fail in that way
-	// -> the only resolution is to discard and recreate the cr, in this case we just need to observe the still existing entitlement
-	// despite the last operation being a failure
+	// PROCESSING_FAILED reflects the *last operation* on the entitlement,
+	// not whether something is currently assigned. Two distinct shapes hit
+	// this branch:
+	//   1. Delete- or update-time failure on a still-assigned entitlement
+	//      (amount > 0). The entitlement is still in use; reporting
+	//      Available avoids flapping orchestration that depends on this CR.
+	//      Example: attempting to delete an entitlement that is already
+	//      consumed will fail in this way; the only resolution is to
+	//      discard and recreate the CR, in this case we just need to
+	//      observe the still existing entitlement despite the last operation
+	//      being a failure.
+	//   2. Assign-time failure with nothing reserved (amount == 0 / nil).
+	//      This is normally short-circuited above by needsCreate() so the
+	//      managed reconciler can retry via Create. The branch below is a
+	//      defensive fallback in case any future change bypasses that
+	//      short-circuit: reporting Available here would be a lie.
 	case apisv1alpha1.EntitlementStatusProcessingFailed:
-		cr.Status.SetConditions(xpv1.Available())
+		if c.assignFailedNoQuota(cr) {
+			cr.Status.SetConditions(xpv1.Unavailable())
+		} else {
+			cr.Status.SetConditions(xpv1.Available())
+		}
 	case apisv1alpha1.EntitlementStatusProcessing:
 		cr.Status.SetConditions(xpv1.Creating())
 	case apisv1alpha1.EntitlementStatusStarted:
@@ -304,8 +318,33 @@ func (c *external) needsUpdate(cr *apisv1alpha1.Entitlement) bool {
 	return false
 }
 
+// assignFailedNoQuota returns true when BTP reports a PROCESSING_FAILED
+// assignment for this entitlement and the reported amount is zero or unset,
+// i.e. nothing is actually reserved on the BTP side. This is distinct from
+// PROCESSING_FAILED with a non-zero amount, which typically reflects a
+// delete- or update-time failure on an entitlement that is still assigned
+// (and which should remain marked as Available so siblings/orchestration are
+// not flapped).
+func (c *external) assignFailedNoQuota(cr *apisv1alpha1.Entitlement) bool {
+	if cr.Status.AtProvider == nil || cr.Status.AtProvider.Assigned == nil {
+		return false
+	}
+	if cr.Status.AtProvider.Assigned.EntityState != apisv1alpha1.EntitlementStatusProcessingFailed {
+		return false
+	}
+	amount := cr.Status.AtProvider.Assigned.Amount
+	return amount == nil || *amount <= 0
+}
+
 func (c *external) needsCreate(cr *apisv1alpha1.Entitlement) bool {
-	return cr.Status.AtProvider.Assigned == nil
+	if cr.Status.AtProvider.Assigned == nil {
+		return true
+	}
+	// Previous assign attempt failed and BTP reserved nothing — treat as
+	// not-yet-created so Crossplane re-issues the assign via Create (which
+	// calls CreateInstance == UpdateInstance) under the managed reconciler's
+	// rate-limited retry.
+	return c.assignFailedNoQuota(cr)
 }
 
 // deletionComplete checks whether this CR's portion has already been removed from BTP.

--- a/internal/controller/account/entitlement/entitlement_test.go
+++ b/internal/controller/account/entitlement/entitlement_test.go
@@ -250,6 +250,89 @@ func TestObserve(t *testing.T) {
 				err: nil,
 			},
 		},
+		"Assign-time PROCESSING_FAILED with amount=0 (enable-style) -- retries via Create": {
+			args: args{
+				kube: &test.MockClient{
+					MockStatusUpdate: noopStatusUpdate,
+					MockList:         test.NewMockListFn(nil, ListEntitlements(entitlement(withEnabled(true)))),
+				},
+				client: fake.MockClient{MockDescribeCluster: func(ctx context.Context, input v1alpha1.Entitlement) (*entitlement2.Instance, error) {
+					return &entitlement2.Instance{
+						EntitledServicePlan: &entclient.ServicePlanResponseObject{
+							Category: internal.Ptr("ELASTIC_SERVICE"),
+						},
+						Assignment: &entclient.AssignedServicePlanSubaccountDTO{
+							Amount:       internal.Ptr(float32(0)),
+							EntityState:  internal.Ptr("PROCESSING_FAILED"),
+							StateMessage: internal.Ptr("Failed to call Provisioning service to assign quota."),
+						},
+					}, nil
+				}},
+				cr: entitlement(withEnabled(true)),
+			},
+			want: want{
+				// Observe returns ResourceExists=false so the managed reconciler
+				// drives Create -> CreateInstance, which re-issues the assign.
+				o:   managed.ExternalObservation{ResourceExists: false},
+				err: nil,
+			},
+		},
+		"Assign-time PROCESSING_FAILED with nil amount (enable-style) -- retries via Create": {
+			args: args{
+				kube: &test.MockClient{
+					MockStatusUpdate: noopStatusUpdate,
+					MockList:         test.NewMockListFn(nil, ListEntitlements(entitlement(withEnabled(true)))),
+				},
+				client: fake.MockClient{MockDescribeCluster: func(ctx context.Context, input v1alpha1.Entitlement) (*entitlement2.Instance, error) {
+					return &entitlement2.Instance{
+						EntitledServicePlan: &entclient.ServicePlanResponseObject{
+							Category: internal.Ptr("ELASTIC_SERVICE"),
+						},
+						Assignment: &entclient.AssignedServicePlanSubaccountDTO{
+							Amount:       nil,
+							EntityState:  internal.Ptr("PROCESSING_FAILED"),
+							StateMessage: internal.Ptr("Failed to call Provisioning service to assign quota."),
+						},
+					}, nil
+				}},
+				cr: entitlement(withEnabled(true)),
+			},
+			want: want{
+				o:   managed.ExternalObservation{ResourceExists: false},
+				err: nil,
+			},
+		},
+		"Assign-time PROCESSING_FAILED with amount=0 -- Ready must not be Available": {
+			args: args{
+				kube: &test.MockClient{
+					MockStatusUpdate: noopStatusUpdate,
+					MockList:         test.NewMockListFn(nil, ListEntitlements(entitlement(withEnabled(true)))),
+				},
+				client: fake.MockClient{MockDescribeCluster: func(ctx context.Context, input v1alpha1.Entitlement) (*entitlement2.Instance, error) {
+					return &entitlement2.Instance{
+						EntitledServicePlan: &entclient.ServicePlanResponseObject{
+							Category: internal.Ptr("ELASTIC_SERVICE"),
+						},
+						Assignment: &entclient.AssignedServicePlanSubaccountDTO{
+							Amount:      internal.Ptr(float32(0)),
+							EntityState: internal.Ptr("PROCESSING_FAILED"),
+						},
+					}, nil
+				}},
+				cr: entitlement(withEnabled(true)),
+			},
+			want: want{
+				o: managed.ExternalObservation{ResourceExists: false},
+				comparefn: func(v *v1alpha1.Entitlement) string {
+					got := v.Status.GetCondition(xpv1.Available().Type).Status
+					if got == xpv1.Available().Status {
+						return "Ready=True/Available should not be set when BTP reports PROCESSING_FAILED with amount=0"
+					}
+					return ""
+				},
+				err: nil,
+			},
+		},
 		"Needs Deletion, assignment gone, noop needed": {
 			args: args{
 				kube: &test.MockClient{


### PR DESCRIPTION
**What this fixes**

Fixes #769 (closely related: previously-closed #391).

When the BTP Entitlements / Provisioning service rejects the initial assign call, the `Entitlement` controller currently maps the resulting `assigned.entityState=PROCESSING_FAILED` with `amount=0` (or `nil`) to `Ready=Available` and never retries. Downstream resources gating on `Ready=True` (compositions, `ServiceInstance`) treat the entitlement as healthy when nothing is actually reserved on BTP. `ServiceInstance` reconciles then fail with `connect failed: while initializing service plan: cannot resolve plan ID: no service offering found for '<service>'` because the catalog never received the assignment.

**What this changes**

* **`needsCreate`** is broadened to also return `true` when `assigned.entityState=PROCESSING_FAILED && assigned.amount<=0` (or `nil`). The managed reconciler then drives `Create` → `CreateInstance` (which is `UpdateInstance` in `internal/clients/entitlement/entitlement.go`), retrying the assign on every poll. `Ready` is now honestly `Creating` instead of `Available`.
* The existing tolerance for delete- or update-time `PROCESSING_FAILED` with `amount > 0` is preserved (that was the intent of the original comment on the switch case — failing a *change* on a still-assigned entitlement should not flap dependents). The new `assignFailedNoQuota` helper makes the discriminator explicit.
* A defensive `Unavailable` mapping is added inside the existing `switch` `PROCESSING_FAILED` branch, so the green-but-broken state is unreachable even if the early `needsCreate` short-circuit is bypassed in a future refactor.

**Discriminator**

| Field | Assign-time failure (this fix) | Delete-/update-time failure (existing tolerated case) |
|---|---|---|
| `Assigned.EntityState` | `PROCESSING_FAILED` | `PROCESSING_FAILED` |
| `Assigned.Amount` (`*int`) | `nil` or `*amount == 0` | `> 0` |
| What's actually in BTP | nothing reserved; catalog has no offering | entitlement is still assigned; just the last change op failed |

Negative checks:
* Numeric quota with `EntityState=OK, Amount=0` (someone disabled the entitlement): unaffected, `EntityState != PROCESSING_FAILED`.
* Enable-style with `Enable=false, EntityState=OK`: unaffected for the same reason.
* Brand-new entitlement before first BTP response (`Assigned == nil`): already caught by the existing `needsCreate`.

**Tests**

Three new cases under `TestObserve`:
1. `Assign-time PROCESSING_FAILED with amount=0 (enable-style) -- retries via Create` — asserts `ResourceExists=false` so the managed reconciler retries.
2. `Assign-time PROCESSING_FAILED with nil amount (enable-style) -- retries via Create` — same, with `nil` instead of `0`.
3. `Assign-time PROCESSING_FAILED with amount=0 -- Ready must not be Available` — asserts the `Ready` condition is not set to `Available` for this shape.

The existing test `"Simple Case, All up-to-date, unavailable condition"` (which asserts `amount=1, PROCESSING_FAILED → Ready=Available`) is preserved and still passes — it's the delete-/update-time tolerance case, and the new helper specifically excludes it.

```
$ go test ./internal/controller/account/entitlement/... -run TestObserve -count=1
ok    github.com/sap/crossplane-provider-btp/internal/controller/account/entitlement   0.679s
```

`go vet ./...` clean, `go build ./...` clean.

**Diff is confined to two files**

* `internal/controller/account/entitlement/entitlement.go` (helper + `needsCreate` broaden + defensive switch update)
* `internal/controller/account/entitlement/entitlement_test.go` (three new cases)

No CRD / API / generated-code changes.

**Out of scope**

* Surfacing the BTP `stateMessage` directly on the `Ready` condition. Crossplane's managed reconciler overwrites `Ready` to `Creating` after our Observe returns, so the message would need either an event recorder injected into the `external` client (precedent exists in other controllers in this repo) or a custom condition type. Happy to follow up with that in a separate PR if you'd like.
* The deletion-time leak path observed at the same time (cascading `ServiceBinding`/`ServiceInstance`/`ServiceManager` leak when upjet `Observe` mis-reports `ResourceExists=false`). Separate root cause, separate fix.
