### PR TITLE
fix(servicemanager,cloudmanagement): don't orphan the service instance when deleting with a missing binding

### DIFF
--- a/internal/clients/cis/cis_tf_client.go
+++ b/internal/clients/cis/cis_tf_client.go
@@ -186,6 +186,40 @@ func (tf *TfClient) ObserveResources(ctx context.Context, cr *apisv1beta1.CloudM
 	if err != nil {
 		return ResourcesStatus{}, err
 	}
+
+	// Deletion path: key ResourceExists off the INSTANCE alone.
+	//
+	// BTP invariant: a service instance cannot be deleted while a service
+	// binding still references it, so the binding is necessarily gone once the
+	// instance is gone. The instance's existence is therefore the
+	// authoritative "is there anything left in BTP" signal during deletion.
+	//
+	// Why this matters: the crossplane managed reconciler only calls Delete()
+	// while the observed resource still exists (reconciler.go: `if
+	// observation.ResourceExists && policy.ShouldDelete()`). If we report
+	// ResourceExists:false while the CR is being deleted, it skips Delete(),
+	// strips the finalizer and removes the CR — orphaning whatever is still in
+	// BTP. That is exactly the observed orphan incident: DeleteResources()
+	// deletes the binding FIRST and then the instance; if the instance delete
+	// errors or lags, the next Observe sees the binding gone, and the old
+	// two-phase-create gating below reported ResourceExists:false ("binding
+	// needs creation") which, under a deletion timestamp, finalized the CR and
+	// stranded the instance. Keying off the instance keeps Delete() firing
+	// until the instance is actually gone; only then do we report false and
+	// let the finalizer drop.
+	if meta.WasDeleted(cr) {
+		status := ResourcesStatus{
+			ExternalObservation: managed.ExternalObservation{
+				ResourceExists:   siObs.ResourceExists,
+				ResourceUpToDate: true,
+			},
+		}
+		if siObs.ResourceExists {
+			status.Instance = tf.sInstance.Status.AtProvider
+		}
+		return status, nil
+	}
+
 	if !siObs.ResourceExists {
 		return ResourcesStatus{
 			ExternalObservation: managed.ExternalObservation{ResourceExists: false},

--- a/internal/clients/cis/cis_tf_client_test.go
+++ b/internal/clients/cis/cis_tf_client_test.go
@@ -394,6 +394,94 @@ func TestObserveResources(t *testing.T) {
 				err: nil,
 			},
 		},
+		{
+			// REGRESSION GUARD (orphan bug): CR is being deleted, the instance
+			// still exists in BTP but the binding is already gone (e.g. the
+			// binding delete landed and the instance delete then errored/lagged,
+			// or the binding was removed out-of-band). The OLD code reported
+			// ResourceExists:false here ("binding needs creation"), which under a
+			// deletion timestamp made the managed reconciler skip Delete(), strip
+			// the finalizer and ORPHAN the instance in BTP. We must report
+			// ResourceExists:true so Delete() keeps firing until the instance is
+			// actually gone.
+			//
+			// The binding is intentionally NOT observed on the delete path (BTP
+			// invariant: an instance cannot be deleted while a binding references
+			// it, so instance-gone implies binding-gone). To prove the binding is
+			// never consulted here, its observeFn returns an error: if the code
+			// observed it, this test would surface that error.
+			name: "DeletingInstanceExistsBindingGone",
+			args: args{
+				siExternal: ExternalClientFake{
+					observeFn: func() (managed.ExternalObservation, error) {
+						return managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: true}, nil
+					},
+				},
+				sbExternal: ExternalClientFake{
+					observeFn: func() (managed.ExternalObservation, error) {
+						return managed.ExternalObservation{}, errors.New("binding must not be observed on the delete path")
+					},
+				},
+				cr: deletingCMCr(utilCloudManagementParams{extName: defaultExtName, siName: defaultInstanceName, sbName: defaultBindingName, statusInstanceID: defaultStatusInstanceID}),
+			},
+			want: want{
+				obs: ResourcesStatus{
+					ExternalObservation: managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: true},
+					Instance:            v1alpha1.SubaccountServiceInstanceObservation{ID: internal.Ptr(defaultInstanceID), Name: internal.Ptr(defaultInstanceName)},
+				},
+				err: nil,
+			},
+		},
+		{
+			// CR being deleted and the instance is gone from BTP. The binding is
+			// necessarily gone too (BTP invariant), so nothing remains: report
+			// ResourceExists:false and let the reconciler finalize the CR.
+			name: "DeletingInstanceGoneFinalizes",
+			args: args{
+				siExternal: ExternalClientFake{
+					observeFn: func() (managed.ExternalObservation, error) {
+						return managed.ExternalObservation{ResourceExists: false}, nil
+					},
+				},
+				sbExternal: ExternalClientFake{
+					observeFn: func() (managed.ExternalObservation, error) {
+						return managed.ExternalObservation{}, errors.New("binding must not be observed on the delete path")
+					},
+				},
+				cr: deletingCMCr(utilCloudManagementParams{extName: defaultExtName, siName: defaultInstanceName, sbName: defaultBindingName, statusInstanceID: defaultStatusInstanceID}),
+			},
+			want: want{
+				obs: ResourcesStatus{
+					ExternalObservation: managed.ExternalObservation{ResourceExists: false, ResourceUpToDate: true},
+				},
+				err: nil,
+			},
+		},
+		{
+			// CR being deleted and the instance still exists. Keep reporting
+			// exists so Delete() runs; binding is not consulted.
+			name: "DeletingInstanceExistsKeepsDeleting",
+			args: args{
+				siExternal: ExternalClientFake{
+					observeFn: func() (managed.ExternalObservation, error) {
+						return managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: false}, nil
+					},
+				},
+				sbExternal: ExternalClientFake{
+					observeFn: func() (managed.ExternalObservation, error) {
+						return managed.ExternalObservation{}, errors.New("binding must not be observed on the delete path")
+					},
+				},
+				cr: deletingCMCr(utilCloudManagementParams{extName: defaultExtName, siName: defaultInstanceName, sbName: defaultBindingName, statusInstanceID: defaultStatusInstanceID}),
+			},
+			want: want{
+				obs: ResourcesStatus{
+					ExternalObservation: managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: true},
+					Instance:            v1alpha1.SubaccountServiceInstanceObservation{ID: internal.Ptr(defaultInstanceID), Name: internal.Ptr(defaultInstanceName)},
+				},
+				err: nil,
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -665,6 +753,16 @@ func testCMCr(params utilCloudManagementParams) *v1beta1.CloudManagement {
 	}
 	meta.SetExternalName(sm, params.extName)
 	return sm
