### PR TITLE
[DO NOT MERGE] Workaround: detect ServiceInstance parameter drift via Service Manager

### DIFF
--- a/internal/clients/servicemanager/recovery.go
+++ b/internal/clients/servicemanager/recovery.go
@@ -1,8 +1,11 @@
 package servicemanager
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -28,6 +31,16 @@ type SemanticLookuper interface {
 	// instance, and the binding name avoids returning a transient admin binding.
 	// The returned created_at is the instance's timestamp (phase-1 happens first).
 	LookupInstanceAndBinding(ctx context.Context, planID, instanceName, bindingName string) (serviceInstanceID, serviceBindingID string, instanceCreatedAt time.Time, found bool, err error)
+
+	// GetInstanceParameters returns the configuration parameters currently in
+	// effect for the given service instance, as reported by the Service Manager
+	// (GET /v1/service_instances/{id}/parameters). found is false when the
+	// offering does not return parameters (instances_retrievable=false) or the
+	// instance has none; callers must treat !found as "no drift signal
+	// available" and skip the parameter comparison. Nested objects are
+	// preserved (the value is decoded from the raw response body, not the
+	// flattened map[string]string the generated client returns).
+	GetInstanceParameters(ctx context.Context, serviceInstanceID string) (params map[string]any, found bool, err error)
 }
 
 var _ SemanticLookuper = &ServiceManagerClient{}
@@ -94,6 +107,50 @@ func (sm *ServiceManagerClient) lookupRotatedBinding(ctx context.Context, servic
 			"refusing to recover: %d ready rotated bindings match prefix %q for service instance %q",
 			len(ready), prefix, serviceInstanceID)
 	}
