### PR TITLE
chore: reduce renovate PR volume via grouping and weekly schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,30 @@
   "labels": ["release-notes/dependencies"],
   "prConcurrentLimit": 10,
   "prHourlyLimit": 0,
+  "packageRules": [
+    {
+      "groupName": "crossplane and upjet",
+      "matchPackageNames": [
+        "github.com/crossplane/**",
+        "github.com/crossplane-contrib/**"
+      ]
+    },
+    {
+      "groupName": "kubernetes",
+      "matchPackageNames": [
+        "k8s.io/**",
+        "sigs.k8s.io/**"
+      ]
+    },
+    {
+      "groupName": "golang.org/x",
+      "matchPackageNames": ["golang.org/x/**"]
+    },
+    {
+      "groupName": "github actions",
+      "matchManagers": ["github-actions"]
+    }
+  ],
   "customManagers": [
     {
       "fileMatch": [

--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
     ":dependencyDashboard",
     "schedule:weekly"
   ],
+  "ignorePresets": ["group:goOpenapi"],
   "postUpdateOptions": [
     "gomodTidy"
   ],
@@ -20,7 +21,13 @@
       ]
     },
     {
+      "groupName": "crossplane and upjet",
+      "matchDatasources": ["helm"],
+      "matchPackageNames": ["crossplane"]
+    },
+    {
       "groupName": "kubernetes",
+      "groupSlug": "kubernetes",
       "matchPackageNames": [
         "k8s.io/**",
         "sigs.k8s.io/**"

--- a/renovate.json
+++ b/renovate.json
@@ -36,6 +36,7 @@
   ],
   "customManagers": [
     {
+      "customType": "regex",
       "fileMatch": [
         "(^|/)Makefile$",
         "(^|/)Dockerfile$",

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
+    ":dependencyDashboard",
     "schedule:weekly"
   ],
   "postUpdateOptions": [

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,8 @@
     "gomodTidy"
   ],
   "labels": ["release-notes/dependencies"],
+  "prConcurrentLimit": 10,
+  "prHourlyLimit": 0,
   "customManagers": [
     {
       "fileMatch": [

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    "schedule:weekly"
   ],
   "postUpdateOptions": [
     "gomodTidy"


### PR DESCRIPTION
I would like to suggest an adaption of our renovate config to reduce the effort needed to merge its PRs. Let me know what you think.

## Summary

- **Group updates by ecosystem** - crossplane+upjet, kubernetes, `golang.org/x`, GitHub Actions
- **Weekly schedule** (`schedule:weekly`) - updates open in a single Monday batch
- **Concurrency caps** (`prConcurrentLimit: 10`, `prHourlyLimit: 0`) - still limit the number of open renovate PRs
- **Dependency dashboard** (`:dependencyDashboard`) - one issue giving us an overview of renovate's actions

## Additional Notes

- No automerge (yet) - every PR is still merged by hand (no change from now).
- Major version bumps still get their own PR (e.g. `golang-jwt/jwt/v4 → v5`).
- Standalone modules (e.g. `go-cfclient`, `go-logr`, `kubelogin`, `genproto`, …) stay single PRs - nothing to batch them with.
