### PR TITLE
feat: add metrics-operator examples for BTP resource observability

### DIFF
--- a/examples/metrics-operator/README.md
+++ b/examples/metrics-operator/README.md
@@ -1,0 +1,63 @@
+# SAP BTP Crossplane Provider — Metrics Operator
+
+This directory contains [metrics-operator](https://github.com/openmcp-project/metrics-operator) resources for observing the state of crossplane-provider-btp managed resources and shipping them to an OpenTelemetry endpoint.
+
+## Prerequisites & Setup
+
+For installation, DataSink configuration, and OTEL endpoint setup, follow the upstream documentation:
+
+- **Install the operator:** [metrics-operator — Getting Started](https://github.com/openmcp-project/metrics-operator?tab=readme-ov-file#getting-started)
+- **Configure a DataSink:** [DataSink Configuration Guide](https://github.com/openmcp-project/metrics-operator/blob/main/docs/datasink-configuration.md)
+- **Configure dimensions:** [Dimensions Configuration Guide](https://github.com/openmcp-project/metrics-operator/blob/main/docs/dimensions-configuration.md)
+
+## Apply BTP Metrics
+
+Once the operator is running and a DataSink named `default` exists in the `metrics-operator-system` namespace, apply the resources from this directory:
+
+```bash
+kubectl apply -f managed-metric-subaccounts.yaml
+kubectl apply -f managed-metric-entitlements-subscriptions.yaml
+kubectl apply -f managed-metric-service-instances.yaml
+kubectl apply -f managed-metric-environments.yaml
+kubectl apply -f managed-metric-security.yaml
+kubectl apply -f metric-resource-age.yaml   # optional: age/drift tracking
+```
+
+## Recommended Metrics
+
+| File | Metric name | What it tracks |
+|---|---|---|
+| `managed-metric-subaccounts.yaml` | `btp_subaccount_count` | All Subaccount CRs — ready/synced state, region, ID |
+| `managed-metric-entitlements-subscriptions.yaml` | `btp_entitlement_count` | Entitlements per service plan |
+| `managed-metric-entitlements-subscriptions.yaml` | `btp_subscription_count` | SaaS subscriptions per app/plan |
+| `managed-metric-service-instances.yaml` | `btp_service_instance_count` | ServiceInstance CRs per offering |
+| `managed-metric-service-instances.yaml` | `btp_service_binding_count` | ServiceBinding CRs |
+| `managed-metric-environments.yaml` | `btp_cf_environment_count` | CloudFoundry environments |
+| `managed-metric-environments.yaml` | `btp_kyma_environment_count` | Kyma environments per plan |
+| `managed-metric-security.yaml` | `btp_role_collection_count` | RoleCollections |
+| `managed-metric-security.yaml` | `btp_trust_configuration_count` | Trust configs per IdP origin |
+| `metric-resource-age.yaml` | `btp_subaccount_creation_timestamp_seconds` | Subaccount age (drift detection) |
+| `metric-resource-age.yaml` | `btp_service_instance_creation_timestamp_seconds` | ServiceInstance age |
+
+## Key Dimensions
+
+All `ManagedMetric` resources expose these dimensions by default:
+
+| Dimension | Description |
+|---|---|
+| `cluster` | Kubernetes cluster name |
+| `group` | CRD API group |
+| `version` | CRD version |
+| `kind` | Resource kind |
+| `condition_ready` | Full `Ready` condition object (JSON) |
+| `condition_synced` | Full `Synced` condition object (JSON) |
+
+Resource-specific dimensions (name, region, plan, offering, …) are defined per metric.
+
+## Why ManagedMetric over Metric?
+
+`ManagedMetric` is purpose-built for Crossplane — it automatically includes `ready` and `synced` convenience dimensions when no custom `dimensions` block is specified. Once you add a custom `dimensions` block (as done here), you take full control and only the `cluster` base dimension is added automatically.
+
+## OTEL Collector tip
+
+For production, place an OTel Collector in-cluster and point the DataSink at it over gRPC (`grpc://<collector-svc>:4317`). The collector can then parse the `condition_ready`/`condition_synced` JSON strings, flatten them into individual attributes, and route to multiple backends.

--- a/examples/metrics-operator/README.md
+++ b/examples/metrics-operator/README.md
@@ -12,7 +12,29 @@ For installation, DataSink configuration, and OTEL endpoint setup, follow the up
 
 ## Apply BTP Metrics
 
-Once the operator is running and a DataSink named `default` exists in the `metrics-operator-system` namespace, apply the resources from this directory:
+The resources in this directory are plain Kubernetes manifests and are best managed via **GitOps** — point your GitOps tool at this directory so that metric definitions are version-controlled, auditable, and automatically reconciled.
+
+**Flux v2 example** — create a `Kustomization` that watches this path:
+
+```yaml
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: btp-metrics
+  namespace: flux-system
+spec:
+  interval: 10m
+  sourceRef:
+    kind: GitRepository
+    name: crossplane-provider-btp   # your existing GitRepository source
+  path: ./examples/metrics-operator
+  prune: true
+  wait: true
+```
+
+See the [Flux Kustomization documentation](https://fluxcd.io/flux/components/kustomize/kustomizations/) for full reference.
+
+If you prefer to apply manually, once the operator is running and a DataSink named `default` exists in `metrics-operator-system`:
 
 ```bash
 kubectl apply -f managed-metric-subaccounts.yaml

--- a/examples/metrics-operator/managed-metric-entitlements-subscriptions.yaml
+++ b/examples/metrics-operator/managed-metric-entitlements-subscriptions.yaml
@@ -1,0 +1,55 @@
+# ──────────────────────────────────────────────────────────────────
+# account.btp.sap.crossplane.io — Entitlements
+# ──────────────────────────────────────────────────────────────────
+apiVersion: metrics.openmcp.cloud/v1alpha1
+kind: ManagedMetric
+metadata:
+  name: btp-entitlements
+spec:
+  name: btp_entitlement_count
+  description: "Count of SAP BTP Entitlement managed resources per service plan, labelled by ready/synced state"
+  kind: Entitlement
+  group: account.btp.sap.crossplane.io
+  version: v1alpha1
+  interval: "1m"
+  dimensions:
+    - name: name
+      fieldPath: "metadata.name"
+    - name: service_name
+      fieldPath: "spec.forProvider.serviceName"
+    - name: plan_name
+      fieldPath: "spec.forProvider.planName"
+    - name: condition_ready
+      fieldPath: "status.conditions[?(@.type=='Ready')]"
+      type: slice
+    - name: condition_synced
+      fieldPath: "status.conditions[?(@.type=='Synced')]"
+      type: slice
+---
+# ──────────────────────────────────────────────────────────────────
+# account.btp.sap.crossplane.io — Subscriptions
+# ──────────────────────────────────────────────────────────────────
+apiVersion: metrics.openmcp.cloud/v1alpha1
+kind: ManagedMetric
+metadata:
+  name: btp-subscriptions
+spec:
+  name: btp_subscription_count
+  description: "Count of SAP BTP Subscription managed resources per SaaS application"
+  kind: Subscription
+  group: account.btp.sap.crossplane.io
+  version: v1alpha1
+  interval: "1m"
+  dimensions:
+    - name: name
+      fieldPath: "metadata.name"
+    - name: app_name
+      fieldPath: "spec.forProvider.appName"
+    - name: plan_name
+      fieldPath: "spec.forProvider.planName"
+    - name: condition_ready
+      fieldPath: "status.conditions[?(@.type=='Ready')]"
+      type: slice
+    - name: condition_synced
+      fieldPath: "status.conditions[?(@.type=='Synced')]"
+      type: slice

--- a/examples/metrics-operator/managed-metric-environments.yaml
+++ b/examples/metrics-operator/managed-metric-environments.yaml
@@ -1,0 +1,48 @@
+# ──────────────────────────────────────────────────────────────────
+# environment.btp.sap.crossplane.io — CloudFoundry + Kyma
+# ──────────────────────────────────────────────────────────────────
+apiVersion: metrics.openmcp.cloud/v1alpha1
+kind: ManagedMetric
+metadata:
+  name: btp-cf-environments
+spec:
+  name: btp_cf_environment_count
+  description: "Count of CloudFoundryEnvironment managed resources per subaccount"
+  kind: CloudFoundryEnvironment
+  group: environment.btp.sap.crossplane.io
+  version: v1alpha1
+  interval: "1m"
+  dimensions:
+    - name: name
+      fieldPath: "metadata.name"
+    - name: org_name
+      fieldPath: "spec.forProvider.orgName"
+    - name: condition_ready
+      fieldPath: "status.conditions[?(@.type=='Ready')]"
+      type: slice
+    - name: condition_synced
+      fieldPath: "status.conditions[?(@.type=='Synced')]"
+      type: slice
+---
+apiVersion: metrics.openmcp.cloud/v1alpha1
+kind: ManagedMetric
+metadata:
+  name: btp-kyma-environments
+spec:
+  name: btp_kyma_environment_count
+  description: "Count of KymaEnvironment managed resources"
+  kind: KymaEnvironment
+  group: environment.btp.sap.crossplane.io
+  version: v1alpha1
+  interval: "1m"
+  dimensions:
+    - name: name
+      fieldPath: "metadata.name"
+    - name: plan
+      fieldPath: "spec.forProvider.plan"
+    - name: condition_ready
+      fieldPath: "status.conditions[?(@.type=='Ready')]"
+      type: slice
+    - name: condition_synced
+      fieldPath: "status.conditions[?(@.type=='Synced')]"
+      type: slice

--- a/examples/metrics-operator/managed-metric-security.yaml
+++ b/examples/metrics-operator/managed-metric-security.yaml
@@ -1,0 +1,46 @@
+# ──────────────────────────────────────────────────────────────────
+# security.btp.sap.crossplane.io — RoleCollections + Trust Configs
+# ──────────────────────────────────────────────────────────────────
+apiVersion: metrics.openmcp.cloud/v1alpha1
+kind: ManagedMetric
+metadata:
+  name: btp-role-collections
+spec:
+  name: btp_role_collection_count
+  description: "Count of RoleCollection managed resources"
+  kind: RoleCollection
+  group: security.btp.sap.crossplane.io
+  version: v1alpha1
+  interval: "5m"
+  dimensions:
+    - name: name
+      fieldPath: "metadata.name"
+    - name: condition_ready
+      fieldPath: "status.conditions[?(@.type=='Ready')]"
+      type: slice
+    - name: condition_synced
+      fieldPath: "status.conditions[?(@.type=='Synced')]"
+      type: slice
+---
+apiVersion: metrics.openmcp.cloud/v1alpha1
+kind: ManagedMetric
+metadata:
+  name: btp-trust-configurations
+spec:
+  name: btp_trust_configuration_count
+  description: "Count of SubaccountTrustConfiguration managed resources per IdP origin"
+  kind: SubaccountTrustConfiguration
+  group: security.btp.sap.crossplane.io
+  version: v1alpha1
+  interval: "5m"
+  dimensions:
+    - name: name
+      fieldPath: "metadata.name"
+    - name: origin
+      fieldPath: "spec.forProvider.origin"
+    - name: condition_ready
+      fieldPath: "status.conditions[?(@.type=='Ready')]"
+      type: slice
+    - name: condition_synced
+      fieldPath: "status.conditions[?(@.type=='Synced')]"
+      type: slice

--- a/examples/metrics-operator/managed-metric-service-instances.yaml
+++ b/examples/metrics-operator/managed-metric-service-instances.yaml
@@ -1,0 +1,50 @@
+# ──────────────────────────────────────────────────────────────────
+# account.btp.sap.crossplane.io — ServiceInstance + ServiceBinding
+# ──────────────────────────────────────────────────────────────────
+apiVersion: metrics.openmcp.cloud/v1alpha1
+kind: ManagedMetric
+metadata:
+  name: btp-service-instances
+spec:
+  name: btp_service_instance_count
+  description: "Count of SAP BTP ServiceInstance managed resources per offering/plan"
+  kind: ServiceInstance
+  group: account.btp.sap.crossplane.io
+  version: v1alpha1
+  interval: "1m"
+  dimensions:
+    - name: name
+      fieldPath: "metadata.name"
+    - name: offering_name
+      fieldPath: "spec.forProvider.serviceOfferingName"
+    - name: plan_name
+      fieldPath: "spec.forProvider.servicePlanName"
+    - name: condition_ready
+      fieldPath: "status.conditions[?(@.type=='Ready')]"
+      type: slice
+    - name: condition_synced
+      fieldPath: "status.conditions[?(@.type=='Synced')]"
+      type: slice
+---
+apiVersion: metrics.openmcp.cloud/v1alpha1
+kind: ManagedMetric
+metadata:
+  name: btp-service-bindings
+spec:
+  name: btp_service_binding_count
+  description: "Count of SAP BTP ServiceBinding managed resources"
+  kind: ServiceBinding
+  group: account.btp.sap.crossplane.io
+  version: v1alpha1
+  interval: "1m"
+  dimensions:
+    - name: name
+      fieldPath: "metadata.name"
+    - name: instance_name
+      fieldPath: "spec.forProvider.serviceInstanceName"
+    - name: condition_ready
+      fieldPath: "status.conditions[?(@.type=='Ready')]"
+      type: slice
+    - name: condition_synced
+      fieldPath: "status.conditions[?(@.type=='Synced')]"
+      type: slice

--- a/examples/metrics-operator/managed-metric-subaccounts.yaml
+++ b/examples/metrics-operator/managed-metric-subaccounts.yaml
@@ -1,0 +1,32 @@
+# ──────────────────────────────────────────────────────────────────
+# account.btp.sap.crossplane.io — Subaccounts
+# ──────────────────────────────────────────────────────────────────
+# Tracks every Subaccount managed resource.
+# Default ManagedMetric convenience dimensions include:
+#   cluster, group, version, kind, ready, synced
+# Custom dimensions below add BTP-specific context.
+apiVersion: metrics.openmcp.cloud/v1alpha1
+kind: ManagedMetric
+metadata:
+  name: btp-subaccounts
+spec:
+  name: btp_subaccount_count
+  description: "Count of SAP BTP Subaccount managed resources, labelled by ready/synced state and subaccount name"
+  kind: Subaccount
+  group: account.btp.sap.crossplane.io
+  version: v1alpha1
+  interval: "1m"
+  dimensions:
+    - name: name
+      fieldPath: "metadata.name"
+    - name: subaccount_id
+      fieldPath: "status.atProvider.subaccountId"
+    - name: region
+      fieldPath: "spec.forProvider.region"
+    - name: condition_ready
+      fieldPath: "status.conditions[?(@.type=='Ready')]"
+      type: slice
+    - name: condition_synced
+      fieldPath: "status.conditions[?(@.type=='Synced')]"
+      type: slice
+  # dataSinkRef omitted → uses DataSink named "default"

--- a/examples/metrics-operator/metric-resource-age.yaml
+++ b/examples/metrics-operator/metric-resource-age.yaml
@@ -1,0 +1,51 @@
+# ──────────────────────────────────────────────────────────────────
+# Cross-cutting: resource age metrics (using Metric + valueFrom)
+#
+# These track how long BTP resources have existed (Unix seconds),
+# useful for detecting stale/stuck resources or governance drift.
+# Uses the base Metric type (not ManagedMetric) because valueFrom
+# is only supported on Metric/FederatedMetric.
+# ──────────────────────────────────────────────────────────────────
+apiVersion: metrics.openmcp.cloud/v1alpha1
+kind: Metric
+metadata:
+  name: btp-subaccount-age
+spec:
+  name: btp_subaccount_creation_timestamp_seconds
+  description: "Unix creation timestamp of each BTP Subaccount (use to derive resource age)"
+  target:
+    kind: Subaccount
+    group: account.btp.sap.crossplane.io
+    version: v1alpha1
+  interval: "5m"
+  valueFrom:
+    fieldPath: "metadata.creationTimestamp"
+    type: timestamp
+  projections:
+    - name: name
+      fieldPath: "metadata.name"
+    - name: region
+      fieldPath: "spec.forProvider.region"
+---
+apiVersion: metrics.openmcp.cloud/v1alpha1
+kind: Metric
+metadata:
+  name: btp-service-instance-age
+spec:
+  name: btp_service_instance_creation_timestamp_seconds
+  description: "Unix creation timestamp of each BTP ServiceInstance (use to derive resource age)"
+  target:
+    kind: ServiceInstance
+    group: account.btp.sap.crossplane.io
+    version: v1alpha1
+  interval: "5m"
+  valueFrom:
+    fieldPath: "metadata.creationTimestamp"
+    type: timestamp
+  projections:
+    - name: name
+      fieldPath: "metadata.name"
+    - name: offering_name
+      fieldPath: "spec.forProvider.serviceOfferingName"
+    - name: plan_name
+      fieldPath: "spec.forProvider.servicePlanName"


### PR DESCRIPTION
## Summary

- Adds `examples/metrics-operator/` with `ManagedMetric` and `Metric` resources covering all major BTP provider CRD types (Subaccount, Entitlement, Subscription, ServiceInstance, ServiceBinding, CloudFoundryEnvironment, KymaEnvironment, RoleCollection, SubaccountTrustConfiguration, plus age/drift metrics)
- Metrics ship `ready`/`synced` condition state and resource-specific dimensions (region, plan, offering, IdP origin, …) to any OTEL endpoint via the [openmcp metrics-operator](https://github.com/openmcp-project/metrics-operator)
- README forwards to upstream docs for installation and DataSink configuration, and recommends GitOps/Flux for managing these resources

## Test plan

- [ ] Install [metrics-operator](https://github.com/openmcp-project/metrics-operator) in a test cluster
- [ ] Configure a `DataSink` named `default` in `metrics-operator-system` pointing to an OTEL endpoint
- [ ] `kubectl apply -f examples/metrics-operator/` and verify metrics appear in the OTEL backend
- [ ] Confirm `condition_ready` and `condition_synced` dimensions are populated for at least one resource type