### PR TITLE
fix: inherit secrets in release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,14 +44,7 @@ jobs:
       - run-make-reviewable-and-check-diff
       with:
         environment: pr-e2e-no-approval
-      secrets:
-        CLI_SERVER_URL: ${{ secrets.CLI_SERVER_URL }}
-        GLOBAL_ACCOUNT: ${{ secrets.GLOBAL_ACCOUNT }}
-        IDP_URL: ${{ secrets.IDP_URL }}
-        SECOND_DIRECTORY_ADMIN_EMAIL: ${{ secrets.SECOND_DIRECTORY_ADMIN_EMAIL }}
-        CIS_CENTRAL_BINDING: ${{ secrets.CIS_CENTRAL_BINDING }}
-        BTP_TECHNICAL_USER: ${{ secrets.BTP_TECHNICAL_USER }}
-        TECHNICAL_USER_EMAIL: ${{ secrets.TECHNICAL_USER_EMAIL }}
+      secrets: inherit
       permissions:
         contents: read
 


### PR DESCRIPTION
There was a mixup in #764. 

We need to inherit those secrets. 