### PR TITLE
[Bug] add `environment` to distinguish service plan ID resolver

### DIFF
--- a/apis/account/v1alpha1/serviceinstance_types.go
+++ b/apis/account/v1alpha1/serviceinstance_types.go
@@ -36,6 +36,13 @@ type ServiceInstanceParameters struct {
 	// +kubebuilder:validation:Optional
 	ServicePlanID string `json:"servicePlanID,omitempty"`
 
+	// Environment for which to resolve the service plan. Valid values: sapbtp, kubernetes, cloudfoundry.
+	// Defaults to sapbtp if not set.
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Enum=sapbtp;kubernetes;cloudfoundry
+	// +kubebuilder:default=sapbtp
+	Environment string `json:"environment,omitempty"`
+
 	// Whether the service instance is shared or not
 	// +kubebuilder:validation:Optional
 	Shared *bool `json:"shared,omitempty"`

--- a/internal/clients/servicemanager/api_plan_resolver.go
+++ b/internal/clients/servicemanager/api_plan_resolver.go
@@ -24,7 +24,7 @@ const ErrMissingXsappname = "Xsappname (xsappname) is missing"
 
 // PlanIdResolver used as its own resolval implementation downstream
 type PlanIdResolver interface {
-	PlanIDByName(ctx context.Context, offeringName string, servicePlanName string, dataCenter string) (string, error)
+	PlanIDByName(ctx context.Context, offeringName string, servicePlanName string, dataCenter string, environment string) (string, error)
 }
 
 // NewCredsFromOperatorSecret creates a new BindingCredentials from a secret data
@@ -119,8 +119,11 @@ func NewServiceManagerClient(ctx context.Context, creds *BindingCredentials) (*S
 	}, nil
 }
 
