### PR TITLE
docs: add SubaccountApiCredentials reset workaround

### DIFF
--- a/docs/end-user-guides/account/usermanagement.mdx
+++ b/docs/end-user-guides/account/usermanagement.mdx
@@ -23,6 +23,14 @@ This guide shows how to use Crossplane to configure user access to your global a
 
 The `SubaccountApiCredentials` can not be imported from an existing BTP landscape. Its generated secret is only correct when Crossplane initially creates the resource from scratch.
 
+To fix the issue, use the BTP CLI to delete the previously generated credentials:
+
+```sh
+btp delete security/api-credential managed-subbaccount-api-credential --subaccount [ID]
+```
+
+Once deleted, `SubaccountApiCredentials` will generate a new, correct secret.
+
 :::
 To orchestrate users and roles in BTP, you need to have access to the underlying XSUAA. The role collections can be managed on **subaccount, global-account, and directory** level.
 


### PR DESCRIPTION
## Summary
- Adds the BTP CLI workaround for resetting `SubaccountApiCredentials` when the previously generated secret is incorrect (cannot be imported from an existing landscape).

## Context
Credit to Markus Perndorfer for the original fix.

## Test plan
- [ ] Render the page locally and verify the new code block appears inside the existing `:::warning` admonition.