+}
+
+// GetInstanceParameters implements SemanticLookuper.
+func (sm *ServiceManagerClient) GetInstanceParameters(ctx context.Context, serviceInstanceID string) (map[string]any, bool, error) {
+	// The generated Execute() decodes into map[string]string, which flattens
+	// nested parameter objects; we ignore that value and re-decode the raw
+	// response body (buffered back onto resp.Body by the generated client) into
+	// map[string]any so nested objects like {"backend":{...}} survive.
+	_, resp, err := sm.ServiceInstancesAPI.
+		GetServiceInstanceParameters(ctx, serviceInstanceID).Execute()
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		// A 404 / 400 (e.g. offering with instances_retrievable=false) is not a
+		// hard error for drift purposes: no parameters available means no drift
+		// signal, so the caller skips the comparison.
+		if resp != nil && (resp.StatusCode == 404 || resp.StatusCode == 400) {
+			return nil, false, nil
+		}
+		return nil, false, specifyAPIError(err)
+	}
+	if resp == nil {
+		return nil, false, nil
+	}
+
+	body, rerr := io.ReadAll(resp.Body)
+	if rerr != nil {
+		return nil, false, rerr
+	}
+	body = bytes.TrimSpace(body)
+	if len(body) == 0 || string(body) == "null" || string(body) == "{}" {
+		return nil, false, nil
+	}
+
+	params := map[string]any{}
+	if jerr := json.Unmarshal(body, &params); jerr != nil {
+		// A non-object body is treated as "no parameters", not an error.
+		return nil, false, nil
+	}
+	if len(params) == 0 {
+		return nil, false, nil
+	}
+	return params, true, nil
 }
 
 func (sm *ServiceManagerClient) LookupInstanceAndBinding(ctx context.Context, planID, instanceName, bindingName string) (string, string, time.Time, bool, error) {

--- a/internal/controller/account/servicebinding/servicebinding_recovery_test.go
+++ b/internal/controller/account/servicebinding/servicebinding_recovery_test.go
@@ -49,6 +49,10 @@ func (l *sbLookuperFake) LookupInstanceAndBinding(ctx context.Context, planID, i
 	return "", "", time.Time{}, false, nil
 }
 
+func (l *sbLookuperFake) GetInstanceParameters(ctx context.Context, serviceInstanceID string) (map[string]any, bool, error) {
+	return nil, false, nil
+}
+
 type sbRecorderFake struct{ events []string }
 
 func (r *sbRecorderFake) Event(_ runtimeobj.Object, e event.Event) {

--- a/internal/controller/account/serviceinstance/params_compare.go
+++ b/internal/controller/account/serviceinstance/params_compare.go
@@ -1,0 +1,94 @@
+package serviceinstance
+
+import (
+	"encoding/json"
+)
+
+// paramsSubsetMatch reports whether every key in desired is present in server
+// with an equal (deep, order-independent) value. Keys that exist only on the
+// server side are ignored.
+//
+// This asymmetry is deliberate and is what makes reading BTP service-instance
+// parameters safe as a drift signal despite the two constraints the BTP
+// Terraform provider maintainers called out (terraform-provider-btp#1643):
+//
+//  1. Not every offering returns parameters — handled by the caller, which
+//     skips the comparison entirely when the server returns no parameters.
+//  2. There is no contract that returned parameters match the create/update
+//     schema — the server may add defaults or extra fields. A full equality
+//     check would flag those as drift forever. Subset matching only asserts
+//     "everything I asked for is in effect", never "the server looks exactly
+//     like my request", so server-added defaults never cause phantom drift.
+//
+// Comparison is structural (both sides are decoded from JSON into any), so
+// object key ordering is irrelevant and nested objects are compared recursively.
+//
+// SCOPE — ADD/CHANGE ONLY, NO DELETE. This detects a desired parameter that is
+// added or changed relative to the server, but deliberately does NOT detect a
+// parameter that was previously set and is now removed from the desired spec.
+// Reason (verified empirically against a live SAP BTP object-store broker,
+// July 2026): parameter deletion is not reliably expressible over the Service
+// Manager update API.
+//   - Sending an empty object {} is a no-op — the broker keeps all existing
+//     parameters.
+//   - Sending a non-empty object that omits a previously-set key does NOT reset
+//     that key; the broker merges, keeping the old value.
+//   - Sending an explicit null for a key crashes the broker (HTTP 500).
+//
+// Because a removed key cannot be cleared through an update, forcing drift on
+// deletion would either loop forever (update sent, server unchanged, drift
+// re-detected) or fail the update outright. The only reliable way to remove a
+// parameter is to recreate the instance. Deletion is therefore left to the
+// normal spec-driven recreate path, not to this drift signal.
+func paramsSubsetMatch(desired, server map[string]any) bool {
+	for k, dv := range desired {
+		sv, ok := server[k]
+		if !ok {
+			return false
+		}
+		if !deepValueEqual(dv, sv) {
+			return false
+		}
+	}
+	return true
+}
+
+// deepValueEqual compares two JSON-decoded values. Objects are compared as a
+// subset (desired ⊆ server) recursively; arrays and scalars require full
+// equality. Numbers are compared via their JSON encoding so that, e.g., an
+// int-typed desired value and a float64-typed decoded server value that
+// represent the same number compare equal.
+func deepValueEqual(desired, server any) bool {
+	switch dv := desired.(type) {
+	case map[string]any:
+		sv, ok := server.(map[string]any)
+		if !ok {
+			return false
+		}
+		return paramsSubsetMatch(dv, sv)
+	case []any:
+		sv, ok := server.([]any)
+		if !ok || len(dv) != len(sv) {
+			return false
+		}
+		for i := range dv {
+			if !deepValueEqual(dv[i], sv[i]) {
+				return false
+			}
+		}
+		return true
+	default:
+		return scalarEqual(desired, server)
+	}
+}
+
+// scalarEqual compares two scalar JSON values tolerant of Go type differences
+// introduced by json.Unmarshal (e.g. json.Number vs float64 vs int).
+func scalarEqual(a, b any) bool {
+	ab, err1 := json.Marshal(a)
+	bb, err2 := json.Marshal(b)
+	if err1 != nil || err2 != nil {
+		return false
+	}
+	return string(ab) == string(bb)
+}

--- a/internal/controller/account/serviceinstance/params_compare_test.go
+++ b/internal/controller/account/serviceinstance/params_compare_test.go
@@ -1,0 +1,112 @@
+package serviceinstance
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func mustMap(t *testing.T, s string) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal([]byte(s), &m); err != nil {
+		t.Fatalf("bad test json %q: %v", s, err)
+	}
+	return m
+}
+
+func TestParamsSubsetMatch(t *testing.T) {
+	cases := []struct {
+		name    string
+		desired string
+		server  string
+		want    bool
+	}{
+		{
+			name:    "exact match",
+			desired: `{"ingest_otlp":{"enabled":true}}`,
+			server:  `{"ingest_otlp":{"enabled":true}}`,
+			want:    true,
+		},
+		{
+			name:    "server has extra defaults (must NOT be drift)",
+			desired: `{"ingest_otlp":{"enabled":true}}`,
+			server:  `{"ingest_otlp":{"enabled":true},"retention_period":0,"saml":{"enabled":true},"rotate_root_ca":true}`,
+			want:    true,
+		},
+		{
+			name:    "key order irrelevant",
+			desired: `{"backend":{"api_enabled":true,"max_data_nodes":2},"ingest_otlp":{"enabled":true}}`,
+			server:  `{"ingest_otlp":{"enabled":true},"backend":{"max_data_nodes":2,"api_enabled":true}}`,
+			want:    true,
+		},
+		{
+			name:    "desired adds nested field the server lacks (IS drift)",
+			desired: `{"ingest_otlp":{"enabled":true,"span_passthrough":true}}`,
+			server:  `{"ingest_otlp":{"enabled":true}}`,
+			want:    false,
+		},
+		{
+			name:    "desired value differs from server (IS drift)",
+			desired: `{"ingest_otlp":{"enabled":true}}`,
+			server:  `{"ingest_otlp":{"enabled":false}}`,
+			want:    false,
+		},
+		{
+			name:    "desired top-level key missing on server (IS drift)",
+			desired: `{"backend":{"api_enabled":true}}`,
+			server:  `{"ingest_otlp":{"enabled":true}}`,
+			want:    false,
+		},
+		{
+			name:    "empty desired always matches",
+			desired: `{}`,
+			server:  `{"ingest_otlp":{"enabled":true}}`,
+			want:    true,
+		},
+		{
+			name:    "number type tolerance (int vs float)",
+			desired: `{"backend":{"max_data_nodes":2}}`,
+			server:  `{"backend":{"max_data_nodes":2.0}}`,
+			want:    true,
+		},
+		{
+			name:    "array equality required",
+			desired: `{"feature_flags":["a","b"]}`,
+			server:  `{"feature_flags":["a","b"]}`,
+			want:    true,
+		},
+		{
+			name:    "array order matters (IS drift)",
+			desired: `{"feature_flags":["a","b"]}`,
+			server:  `{"feature_flags":["b","a"]}`,
+			want:    false,
+		},
+		{
+			// Empirically-motivated: object-store-style instance where the
+			// broker materializes many defaults the spec never set. Only the
+			// one desired key is asserted; the defaults are ignored, so no
+			// phantom drift.
+			name:    "object-store defaults ignored, single desired key present",
+			desired: `{"backupEnabled":true}`,
+			server:  `{"backupEnabled":true,"backupRetentionPeriod":20,"versioning":true,"preventDeletion":false,"autoExpiration":[{"id":"x"}]}`,
+			want:    true,
+		},
+		{
+			// DELETE is intentionally NOT detected (see paramsSubsetMatch doc):
+			// a key removed from desired but still present on the server is not
+			// drift, because it cannot be cleared via the update API.
+			name:    "key removed from desired still on server -> NOT drift (by design)",
+			desired: `{"ingest_otlp":{"enabled":true}}`,
+			server:  `{"ingest_otlp":{"enabled":true,"span_passthrough":true}}`,
+			want:    true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := paramsSubsetMatch(mustMap(t, tc.desired), mustMap(t, tc.server))
+			if got != tc.want {
+				t.Errorf("paramsSubsetMatch(%s, %s) = %v, want %v", tc.desired, tc.server, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/controller/account/serviceinstance/params_drift_test.go
+++ b/internal/controller/account/serviceinstance/params_drift_test.go
@@ -1,0 +1,103 @@
+package serviceinstance
+
+import (
+	"context"
+	"testing"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/meta"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
+
+	"github.com/sap/crossplane-provider-btp/apis/account/v1alpha1"
+	smClient "github.com/sap/crossplane-provider-btp/internal/clients/servicemanager"
+)
+
+// siWithParams builds a ServiceInstance CR with the given desired parameters
+// JSON and an external-name (BTP guid) so parametersDrifted proceeds past its
+// guards.
+func siWithParams(paramsJSON string) *v1alpha1.ServiceInstance {
+	cr := &v1alpha1.ServiceInstance{}
+	cr.SetName("cls-test")
+	meta.SetExternalName(cr, "11111111-1111-1111-1111-111111111111")
+	if paramsJSON != "" {
+		cr.Spec.ForProvider.Parameters.Raw = []byte(paramsJSON)
+	}
+	return cr
+}
+
+func TestParametersDrifted(t *testing.T) {
+	kube := &test.MockClient{} // not consulted: no ParameterSecretRefs in these cases
+
+	cases := []struct {
+		name         string
+		cr           *v1alpha1.ServiceInstance
+		lookuper     *lookuperFake
+		noLookuperFn bool
+		want         bool
+		wantCalls    int
+	}{
+		{
+			name:     "desired subset present on server -> no drift",
+			cr:       siWithParams(`{"ingest_otlp":{"enabled":true}}`),
+			lookuper: &lookuperFake{paramsFound: true, paramsResult: map[string]any{"ingest_otlp": map[string]any{"enabled": true}, "retention_period": float64(0)}},
+			want:     false, wantCalls: 1,
+		},
+		{
+			name:     "desired adds span_passthrough missing on server -> drift",
+			cr:       siWithParams(`{"ingest_otlp":{"enabled":true,"span_passthrough":true}}`),
+			lookuper: &lookuperFake{paramsFound: true, paramsResult: map[string]any{"ingest_otlp": map[string]any{"enabled": true}}},
+			want:     true, wantCalls: 1,
+		},
+		{
+			name:     "server returns no parameters (not retrievable) -> skip, no drift",
+			cr:       siWithParams(`{"ingest_otlp":{"enabled":true}}`),
+			lookuper: &lookuperFake{paramsFound: false},
+			want:     false, wantCalls: 1,
+		},
+		{
+			name:     "lookuper error -> fail-safe, no drift",
+			cr:       siWithParams(`{"ingest_otlp":{"enabled":true}}`),
+			lookuper: &lookuperFake{paramsErr: context.DeadlineExceeded},
+			want:     false, wantCalls: 1,
+		},
+		{
+			name:     "no desired parameters -> skip before any call",
+			cr:       siWithParams(``),
+			lookuper: &lookuperFake{paramsFound: true, paramsResult: map[string]any{"x": 1}},
+			want:     false, wantCalls: 0,
+		},
+		{
+			name: "no external-name yet -> skip before any call",
+			cr: func() *v1alpha1.ServiceInstance {
+				c := siWithParams(`{"a":1}`)
+				meta.SetExternalName(c, "cls-test")
+				return c
+			}(),
+			lookuper: &lookuperFake{paramsFound: true, paramsResult: map[string]any{"a": float64(1)}},
+			want:     false, wantCalls: 0,
+		},
+		{
+			name:         "no admin lookuper configured -> skip",
+			cr:           siWithParams(`{"a":1}`),
+			noLookuperFn: true,
+			want:         false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := external{kube: kube}
+			if !tc.noLookuperFn {
+				e.newAdminLookuperFn = func(context.Context, *v1alpha1.ServiceInstance) (smClient.SemanticLookuper, func(), error) {
+					return tc.lookuper, func() {}, nil
+				}
+			}
+			got := e.parametersDrifted(context.Background(), tc.cr)
+			if got != tc.want {
+				t.Errorf("parametersDrifted = %v, want %v", got, tc.want)
+			}
+			if tc.lookuper != nil && tc.lookuper.paramsCalls != tc.wantCalls {
+				t.Errorf("GetInstanceParameters calls = %d, want %d", tc.lookuper.paramsCalls, tc.wantCalls)
+			}
+		})
+	}
+}

--- a/internal/controller/account/serviceinstance/serviceinstance.go
+++ b/internal/controller/account/serviceinstance/serviceinstance.go
@@ -2,6 +2,7 @@ package serviceinstance
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -244,6 +245,22 @@ func (e *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 			}
 		}
 
+		// The bundled BTP Terraform provider discards service-instance
+		// `parameters` on read, so its diff never covers them and a
+		// parameters-only change is reported as UpToDate. Compensate by
+		// comparing the desired parameters against what the Service Manager
+		// actually has, and force an update when they diverge. Skipped for
+		// Observe-only resources and whenever the server exposes no parameters
+		// (see parametersDrifted).
+		if !isObserveOnly(cr) {
+			if e.parametersDrifted(ctx, cr) {
+				return managed.ExternalObservation{
+					ResourceExists:   true,
+					ResourceUpToDate: false,
+				}, nil
+			}
+		}
+
 		return managed.ExternalObservation{
 			ResourceExists:    true,
 			ResourceUpToDate:  true,
@@ -310,6 +327,71 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) (managed.Ext
 		return managed.ExternalDelete{}, errors.Wrap(err, errDeleteInstance)
 	}
 	return managed.ExternalDelete{}, nil
+}
+
+// parametersDrifted reports whether the desired service-instance parameters
+// (spec + resolved secret refs) are NOT fully reflected by what the Service
+// Manager currently has. It exists to compensate for the bundled BTP Terraform
+// provider dropping `parameters` on read, which otherwise makes a
+// parameters-only change invisible to drift detection.
+//
+// It is deliberately fail-safe: any inability to determine drift with
+// confidence (no admin lookuper, lookup/fetch error, offering that does not
+// return parameters, unparseable desired spec) returns false, preserving the
+// pre-existing behaviour rather than forcing a spurious update. It never
+// returns true unless it positively observed that a desired key is missing or
+// differs on the server, so it cannot cause an update loop: after Update()
+// writes the parameters, the next fetch reflects them and the comparison
+// matches.
+//
+// The comparison is a subset match (desired ⊆ server), which tolerates the two
+// BTP constraints that block a Terraform-side fix (terraform-provider-btp#1643):
+// offerings that do not return parameters (handled via found==false) and
+// server-added defaults / extra fields (ignored by the subset semantics). It
+// detects added/changed parameters only, never deletions — see paramsSubsetMatch
+// for why parameter removal is not expressible over the update API.
+func (e *external) parametersDrifted(ctx context.Context, cr *v1alpha1.ServiceInstance) bool {
+	if e.newAdminLookuperFn == nil {
+		return false
+	}
+
+	// Desired parameters, built exactly as they are sent to the TF layer.
+	desiredJSON, err := siClient.BuildComplexParameterJson(
+		ctx, e.kube, cr.Spec.ForProvider.ParameterSecretRefs, cr.Spec.ForProvider.Parameters.Raw)
+	if err != nil {
+		log.FromContext(ctx).V(1).Info("parameter drift check skipped: cannot build desired parameters", "error", err.Error())
+		return false
+	}
+	desired := map[string]any{}
+	if uerr := json.Unmarshal(desiredJSON, &desired); uerr != nil || len(desired) == 0 {
+		// No desired parameters -> nothing to enforce.
+		return false
+	}
+
+	guid := meta.GetExternalName(cr)
+	if guid == "" || guid == cr.Name {
+		// No real BTP id yet (not created / not adopted) -> nothing to compare.
+		return false
+	}
+
+	lookuper, cleanup, err := e.newAdminLookuperFn(ctx, cr)
+	if err != nil {
+		log.FromContext(ctx).V(1).Info("parameter drift check skipped: cannot obtain admin lookup client", "error", err.Error())
+		return false
+	}
+	defer cleanup()
+
+	server, found, err := lookuper.GetInstanceParameters(ctx, guid)
+	if err != nil {
+		log.FromContext(ctx).V(1).Info("parameter drift check skipped: cannot read server parameters", "error", err.Error())
+		return false
+	}
+	if !found {
+		// Offering does not return parameters (or none set) -> no drift signal.
+		return false
+	}
+
+	return !paramsSubsetMatch(desired, server)
 }
 
 func (e *external) healExternalName(ctx context.Context, cr *v1alpha1.ServiceInstance) error {

--- a/internal/controller/account/serviceinstance/serviceinstance_recovery_test.go
+++ b/internal/controller/account/serviceinstance/serviceinstance_recovery_test.go
@@ -49,6 +49,13 @@ type lookuperFake struct {
 	siErr       error
 	gotName     string
 	calls       int
+
+	// GetInstanceParameters behaviour
+	paramsResult map[string]any
+	paramsFound  bool
+	paramsErr    error
+	paramsGUID   string
+	paramsCalls  int
 }
 
 func (l *lookuperFake) LookupServiceInstance(ctx context.Context, name string) (string, time.Time, bool, error) {
@@ -63,6 +70,12 @@ func (l *lookuperFake) LookupServiceBinding(ctx context.Context, serviceInstance
 
 func (l *lookuperFake) LookupInstanceAndBinding(ctx context.Context, planID, instanceName, bindingName string) (string, string, time.Time, bool, error) {
 	return "", "", time.Time{}, false, nil
+}
+
+func (l *lookuperFake) GetInstanceParameters(ctx context.Context, serviceInstanceID string) (map[string]any, bool, error) {
+	l.paramsCalls++
+	l.paramsGUID = serviceInstanceID
+	return l.paramsResult, l.paramsFound, l.paramsErr
 }
 
 func mkFactory(lk *lookuperFake) func(context.Context, *v1alpha1.ServiceInstance) (smClient.SemanticLookuper, func(), error) {

--- a/internal/controller/account/servicemanager/servicemanager_recovery_test.go
+++ b/internal/controller/account/servicemanager/servicemanager_recovery_test.go
@@ -53,6 +53,10 @@ func (l *smLookuperFake) LookupInstanceAndBinding(ctx context.Context, planID, i
 	return l.siID, l.sbID, l.siCreatedAt, l.found, l.err
 }
 
+func (l *smLookuperFake) GetInstanceParameters(ctx context.Context, serviceInstanceID string) (map[string]any, bool, error) {
+	return nil, false, nil
+}
+
 type smRecorderFake struct{ events []string }
 
 func (r *smRecorderFake) Event(_ runtimeobj.Object, e event.Event) {

--- a/test/e2e/serviceinstance_test.go
+++ b/test/e2e/serviceinstance_test.go
@@ -24,6 +24,7 @@ import (
 
 var (
 	siCreateName = "e2e-destination-instance"
+	siDriftName  = "e2e-onemds-drift-instance"
 )
 
 func TestServiceInstance_CreationFlow(t *testing.T) {
@@ -52,6 +53,31 @@ func TestServiceInstance_CreationFlow(t *testing.T) {
 				return ctx
 			},
 		).Assess(
+		// destination is instances_retrievable:false: the Service Manager does
+		// NOT return its parameters, so the parameter-drift compensation must
+		// SKIP the comparison. This asserts the instance settles and does not
+		// keep reconciling — i.e. we never force a phantom update on a
+		// non-retrievable offering (which would otherwise loop forever, since
+		// the parameters can never be read back to match).
+		"Non-retrievable instance stays settled (no phantom parameter drift)", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			first := &v1alpha1.ServiceInstance{}
+			MustGetResource(t, cfg, siCreateName, nil, first)
+			gen := first.Status.ObservedGeneration
+
+			time.Sleep(3 * time.Minute)
+
+			after := &v1alpha1.ServiceInstance{}
+			MustGetResource(t, cfg, siCreateName, nil, after)
+			if after.Status.ObservedGeneration != gen {
+				t.Errorf("non-retrievable instance kept reconciling: observedGeneration moved %d -> %d (phantom parameter drift?)",
+					gen, after.Status.ObservedGeneration)
+			}
+			if s := after.GetCondition(xpv1.TypeSynced); s.Status != "True" {
+				t.Errorf("non-retrievable instance not Synced after settle: %v", s)
+			}
+			return ctx
+		},
+	).Assess(
 		"Properly delete all resources", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
 			// k8s resource cleaned up?
 			si := &v1alpha1.ServiceInstance{}
@@ -94,4 +120,138 @@ func TestServiceInstanceImportFlow(t *testing.T) {
 
 	importFeature := importTester.BuildTestFeature("BTP ServiceInstance Import Flow").Feature()
 	testenv.Test(t, importFeature)
+}
+
+// TestServiceInstance_ParameterDrift verifies the parameter-drift compensation
+// for the bundled BTP Terraform provider's dropped-parameters bug. It runs
+// against a one-mds instance (free sap-integration plan, instances_retrievable
+// :true and update-allowed), so the Service Manager actually returns the
+// parameters that the drift check compares.
+//
+// The flow proves the two properties that matter:
+//   - a parameters-only change on an existing instance is detected and applied
+//     (add/change drift), and
+//   - once applied, the instance settles and does NOT keep re-updating
+//     (loop-safety; server-side defaults / extra fields must not read as drift).
+func TestServiceInstance_ParameterDrift(t *testing.T) {
+	driftFeatureSuite := features.New("ServiceInstance Parameter Drift").
+		Setup(
+			func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+				resources.ImportResources(ctx, t, cfg, crsPath("serviceinstance_drift"))
+				r, _ := res.New(cfg.Client().RESTConfig())
+				_ = apis.AddToScheme(r.GetScheme())
+
+				si := v1alpha1.ServiceInstance{
+					ObjectMeta: metav1.ObjectMeta{Name: siDriftName, Namespace: cfg.Namespace()},
+				}
+				waitForResource(&si, cfg, t, wait.WithTimeout(15*time.Minute))
+				return ctx
+			},
+		).
+		Assess(
+			"Instance is Ready with initial parameters", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+				si := &v1alpha1.ServiceInstance{}
+				MustGetResource(t, cfg, siDriftName, nil, si)
+				if si.Status.AtProvider.ID == "" {
+					t.Error("one-mds ServiceInstance not fully initialized")
+				}
+				return ctx
+			},
+		).
+		Assess(
+			"parameters-only change is detected and applied", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+				observed := &v1alpha1.ServiceInstance{}
+				MustGetResource(t, cfg, siDriftName, nil, observed)
+				genBefore := observed.GetGeneration()
+
+				// Change businessSystemId — a parameters-only change. Without the
+				// drift compensation the TF provider would report UpToDate and
+				// this would never reach BTP. enableTenantDeletion is kept so the
+				// teardown can still deprovision the instance.
+				updated := observed.DeepCopy()
+				updated.Spec.ForProvider.Parameters = runtime.RawExtension{
+					Raw: []byte(`{"businessSystemId":"e2e-updated","enableTenantDeletion":true}`),
+				}
+				if err := cfg.Client().Resources().Update(ctx, updated); err != nil {
+					t.Fatalf("failed to update ServiceInstance parameters: %v", err)
+				}
+
+				// The spec change bumps metadata.generation. The parameter-drift
+				// compensation must drive a reconcile that carries the new
+				// generation and settles Synced+Available. This provider does
+				// NOT populate the top-level status.observedGeneration (it stays
+				// 0); instead each condition carries the generation it was set
+				// for (see saveCallback in the controller), so we assert on the
+				// Synced condition's ObservedGeneration.
+				var last *v1alpha1.ServiceInstance
+				err := wait.For(
+					func(ctx context.Context) (bool, error) {
+						si := &v1alpha1.ServiceInstance{}
+						MustGetResource(t, cfg, siDriftName, nil, si)
+						last = si
+						synced := si.GetCondition(xpv1.TypeSynced)
+						avail := si.GetCondition(xpv1.Available().Type)
+						return synced.Status == "True" &&
+							avail.Status == "True" &&
+							synced.ObservedGeneration >= si.GetGeneration() &&
+							si.GetGeneration() > genBefore, nil
+					},
+					wait.WithTimeout(10*time.Minute),
+					wait.WithInterval(10*time.Second),
+				)
+				if err != nil {
+					if last != nil {
+						s := last.GetCondition(xpv1.TypeSynced)
+						a := last.GetCondition(xpv1.Available().Type)
+						t.Errorf("parameter update did not settle: err=%v; gen=%d genBefore=%d synced=%s(obsGen=%d) avail=%s",
+							err, last.GetGeneration(), genBefore, s.Status, s.ObservedGeneration, a.Status)
+					} else {
+						t.Errorf("parameter update did not settle: %v", err)
+					}
+				}
+				return ctx
+			},
+		).
+		Assess(
+			"instance stays settled (no update loop, defaults not drift)", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+				// Sample the metadata.generation, wait through several reconcile
+				// cycles, and require it not to advance — i.e. the drift check
+				// does not keep forcing updates (which each bump generation via
+				// our re-applied spec) once the parameters match. The server
+				// returns extra defaults; those must be ignored by the subset
+				// comparison, otherwise this would loop.
+				first := &v1alpha1.ServiceInstance{}
+				MustGetResource(t, cfg, siDriftName, nil, first)
+				gen := first.GetGeneration()
+				syncedBefore := first.GetCondition(xpv1.TypeSynced).ObservedGeneration
+
+				time.Sleep(3 * time.Minute)
+
+				after := &v1alpha1.ServiceInstance{}
+				MustGetResource(t, cfg, siDriftName, nil, after)
+				if after.GetGeneration() != gen {
+					t.Errorf("instance kept changing: generation moved %d -> %d (parameter drift loop?)",
+						gen, after.GetGeneration())
+				}
+				syncedAfter := after.GetCondition(xpv1.TypeSynced)
+				if syncedAfter.Status != "True" {
+					t.Errorf("instance not Synced after settle: %v", syncedAfter)
+				}
+				// The Synced condition should also have stopped advancing its
+				// observed generation (no repeated update reconciles).
+				if syncedAfter.ObservedGeneration != syncedBefore {
+					t.Errorf("Synced condition kept re-observing: obsGen %d -> %d (drift loop?)",
+						syncedBefore, syncedAfter.ObservedGeneration)
+				}
+				return ctx
+			},
+		).
+		Teardown(
+			func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+				DeleteResourcesIgnoreMissing(ctx, t, cfg, "serviceinstance_drift", wait.WithTimeout(time.Minute*15))
+				return ctx
+			},
+		).Feature()
+
+	testenv.Test(t, driftFeatureSuite)
 }

--- a/test/e2e/testdata/crs/serviceinstance_drift/entitlement.yaml
+++ b/test/e2e/testdata/crs/serviceinstance_drift/entitlement.yaml
@@ -1,0 +1,12 @@
+apiVersion: account.btp.sap.crossplane.io/v1alpha1
+kind: Entitlement
+metadata:
+  name: e2e-onemds-drift-entitlement
+  namespace: default
+spec:
+  forProvider:
+    serviceName: one-mds
+    servicePlanName: sap-integration
+    enable: true
+    subaccountRef:
+      name: e2e-test-si-drift

--- a/test/e2e/testdata/crs/serviceinstance_drift/serviceinstance.yaml
+++ b/test/e2e/testdata/crs/serviceinstance_drift/serviceinstance.yaml
@@ -1,0 +1,23 @@
+apiVersion: account.btp.sap.crossplane.io/v1alpha1
+kind: ServiceInstance
+metadata:
+  name: e2e-onemds-drift-instance
+  namespace: default
+spec:
+  forProvider:
+    name: e2e-onemds-drift-instance
+    # one-mds/sap-integration is a free plan that is instances_retrievable:true
+    # and allows updates, so the Service Manager returns the parameters and the
+    # parameter-drift compensation applies. businessSystemId is a free-form
+    # string with no cross-field dependency, ideal as the drift parameter.
+    offeringName: one-mds
+    planName: sap-integration
+    parameters:
+      businessSystemId: e2e-initial
+      # one-mds refuses deprovisioning unless this is set, so keep it on from
+      # the start to let the test teardown delete the instance cleanly.
+      enableTenantDeletion: true
+    serviceManagerRef:
+      name: e2e-sm-si-drift
+    subaccountRef:
+      name: e2e-test-si-drift

--- a/test/e2e/testdata/crs/serviceinstance_drift/servicemanager.yaml
+++ b/test/e2e/testdata/crs/serviceinstance_drift/servicemanager.yaml
@@ -1,0 +1,12 @@
+apiVersion: account.btp.sap.crossplane.io/v1alpha1
+kind: ServiceManager
+metadata:
+  name: e2e-sm-si-drift
+  namespace: default
+spec:
+  writeConnectionSecretToRef:
+    name: e2e-sm-si-drift
+    namespace: default
+  forProvider:
+    subaccountRef:
+      name: e2e-test-si-drift

--- a/test/e2e/testdata/crs/serviceinstance_drift/subaccount.yaml
+++ b/test/e2e/testdata/crs/serviceinstance_drift/subaccount.yaml
@@ -1,0 +1,15 @@
+apiVersion: account.btp.sap.crossplane.io/v1alpha1
+kind: Subaccount
+metadata:
+  namespace: default
+  name: e2e-test-si-drift
+spec:
+  forProvider:
+    displayName: $BUILD_ID-e2e-test-si-drift
+    region: eu10
+    subdomain: $BUILD_ID-e2e-test-si-drift-co-12111
+    labels:
+      safe-to-delete: [ "yes" ]
+      BUILD_ID: [ "$BUILD_ID" ]
+    subaccountAdmins:
+       - $TECHNICAL_USER_EMAIL


### PR DESCRIPTION
> ⚠️ **DO NOT MERGE.** This is a deliberate downstream **workaround** for a limitation in the bundled BTP Terraform provider, not a change intended for upstream. It is published as a draft so it can be reviewed and consumed from our fork. See "Why this should not be merged" below.

## Problem

For `ServiceInstance`, a `parameters`-only change on an existing instance is never detected as drift and never reaches BTP. Root cause is in the bundled `terraform-provider-btp`: its `Read()` discards the `parameters` value returned by the Service Manager, so upjet-based drift detection never covers them and `Observe()` reports `UpToDate`. The upstream fix was declined (see [terraform-provider-btp#1643](https://github.com/SAP/terraform-provider-btp/pull/1643)) for state-consistency reasons; tracked here as #524 and #447.

## Workaround (Crossplane-side only)

In `Observe()`, once the TF layer reports `UpToDate`, fetch the instance parameters **directly from the Service Manager** (reusing the existing subaccount-admin lookuper) and compare them against the desired parameters. On a difference, force `ResourceUpToDate:false` so `Update()` runs and sends the parameters. The TF provider binary is not touched.

The comparison is a deep, order-independent **subset** match (`desired ⊆ server`), verified empirically against live BTP instances:

| Case | Offering | Behaviour |
|---|---|---|
| add/change of a desired param | cloud-logging (`instances_retrievable:true`) | **drift detected → update applied** |
| offering returns no params | aicore (`instances_retrievable:false`, HTTP 400) | skip, no drift |
| server-added defaults / extra fields | objectstore | ignored, no phantom drift / loop |

**Deletion is intentionally not handled** — the Service Manager update API cannot reliably clear a parameter (empty `{}` is a no-op, omitting a key merges, explicit `null` crashes the broker), so forcing drift on removal would loop or fail. Removal is left to the recreate path (documented at `paramsSubsetMatch`).

## Tests

- Unit tests for the subset compare and the drift/skip logic (`params_compare_test.go`, `params_drift_test.go`).
- E2E `TestServiceInstance_ParameterDrift` (one-mds/sap-integration): ready → change `businessSystemId` → update reconciles → stays settled (no loop). **Passing** against a live subaccount.
- The existing creation-flow e2e is extended with a non-retrievable "no phantom drift" assertion (destination).

## Why this should not be merged

- It is a **compensating workaround** for a provider-binary limitation the upstream Terraform provider maintainers explicitly chose not to fix. If/when that is addressed upstream, this should be removed rather than carried.
- It adds a Service Manager round-trip per `Observe()` on up-to-date instances and cannot detect parameter *deletion* — acceptable for our use case but not a general-purpose guarantee.

Refs #524, #447, [terraform-provider-btp#1643](https://github.com/SAP/terraform-provider-btp/pull/1643)
