### PR TITLE
fix: revert to 2.1.7 (latest patch) in e2e workflow

### DIFF
--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -49,10 +49,10 @@ env:
   E2E_PROVIDER_IMAGE: index.docker.io/e2e/provider-btp-amd64
   CROSSPLANE_CLI_VERSION: v2.0.2
   # renovate: datasource=helm depName=crossplane registryUrl=https://charts.crossplane.io/stable
-  CROSSPLANE_CHART_VERSION: '2.3.3'
-  # SHA256 of crossplane-2.3.3.tgz from upstream charts.crossplane.io/stable
+  CROSSPLANE_CHART_VERSION: '2.1.7'
+  # SHA256 of crossplane-2.1.7.tgz from upstream charts.crossplane.io/stable
   # index.yaml's `digest:` field. Update on every Crossplane version bump.
-  CROSSPLANE_CHART_SHA256: '327cadea168633b9dcaa71da1852fb308d837dd3f9c8a53410c155257df206c8'
+  CROSSPLANE_CHART_SHA256: '2b5242e1e8d91612f2e77a0c34d3de29abd757b02d6292c5b5b10dadca531a9e'
 
 jobs:
   prepare-matrix:


### PR DESCRIPTION
We merged https://github.com/SAP/crossplane-provider-btp/pull/785, which appears to be incompatible. 

Looks like some changes in crossplane 2.2.0 make it incompatible with the way we sideload the provider in our e2e tests.
See change logs: https://github.com/crossplane/crossplane/releases/tag/v2.2.0

For now we can revert to the latest patch release **2.1.7**, which is what this PR does.

## Side notes:
- _Will put a note in the upcoming renovate PR on this_
- Issues like that only come up after being merged to main, because workflows are loaded from main, that might cause issues in the future