+}
+
+// deletingCMCr returns a CloudManagement CR that is mid-deletion (has a
+// DeletionTimestamp), which is what drives the delete-path branch in
+// ObserveResources.
+func deletingCMCr(params utilCloudManagementParams) *v1beta1.CloudManagement {
+	cr := testCMCr(params)
+	now := metav1.Now()
+	cr.SetDeletionTimestamp(&now)
+	return cr
 }
 
 func testServiceInstance(siId, siName string) *v1alpha1.SubaccountServiceInstance {

--- a/internal/clients/servicemanager/service_manager_tf_client.go
+++ b/internal/clients/servicemanager/service_manager_tf_client.go
@@ -203,6 +203,39 @@ func (tf *TfClient) ObserveResources(ctx context.Context, cr *apisv1beta1.Servic
 	if err != nil {
 		return ResourcesStatus{}, err
 	}
+
+	// Deletion path: key ResourceExists off the INSTANCE alone.
+	//
+	// BTP invariant: a service instance cannot be deleted while a service
+	// binding still references it, so the binding is necessarily gone once the
+	// instance is gone. The instance's existence is therefore the
+	// authoritative "is there anything left in BTP" signal during deletion.
+	//
+	// Why this matters: the crossplane managed reconciler only calls Delete()
+	// while the observed resource still exists (reconciler.go: `if
+	// observation.ResourceExists && policy.ShouldDelete()`). If we report
+	// ResourceExists:false while the CR is being deleted, it skips Delete(),
+	// strips the finalizer and removes the CR — orphaning whatever is still in
+	// BTP. DeleteResources() deletes the binding FIRST and then the instance;
+	// if the instance delete errors or lags, the next Observe sees the binding
+	// gone, and the two-phase-create gating below would report
+	// ResourceExists:false ("binding needs creation") which, under a deletion
+	// timestamp, finalizes the CR and strands the instance. Keying off the
+	// instance keeps Delete() firing until the instance is actually gone; only
+	// then do we report false and let the finalizer drop.
+	if meta.WasDeleted(cr) {
+		status := ResourcesStatus{
+			ExternalObservation: managed.ExternalObservation{
+				ResourceExists:   siObs.ResourceExists,
+				ResourceUpToDate: true,
+			},
+		}
+		if siObs.ResourceExists {
+			status.InstanceID = meta.GetExternalName(tf.sInstance)
+		}
+		return status, nil
+	}
+
 	if !siObs.ResourceExists {
 		return ResourcesStatus{
 			ExternalObservation: managed.ExternalObservation{ResourceExists: false},

--- a/internal/clients/servicemanager/service_manager_tf_client_test.go
+++ b/internal/clients/servicemanager/service_manager_tf_client_test.go
@@ -405,6 +405,71 @@ func TestObserveResources(t *testing.T) {
 				err: nil,
 			},
 		},
+		{
+			// REGRESSION GUARD (orphan bug): CR is being deleted, the instance
+			// still exists in BTP but the binding is already gone (binding delete
+			// landed and the instance delete then errored/lagged, or the binding
+			// was removed out-of-band). The OLD code reported ResourceExists:false
+			// here ("binding needs creation"), which under a deletion timestamp
+			// made the managed reconciler skip Delete(), strip the finalizer and
+			// ORPHAN the instance in BTP. We must report ResourceExists:true so
+			// Delete() keeps firing until the instance is actually gone.
+			//
+			// The binding is intentionally NOT observed on the delete path (BTP
+			// invariant: an instance cannot be deleted while a binding references
+			// it, so instance-gone implies binding-gone). Its observeFn returns an
+			// error to prove it is never consulted while deleting.
+			name: "DeletingInstanceExistsBindingGone",
+			args: args{
+				cr: deletingSMCr("subaccountId", "planId", "someID/anotherID", "", "", ""),
+				siExternal: ExternalClientFake{
+					observeFn: func() (managed.ExternalObservation, error) {
+						return managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: true}, nil
+					},
+				},
+				sbExternal: ExternalClientFake{
+					observeFn: func() (managed.ExternalObservation, error) {
+						return managed.ExternalObservation{}, errors.New("binding must not be observed on the delete path")
+					},
+				},
+				sInstance: testServiceInstance("someID"),
+				sBinding:  testServiceBinding("anotherID"),
+			},
+			want: want{
+				obs: ResourcesStatus{
+					ExternalObservation: managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: true},
+					InstanceID:          "someID",
+				},
+				err: nil,
+			},
+		},
+		{
+			// CR being deleted and the instance is gone from BTP. The binding is
+			// necessarily gone too (BTP invariant), so nothing remains: report
+			// ResourceExists:false and let the reconciler finalize the CR.
+			name: "DeletingInstanceGoneFinalizes",
+			args: args{
+				cr: deletingSMCr("subaccountId", "planId", "someID/anotherID", "", "", ""),
+				siExternal: ExternalClientFake{
+					observeFn: func() (managed.ExternalObservation, error) {
+						return managed.ExternalObservation{ResourceExists: false}, nil
+					},
+				},
+				sbExternal: ExternalClientFake{
+					observeFn: func() (managed.ExternalObservation, error) {
+						return managed.ExternalObservation{}, errors.New("binding must not be observed on the delete path")
+					},
+				},
+				sInstance: testServiceInstance("someID"),
+				sBinding:  testServiceBinding("anotherID"),
+			},
+			want: want{
+				obs: ResourcesStatus{
+					ExternalObservation: managed.ExternalObservation{ResourceExists: false, ResourceUpToDate: true},
+				},
+				err: nil,
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -722,6 +787,15 @@ func testSMCr(saId, planId, extName, statusInstanceID, serviceInstanceName, serv
 	}
 	meta.SetExternalName(sm, extName)
 	return sm
+}
+
+// deletingSMCr returns a ServiceManager CR that is mid-deletion (has a
+// DeletionTimestamp), which drives the delete-path branch in ObserveResources.
+func deletingSMCr(saId, planId, extName, statusInstanceID, serviceInstanceName, serviceBindingName string) *v1beta1.ServiceManager {
+	cr := testSMCr(saId, planId, extName, statusInstanceID, serviceInstanceName, serviceBindingName)
+	now := metav1.Now()
+	cr.SetDeletionTimestamp(&now)
+	return cr
 }
 
 func testServiceInstance(extName string) *v1alpha1.SubaccountServiceInstance {

--- a/internal/controller/account/cloudmanagement/cloudmanagement.go
+++ b/internal/controller/account/cloudmanagement/cloudmanagement.go
@@ -239,10 +239,20 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) (managed.Ext
 }
 
 func (c *external) setStatus(ctx context.Context, status cmclient.ResourcesStatus, cr *apisv1beta1.CloudManagement) error {
-	if status.ResourceExists {
+	switch {
+	case meta.WasDeleted(cr) && status.ResourceExists:
+		// Mid-deletion, external instance still present. Status-only cosmetic:
+		// finalization is gated on ExternalObservation.ResourceExists, not on
+		// this condition. But without this branch the CR flips back to
+		// Available/Bound between the Delete() call (which set Deleting()) and
+		// the reconcile that finally observes the instance gone, which is
+		// misleading in kubectl output and dashboards.
+		cr.Status.SetConditions(xpv1.Deleting())
+		cr.Status.AtProvider.Status = apisv1beta1.CisStatusUnbound
+	case status.ResourceExists:
 		cr.Status.SetConditions(xpv1.Available())
 		cr.Status.AtProvider.Status = apisv1beta1.CisStatusBound
-	} else {
+	default:
 		cr.Status.SetConditions(xpv1.Unavailable())
 		cr.Status.AtProvider.Status = apisv1beta1.CisStatusUnbound
 	}

--- a/internal/controller/account/cloudmanagement/cloudmanagement_test.go
+++ b/internal/controller/account/cloudmanagement/cloudmanagement_test.go
@@ -272,6 +272,10 @@ func TestConnect(t *testing.T) {
 }
 
 func TestObserve(t *testing.T) {
+	// deletionTime is captured once so cases that read/write DeletionTimestamp
+	// share the exact same value (otherwise two separate metav1.Now() calls
+	// in args vs want disagree at microsecond precision).
+	deletionTime := metav1.Now()
 	type want struct {
 		err error
 		obs managed.ExternalObservation
@@ -400,6 +404,40 @@ func TestObserve(t *testing.T) {
 						Binding:           &v1beta1.Binding{Id: internal.Ptr("anotherID")},
 					}),
 					WithConditions(xpv1.Available())),
+			},
+		},
+		{
+			// Regression: while the CR is being deleted and the underlying
+			// instance still exists (binding may or may not — the tf-client
+			// keys ResourceExists off the instance during delete), setStatus
+			// must report Deleting()/Unbound, not Available()/Bound. Under the
+			// pre-fix code the delete-aware ObserveResources returned
+			// ResourceExists:true which then flipped the CR back to Available
+			// on every reconcile between Delete() and the final finalize —
+			// misleading in kubectl output and dashboards.
+			name: "DeletingInstanceStillExists",
+			args: args{
+				cr: NewCloudManagement("test", WithDeletionTimestamp(deletionTime)),
+				tfClient: &TfClientFake{
+					observeFn: func() (cmclient.ResourcesStatus, error) {
+						return cmclient.ResourcesStatus{
+							ExternalObservation: managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: true},
+							Instance:            v1alpha1.SubaccountServiceInstanceObservation{ID: internal.Ptr("someID")},
+						}, nil
+					},
+				},
+			},
+			want: want{
+				obs: managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: true},
+				err: nil,
+				cr: NewCloudManagement("test",
+					WithDeletionTimestamp(deletionTime),
+					WithStatus(v1beta1.CloudManagementObservation{
+						Status:            v1alpha1.CisStatusUnbound,
+						ServiceInstanceID: "someID",
+						Instance:          &v1beta1.Instance{Id: internal.Ptr("someID")},
+					}),
+					WithConditions(xpv1.Deleting())),
 			},
 		},
 	}