-func (sm *ServiceManagerClient) PlanIDByName(ctx context.Context, offeringName, planName, dataCenter string) (string, error) {
-	offeringQuery := fmt.Sprintf("catalog_name eq '%s' and data_center eq '%s'", offeringName, dataCenter)
+func (sm *ServiceManagerClient) PlanIDByName(ctx context.Context, offeringName, planName, dataCenter, environment string) (string, error) {
+	offeringQuery := fmt.Sprintf("catalog_name eq '%s'", offeringName)
+	if dataCenter != "" {
+		offeringQuery = fmt.Sprintf("catalog_name eq '%s' and data_center eq '%s'", offeringName, dataCenter)
+	}
 
 	execute, _, err := sm.GetServiceOfferings(ctx).FieldQuery(offeringQuery).Execute()
 	if err != nil {
@@ -134,13 +137,13 @@ func (sm *ServiceManagerClient) PlanIDByName(ctx context.Context, offeringName, 
 	}
 
 	planQuery := fmt.Sprintf("catalog_name eq '%s' and service_offering_id eq '%s'", planName, *execute.Items[0].Id)
-	object, _, err := sm.GetAllServicePlans(ctx).FieldQuery(planQuery).Execute()
+	object, _, err := sm.GetAllServicePlans(ctx).FieldQuery(planQuery).Environment(environment).Execute()
 	if err != nil {
 		return "", specifyAPIError(err)
 	}
 
 	if len(object.Items) == 0 {
-		return "", errors.Errorf("No service plan '%s' found for offering '%s'", planName, offeringName)
+		return "", errors.Errorf("No service plan '%s' found for offering '%s' in environment '%s'", planName, offeringName, environment)
 	}
 
 	servicePlanID := *object.Items[0].Id

--- a/internal/clients/servicemanager/api_plan_resolver_test.go
+++ b/internal/clients/servicemanager/api_plan_resolver_test.go
@@ -193,7 +193,7 @@ func TestPlanIDByName(t *testing.T) {
 				OfferingServiceFake{tc.args.listOfferingsMockFn},
 				PlansServiceFake{listPlansMockFn: tc.args.listPlansMockFn},
 			}
-			planID, err := smClient.PlanIDByName(context.TODO(), "Not relevant, since mocked", "Not relevant, since mocked", tc.args.dataCenter)
+			planID, err := smClient.PlanIDByName(context.TODO(), "Not relevant, since mocked", "Not relevant, since mocked", tc.args.dataCenter, "sapbtp")
 
 			if tc.wantErr != (err != nil) {
 				t.Errorf("Unexpected error return; Expected error: %v, Returned: %v", tc.wantErr, err)

--- a/internal/clients/servicemanager/service_instance_proxy_client.go
+++ b/internal/clients/servicemanager/service_instance_proxy_client.go
@@ -71,7 +71,7 @@ func (t ServiceManagerInstanceProxyClient) resolveServicePlan(ctx context.Contex
 			return "", err
 		}
 
-		id, err := resolver.PlanIDByName(ctx, ServiceManagerOfferingName, servicePlanName, "")
+		id, err := resolver.PlanIDByName(ctx, ServiceManagerOfferingName, servicePlanName, "", "sapbtp")
 		if err != nil {
 			return "", err
 		}

--- a/internal/clients/servicemanager/service_instance_proxy_client_test.go
+++ b/internal/clients/servicemanager/service_instance_proxy_client_test.go
@@ -178,7 +178,7 @@ type PlanIdResolverFake struct {
 	PlanLookupMockFn func() (string, error)
 }
 
-func (p *PlanIdResolverFake) PlanIDByName(ctx context.Context, offeringName, planName string, dataCenter string) (string, error) {
+func (p *PlanIdResolverFake) PlanIDByName(ctx context.Context, offeringName, planName, dataCenter, environment string) (string, error) {
 	return p.PlanLookupMockFn()
 }
 

--- a/internal/controller/account/cloudmanagement/cloudmanagement.go
+++ b/internal/controller/account/cloudmanagement/cloudmanagement.go
@@ -144,7 +144,7 @@ func (c *connector) InitializeServicePlanId(ctx context.Context, cr *apisv1beta1
 		return errors.Wrap(err, errGetPlanId)
 	}
 
-	id, err := sm.PlanIDByName(ctx, "cis", "local", "")
+	id, err := sm.PlanIDByName(ctx, "cis", "local", "", "sapbtp")
 	if err != nil {
 		return errors.Wrap(err, errGetPlanId)
 	}

--- a/internal/controller/account/cloudmanagement/cloudmanagement_test.go
+++ b/internal/controller/account/cloudmanagement/cloudmanagement_test.go
@@ -113,7 +113,7 @@ func TestConnect(t *testing.T) {
 				),
 				planIdResolverFn: func(ctx context.Context, secretData map[string][]byte) (servicemanager.PlanIdResolver, error) {
 					return PlanIDFake{
-						func(ctx context.Context, offeringName string, servicePlanName string, dataCenter string) (string, error) {
+						func(ctx context.Context, offeringName string, servicePlanName string, dataCenter string, environment string) (string, error) {
 							return "planID", nil
 						},
 					}, nil
@@ -161,7 +161,7 @@ func TestConnect(t *testing.T) {
 				),
 				planIdResolverFn: func(ctx context.Context, secretData map[string][]byte) (servicemanager.PlanIdResolver, error) {
 					return PlanIDFake{
-						func(ctx context.Context, offeringName string, servicePlanName string, dataCenter string) (string, error) {
+						func(ctx context.Context, offeringName string, servicePlanName string, dataCenter string, environment string) (string, error) {
 							return "planID", nil
 						},
 					}, nil
@@ -215,7 +215,7 @@ func TestConnect(t *testing.T) {
 				),
 				planIdResolverFn: func(ctx context.Context, secretData map[string][]byte) (servicemanager.PlanIdResolver, error) {
 					return PlanIDFake{
-						func(ctx context.Context, offeringName string, servicePlanName string, dataCenter string) (string, error) {
+						func(ctx context.Context, offeringName string, servicePlanName string, dataCenter string, environment string) (string, error) {
 							return "planID", nil
 						},
 					}, nil
@@ -676,11 +676,11 @@ func (t TfClientFake) DeleteResources(ctx context.Context, cr *v1beta1.CloudMana
 var _ servicemanager.PlanIdResolver = &PlanIDFake{}
 
 type PlanIDFake struct {
-	PlanIDByNameFn func(ctx context.Context, offeringName string, servicePlanName string, dataCenter string) (string, error)
+	PlanIDByNameFn func(ctx context.Context, offeringName string, servicePlanName string, dataCenter string, environment string) (string, error)
 }
 
-func (p PlanIDFake) PlanIDByName(ctx context.Context, offeringName string, servicePlanName string, dataCenter string) (string, error) {
-	return p.PlanIDByNameFn(ctx, offeringName, servicePlanName, dataCenter)
+func (p PlanIDFake) PlanIDByName(ctx context.Context, offeringName string, servicePlanName string, dataCenter string, environment string) (string, error) {
+	return p.PlanIDByNameFn(ctx, offeringName, servicePlanName, dataCenter, environment)
 }
 
 var _ cmclient.ITfClientInitializer = &ClientInitializerFake{}

--- a/internal/controller/account/serviceinstance/initializer.go
+++ b/internal/controller/account/serviceinstance/initializer.go
@@ -57,7 +57,11 @@ func (s *servicePlanInitializer) Initialize(kube client.Client, ctx context.Cont
 		return errors.Wrap(err, errInitPlanResolver)
 	}
 
-	planID, err := idResolver.PlanIDByName(ctx, cr.Spec.ForProvider.OfferingName, cr.Spec.ForProvider.PlanName, cr.Spec.ForProvider.DataCenter)
+	environment := cr.Spec.ForProvider.Environment
+	if environment == "" {
+		environment = "sapbtp"
+	}
+	planID, err := idResolver.PlanIDByName(ctx, cr.Spec.ForProvider.OfferingName, cr.Spec.ForProvider.PlanName, cr.Spec.ForProvider.DataCenter, environment)
 	if err != nil {
 		return errors.Wrap(err, errInitialize)
 	}

--- a/internal/controller/account/serviceinstance/initializer_test.go
+++ b/internal/controller/account/serviceinstance/initializer_test.go
@@ -210,6 +210,6 @@ type mockPlanIdResolver struct {
 	err    error
 }
 
-func (m *mockPlanIdResolver) PlanIDByName(ctx context.Context, offeringName, planName string, dataCenter string) (string, error) {
+func (m *mockPlanIdResolver) PlanIDByName(ctx context.Context, offeringName, planName, dataCenter, environment string) (string, error) {
 	return m.planID, m.err
 }


### PR DESCRIPTION
## Problem

The service plan ID resolver queries the Service Manager API for plans matching `catalog_name eq '<plan>'`. Without an environment filter, the SM API can return plans from multiple environments (`sapbtp`, `kubernetes`, `cloudfoundry`). When more than one plan is returned the resolver silently picks `Items[0]`, which may be the wrong plan for the intended environment.

## Fix

- Adds `spec.forProvider.environment` to the `ServiceInstance` CR
  - Enum: `sapbtp` | `kubernetes` | `cloudfoundry`
  - Default: `sapbtp`
- Passes the environment as a filter to the SM `GetAllServicePlans` query via the existing `.Environment()` parameter
- Updated error message includes the environment when no plan is found
- `cloudmanagement` and `service_instance_proxy_client` callers hardcoded to `sapbtp` (not user-facing)

## Test plan

- [ ] Unit tests pass: `go test ./internal/clients/servicemanager/... ./internal/controller/account/serviceinstance/... ./internal/controller/account/cloudmanagement/...`
- [ ] Verify `environment` field appears in CRD after `make generate`
- [ ] Manual test: create `ServiceInstance` with `environment: kubernetes` and confirm correct plan ID is resolved
- [ ] Existing `ServiceInstance` resources without `environment` field continue to work (default `sapbtp`)