### PR TITLE
chore(ci): derive Go version from go.mod in all workflows

### DIFF
--- a/.github/workflows/check-go-licenses.yaml
+++ b/.github/workflows/check-go-licenses.yaml
@@ -3,10 +3,6 @@ name: Check Go Dependency Licenses
 on:
   workflow_call:
 
-env:
-  # it is important to use the exact same patch version here (compared to the go.mod) to avoid unexpected issues
-  GO_VERSION: '1.25.9'
-
 permissions:
   contents: read
 
@@ -20,7 +16,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Install go-licenses
         run: |

--- a/.github/workflows/cron_long_e2e_test.yaml
+++ b/.github/workflows/cron_long_e2e_test.yaml
@@ -14,9 +14,6 @@ on:
 permissions:
   contents: read
 
-env:
-  GO_VERSION: '1.25'
-
 jobs:
   e2e-test:
     runs-on: ubuntu-latest
@@ -32,7 +29,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
       - run: go version
 
       - name: Install Helm

--- a/.github/workflows/custom-upgrade-test.yaml
+++ b/.github/workflows/custom-upgrade-test.yaml
@@ -10,9 +10,6 @@
 
 name: Custom Upgrade Test Workflow
 
-env:
-  GO_VERSION: '1.25'
-
 permissions:
   contents: read
   packages: write
@@ -70,7 +67,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
       - run: go version
 
       - name: Install Helm
@@ -122,7 +119,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Install BTP CLI
         env:

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -44,7 +44,6 @@ permissions:
 env:
   # hardcoded BTP CLI version
   btp_cli_version: 2.90.2
-  GO_VERSION: '1.25'
   E2E_BUILD_REGISTRY: index.docker.io/e2e
   E2E_PROVIDER_IMAGE: index.docker.io/e2e/provider-btp-amd64
   CROSSPLANE_CLI_VERSION: v2.0.2
@@ -175,7 +174,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Restore CLI tools cache (kind, kubectl, crank)
         id: cli-tools-cache
@@ -270,7 +269,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
       - run: go version
 
       - name: Download CLI tools
@@ -390,7 +389,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Install BTP CLI
         run: |

--- a/.github/workflows/release-candidate.yaml
+++ b/.github/workflows/release-candidate.yaml
@@ -8,9 +8,6 @@
 
 name: Publish Release Candidate
 
-env:
-  GO_VERSION: '1.25'
-
 on:
     workflow_dispatch: {}
 
@@ -47,7 +44,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Vendor Dependencies
         run: make vendor vendor.check

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,9 +4,6 @@
 
 name: Release
 
-env:
-  GO_VERSION: '1.25'
-
 on:
     workflow_dispatch:
       inputs:
@@ -94,7 +91,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Vendor Dependencies
         run: make vendor vendor.check

--- a/.github/workflows/reviewable_check_diff.yaml
+++ b/.github/workflows/reviewable_check_diff.yaml
@@ -7,9 +7,6 @@ permissions:
 on:
   workflow_call: 
 
-env:
-  GO_VERSION: '1.25'
-
 jobs:
   reviewable-checkdiff:
     runs-on: ubuntu-latest
@@ -21,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: go.mod
 
     - name: Install Go tools
       run: go install tool

--- a/.github/workflows/unit_test.yaml
+++ b/.github/workflows/unit_test.yaml
@@ -6,9 +6,6 @@ name: Unit Tests
 on:
   workflow_call: 
 
-env:
-  GO_VERSION: '1.25'
-
 permissions:
   contents: read
 jobs:
@@ -23,7 +20,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: go.mod
 
     - name: Build
       run: go build -v ./...

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -10,9 +10,6 @@
 
 name: Upgrade Test Workflow
 
-env:
-  GO_VERSION: '1.25'
-
 permissions:
   contents: read
   packages: write
@@ -59,7 +56,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
       - run: go version
 
       - name: Install Helm


### PR DESCRIPTION
Replaces hardcoded `GO_VERSION` env vars with `go-version-file: go.mod` in all `actions/setup-go` steps across every workflow. `go.mod` is now the single source of truth for the Go version; future bumps via renovate propagate to CI automatically without a separate workflow change.

✅  Workflow logs confirm that resolved go version matches the one specified in `go.mod`

Triggered by failing workflows in this renovate PR: https://github.com/SAP/crossplane-provider-btp/pull/857