@@ -643,6 +681,12 @@ func WithConditions(c ...xpv1.Condition) CloudManagementModifier {
 func WithExternalName(externalName string) CloudManagementModifier {
 	return func(r *v1beta1.CloudManagement) {
 		meta.SetExternalName(r, externalName)
+	}
+}
+
+func WithDeletionTimestamp(t metav1.Time) CloudManagementModifier {
+	return func(r *v1beta1.CloudManagement) {
+		r.SetDeletionTimestamp(&t)
 	}
 }
 

--- a/internal/controller/account/servicemanager/servicemanager.go
+++ b/internal/controller/account/servicemanager/servicemanager.go
@@ -191,10 +191,20 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) (managed.Ext
 }
 
 func (c *external) setStatus(ctx context.Context, status sm.ResourcesStatus, cr *apisv1beta1.ServiceManager) error {
-	if status.ResourceExists {
+	switch {
+	case meta.WasDeleted(cr) && status.ResourceExists:
+		// Mid-deletion, external instance still present. Status-only cosmetic:
+		// finalization is gated on ExternalObservation.ResourceExists, not on
+		// this condition. But without this branch the CR flips back to
+		// Available/Bound between the Delete() call (which set Deleting()) and
+		// the reconcile that finally observes the instance gone, which is
+		// misleading in kubectl output and dashboards.
+		cr.Status.SetConditions(xpv1.Deleting())
+		cr.Status.AtProvider.Status = apisv1beta1.ServiceManagerUnbound
+	case status.ResourceExists:
 		cr.Status.SetConditions(xpv1.Available())
 		cr.Status.AtProvider.Status = apisv1beta1.ServiceManagerBound
-	} else {
+	default:
 		cr.Status.SetConditions(xpv1.Unavailable())
 		cr.Status.AtProvider.Status = apisv1beta1.ServiceManagerUnbound
 	}

--- a/internal/controller/account/servicemanager/servicemanager_test.go
+++ b/internal/controller/account/servicemanager/servicemanager_test.go
@@ -282,6 +282,10 @@ func TestDelete_DeletionBlocking(t *testing.T) {
 }
 
 func TestObserve(t *testing.T) {
+	// deletionTime is captured once at test-setup so cases that read/write
+	// DeletionTimestamp share the exact same value (otherwise two separate
+	// metav1.Now() calls in args vs want disagree at microsecond precision).
+	deletionTime := metav1.Now()
 	type want struct {
 		err error
 		obs managed.ExternalObservation
@@ -372,6 +376,39 @@ func TestObserve(t *testing.T) {
 						ServiceBindingID:  "anotherID",
 					}),
 					WithConditions(xpv1.Available())),
+			},
+		},
+		{
+			// Regression: while the CR is being deleted and the underlying
+			// instance still exists (binding may or may not — the tf-client
+			// keys ResourceExists off the instance during delete), setStatus
+			// must report Deleting()/Unbound, not Available()/Bound. Under the
+			// pre-fix code the delete-aware ObserveResources returned
+			// ResourceExists:true which then flipped the CR back to Available
+			// on every reconcile between Delete() and the final finalize —
+			// misleading in kubectl output and dashboards.
+			name: "DeletingInstanceStillExists",
+			args: args{
+				cr: NewServiceManager("test", WithDeletionTimestamp(deletionTime)),
+				tfClient: &TfClientFake{
+					observeFn: func() (sm.ResourcesStatus, error) {
+						return sm.ResourcesStatus{
+							ExternalObservation: managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: true},
+							InstanceID:          "someID",
+						}, nil
+					},
+				},
+			},
+			want: want{
+				obs: managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: true},
+				err: nil,
+				cr: NewServiceManager("test",
+					WithDeletionTimestamp(deletionTime),
+					WithStatus(apisv1beta1.ServiceManagerObservation{
+						Status:            apisv1beta1.ServiceManagerUnbound,
+						ServiceInstanceID: "someID",
+					}),
+					WithConditions(xpv1.Deleting())),
 			},
 		},
 	}
