### PR TITLE
fix: support custom IdP origin in CloudFoundryEnvironment initialOrgManagers

### DIFF
--- a/apis/environment/v1alpha1/cfenvironment_types.go
+++ b/apis/environment/v1alpha1/cfenvironment_types.go
@@ -45,7 +45,8 @@ func (u *User) String() string {
 
 // CfEnvironmentParameters are the configurable fields of a CloudFoundryEnvironment.
 type CfEnvironmentParameters struct {
-	// A list of users (email) to assign as the Org Manager role.
+	// A list of users to assign as the Org Manager role.
+	// Each entry is either a plain email address (uses "sap.ids" as origin) or "email|origin" to specify a custom identity provider (e.g. "user@company.com|custom.idp").
 	// The technical user referenced in the ProviderConfig is automatically added as Org Manager and can be omitted from this list (see https://help.sap.com/docs/btp/sap-business-technology-platform/about-roles-in-cloud-foundry-environment).
 	// Cannot be updated after creation --> initial creation only
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="OrgManagers can't be updated once set"

--- a/internal/clients/cfenvironment/cfenvironment.go
+++ b/internal/clients/cfenvironment/cfenvironment.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	cfv3 "github.com/cloudfoundry/go-cfclient/v3/client"
 	"github.com/cloudfoundry/go-cfclient/v3/config"
@@ -161,8 +162,9 @@ func (c CloudFoundryOrganization) CreateInstance(ctx context.Context, cr v1alpha
 		return "", errors.Wrap(err, instanceCreateFailed)
 	}
 
-	for _, managerEmail := range filterOutUser(cr.Spec.ForProvider.Managers, adminServiceAccountEmail) {
-		if err := cloudFoundryClient.addManager(ctx, managerEmail, defaultOrigin); err != nil {
+	for _, managerEntry := range filterOutUser(cr.Spec.ForProvider.Managers, adminServiceAccountEmail) {
+		username, origin := parseManagerString(managerEntry)
+		if err := cloudFoundryClient.addManager(ctx, username, origin); err != nil {
 			return "", errors.Wrap(err, instanceCreateFailed)
 		}
 	}
@@ -193,6 +195,15 @@ func filterOutUser(users []string, exclude string) []string {
 		}
 	}
 	return result
+}
+
+// parseManagerString parses "email" or "email|origin" into (username, origin).
+// If no origin is provided, defaults to defaultOrigin.
+func parseManagerString(s string) (username, origin string) {
+	if idx := strings.Index(s, "|"); idx >= 0 {
+		return s[:idx], s[idx+1:]
+	}
+	return s, defaultOrigin
 }
 
 type organizationClient struct {

--- a/internal/clients/cfenvironment/cfenvironment_test.go
+++ b/internal/clients/cfenvironment/cfenvironment_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"slices"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -248,8 +247,28 @@ func TestFilterOutUser(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := filterOutUser(tt.users, tt.exclude)
-			if !slices.Equal(got, tt.want) {
+			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("filterOutUser() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseManagerString(t *testing.T) {
+	tests := []struct {
+		input          string
+		wantUsername   string
+		wantOrigin     string
+	}{
+		{"user@example.com", "user@example.com", defaultOrigin},
+		{"user@example.com|custom.idp", "user@example.com", "custom.idp"},
+		{"user@example.com|sap.ids", "user@example.com", "sap.ids"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			gotUsername, gotOrigin := parseManagerString(tt.input)
+			if gotUsername != tt.wantUsername || gotOrigin != tt.wantOrigin {
+				t.Errorf("parseManagerString(%q) = (%q, %q), want (%q, %q)", tt.input, gotUsername, gotOrigin, tt.wantUsername, tt.wantOrigin)
 			}
 		})
 	}

--- a/package/crds/environment.btp.sap.crossplane.io_cloudfoundryenvironments.yaml
+++ b/package/crds/environment.btp.sap.crossplane.io_cloudfoundryenvironments.yaml
@@ -167,7 +167,8 @@ spec:
                     type: string
                   initialOrgManagers:
                     description: |-
-                      A list of users (email) to assign as the Org Manager role.
+                      A list of users to assign as the Org Manager role.
+                      Each entry is either a plain email address (uses "sap.ids" as origin) or "email|origin" to specify a custom identity provider (e.g. "user@company.com|custom.idp").
                       The technical user referenced in the ProviderConfig is automatically added as Org Manager and can be omitted from this list (see https://help.sap.com/docs/btp/sap-business-technology-platform/about-roles-in-cloud-foundry-environment).
                       Cannot be updated after creation --> initial creation only
                     items:


### PR DESCRIPTION
Fixes #505

## Summary

- The `initialOrgManagers` field previously hardcoded `sap.ids` as the identity provider origin for all CF Org Managers, making it impossible to add users from custom IdPs during environment creation.
- Entries now support an optional `|origin` suffix (e.g. `user@company.com|custom.idp`). Entries without a separator continue to default to `sap.ids`, preserving full backward compatibility with existing CRs.

## Backward Compatibility

This is intentionally a non-breaking change. The field type remains `[]string` so existing CRs require no migration.

A proper typed change (replacing `[]string` with `[]User`) is tracked in #837 and should be introduced when promoting this resource to `v1beta1`.

## Test plan

- [ ] Existing `TestFilterOutUser` tests still pass with no changes to behavior
- [ ] New `TestParseManagerString` covers plain email (defaults to `sap.ids`), `email|custom.idp`, and explicit `email|sap.ids`
- [ ] `go build ./...` passes cleanly