@@ -664,6 +701,12 @@ func WithConditions(c ...xpv1.Condition) ServiceManagerModifier {
 func WithExternalName(externalName string) ServiceManagerModifier {
 	return func(r *apisv1beta1.ServiceManager) {
 		meta.SetExternalName(r, externalName)
+	}
+}
+
+func WithDeletionTimestamp(t metav1.Time) ServiceManagerModifier {
+	return func(r *apisv1beta1.ServiceManager) {
+		r.SetDeletionTimestamp(&t)
 	}
 }
 


### PR DESCRIPTION
## What

Fixes a delete-path orphan in **both** the **ServiceManager** and **CloudManagement** controllers: the Kubernetes CR is finalized and removed while its service instance is left stranded in BTP. Matches the observed incident — *CR gone from K8s, service binding gone, service instance still in BTP*.

Both controllers are structurally parallel: they provision a **service instance + binding** (two-phase create) and store them as a compound external-name `"<serviceInstanceID>/<serviceBindingID>"`, so both had the identical bug and get the identical fix.

## Root cause

The cis (`CloudManagement`) and servicemanager (`ServiceManager`) tf clients' `ObserveResources` reported `ResourceExists:false` whenever the **binding** was missing, so the managed reconciler would drive phase-2 (`createBinding`). Correct while creating — but it was applied unconditionally, **including while the CR is being deleted**.

The crossplane managed reconciler only calls `Delete()` while the observed resource still exists (`reconciler.go`: `if observation.ResourceExists && policy.ShouldDelete()`). Under a deletion timestamp, `ResourceExists:false` makes it skip `Delete()`, unpublish, strip the finalizer and remove the CR. So:

1. `DeleteResources()` deletes the **binding first**, then the instance.
2. If the instance delete errors/lags (async terraform destroy), the reconcile requeues.
3. The next `Observe` sees the binding already gone → reports `ResourceExists:false`.
4. The reconciler treats the resource as already deleted, strips the finalizer, and the CR disappears **while the service instance remains in BTP**.

Intermittent in the wild because most deletes remove binding + instance in the same reconcile; the orphan only occurs when the instance delete doesn't complete in the pass that removed the binding.

## Fix

Make `ObserveResources` delete-aware in both tf clients: when the CR has a deletion timestamp, key `ResourceExists` off the **instance alone**. BTP does not allow deleting a service instance while a binding references it, so the binding is necessarily gone once the instance is gone — the instance is the authoritative "is anything left in BTP" signal during deletion. This keeps `Delete()` firing until the instance is actually gone; only then does `Observe` report false and let the finalizer drop. The non-deleting two-phase-create gating is unchanged.

```go
if meta.WasDeleted(cr) {
    status := ResourcesStatus{
        ExternalObservation: managed.ExternalObservation{
            ResourceExists:   siObs.ResourceExists, // instance-only
            ResourceUpToDate: true,
        },
    }
    if siObs.ResourceExists {
        status.Instance /* or InstanceID */ = ...
    }
    return status, nil
}
```

## Mid-delete status reporting

With the delete-aware `Observe` returning `ResourceExists:true` while the instance still exists mid-delete, the controllers' `setStatus` would previously key off that bool alone and mark the CR `Available` / `Bound` between the `Delete()` call (which set `Deleting()`) and the reconcile that finally observes the instance gone. Purely cosmetic — finalize is gated on `ExternalObservation.ResourceExists`, not the condition — but misleading in `kubectl get` output and dashboards while a delete is in flight.

`setStatus` in both controllers now branches on `meta.WasDeleted(cr) && status.ResourceExists` → `Deleting()` / `Unbound`, and reports `Available` / `Bound` only when not deleting. Under 5 added lines per controller, no struct/API change.

## Testing

**Reproduced and verified end-to-end against real BTP on a kind cluster** (provider run out-of-cluster), for **both** CloudManagement and ServiceManager:

| | Before fix (buggy) | After fix |
|---|---|---|
| `Observe` during delete (binding gone, instance present) | `ResourceExists:false` | `ResourceExists:true` |
| `Delete()` external calls | **0** | **2** ("Successfully requested deletion") |
| CR finalized | ✅ immediately | ✅ after delete completes |
| service instance in BTP afterwards | **orphaned** ❌ | **deleted** ✅ (verified via `btp list services/instance`) |

Deterministic repro for each controller: get the resource to `Ready`, delete its binding out-of-band via the `btp` CLI, then delete the CR — forcing exactly the "binding gone, instance present, mid-deletion" edge state. Confirmed instance/binding presence at each step with `btp list services/instance|binding`; confirmed via BTP CLI that the instance is deleted (not just the CR).

**Unit regression tests** added:

- `cis_tf_client_test.go` and `service_manager_tf_client_test.go` — delete-path scenarios:
  - `DeletingInstanceExistsBindingGone` — instance exists, binding gone → `ResourceExists:true`.
  - `DeletingInstanceGoneFinalizes` — instance gone → `ResourceExists:false`.
  - (cis) `DeletingInstanceExistsKeepsDeleting` — instance exists, binding present → keeps deleting.

  The binding's fake `Observe` returns an error in the delete cases to prove the binding is **not** consulted on the delete path.

- `internal/controller/account/{servicemanager,cloudmanagement}/*_test.go` — new `DeletingInstanceStillExists` case in `TestObserve`:
  - Asserts the CR ends up with `Deleting()` + `Unbound` (not `Available()` + `Bound`) when a delete is in flight and the instance still exists.

All new tests **fail against the pre-fix code** (guard integrity verified) and pass against the fixed code.

`go build ./...`, `go test ./...`, and `golangci-lint run ./...` all clean.

## Notes for reviewers

- Distinct from #830 (semantic-lookup healing of orphaned external-names). That heals a CR that still exists with a fallback external-name; this fixes the delete path so the CR isn't finalized while the instance still exists. Different root cause, isolated on its own branch.
- Only the two tf clients + the two controllers changed:
  - `internal/clients/cis/cis_tf_client.go`
  - `internal/clients/servicemanager/service_manager_tf_client.go`
  - `internal/controller/account/cloudmanagement/cloudmanagement.go`
  - `internal/controller/account/servicemanager/servicemanager.go`
  - (plus their tests)
