### PR TITLE
fix(accounts): surface API error details instead of only the general message

### DIFF
--- a/internal/apierror/accounts.go
+++ b/internal/apierror/accounts.go
@@ -1,0 +1,74 @@
+// Package apierror translates errors returned by the generated BTP OpenAPI
+// clients into messages that are useful in a managed resource's status and
+// events.
+package apierror
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/sap/crossplane-provider-btp/internal"
+	accountclient "github.com/sap/crossplane-provider-btp/internal/openapi_clients/btp-accounts-service-api-go/pkg"
+)
+
+// FromAccounts converts an error returned by the accounts service client into a
+// readable error, including the per-field reasons the API reports in "details".
+// Errors that did not come from that client are returned unchanged.
+func FromAccounts(err error) error {
+	genericErr, ok := err.(*accountclient.GenericOpenAPIError)
+	if !ok {
+		return err
+	}
+
+	if accountError, ok := genericErr.Model().(accountclient.ApiExceptionResponseObject); ok {
+		general := fmt.Sprintf("API Error: %v, Code %v", internal.Val(accountError.Error.Message), internal.Val(accountError.Error.Code))
+
+		// The API reports the actual cause of a rejected payload in a "details"
+		// array rather than in the top-level message. Without it the caller only
+		// sees "Request payload is invalid, Code 11000" and has to inspect the
+		// raw response to find out which field was wrong.
+		if details := detailMessages(accountError.Error.AdditionalProperties); len(details) > 0 {
+			return fmt.Errorf("%s; details: %s", general, strings.Join(details, "; "))
+		}
+		return errors.New(general)
+	}
+
+	if genericErr.Body() != nil {
+		return fmt.Errorf("API Error: %s", string(genericErr.Body()))
+	}
+
+	return err
+}
+
+// detailMessages pulls the messages out of the error's "details" array.
+//
+// The generated ApiExceptionResponseObjectError has no Details field, but its
+// UnmarshalJSON collects every key it does not model into AdditionalProperties,
+// so the details survive there as plain JSON values. Anything not matching the
+// expected shape is skipped rather than reported, which leaves the caller with
+// the same general message it would have produced before.
+func detailMessages(additionalProperties map[string]interface{}) []string {
+	entries, ok := additionalProperties["details"].([]interface{})
+	if !ok {
+		return nil
+	}
+
+	messages := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		detail, ok := entry.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		message, ok := detail["message"].(string)
+		if !ok {
+			continue
+		}
+		if message = strings.TrimSpace(message); message == "" {
+			continue
+		}
+		messages = append(messages, message)
+	}
+
+	return messages
+}

--- a/internal/apierror/accounts_test.go
+++ b/internal/apierror/accounts_test.go
@@ -1,0 +1,153 @@
+package apierror
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/sap/crossplane-provider-btp/internal/testutils"
+)
+
+func TestFromAccounts(t *testing.T) {
+	plain := errors.New("boom")
+
+	tests := map[string]struct {
+		in error
+		// want is the expected message. wantSame additionally asserts the
+		// original error is handed back untouched, rather than merely
+		// formatting to the same text.
+		want     string
+		wantSame bool
+	}{
+		"non-generic error passes through": {
+			in:       plain,
+			want:     "boom",
+			wantSame: true,
+		},
+		"nil passes through": {
+			in: nil,
+		},
+
+		// The case from the issue: the top-level message says only that the
+		// payload was invalid, and the reason lives in details.
+		"payload invalid, detail is surfaced": {
+			in: testutils.NewAccountAPIErrorFromBody([]byte(`{
+				"error": {
+					"code": 11000,
+					"message": "Request payload is invalid",
+					"target": "/accounts/v1/subaccounts",
+					"correlationID": "bb8d3f4b-c9f8-4126-4813-8265e34d687a",
+					"details": [
+						{"code": 11001, "message": "displayName: Display name can't contain / "}
+					]
+				}
+			}`), "400 Bad Request"),
+			want: `API Error: Request payload is invalid, Code 11000; details: displayName: Display name can't contain /`,
+		},
+		"several details are all surfaced": {
+			in: testutils.NewAccountAPIErrorFromBody([]byte(`{
+				"error": {
+					"code": 11000,
+					"message": "Request payload is invalid",
+					"details": [
+						{"code": 11001, "message": "displayName: Display name can't contain / "},
+						{"code": 11002, "message": "subdomain: Subdomain is already taken"}
+					]
+				}
+			}`), "400 Bad Request"),
+			want: `API Error: Request payload is invalid, Code 11000; details: displayName: Display name can't contain /; subdomain: Subdomain is already taken`,
+		},
+
+		// Errors that carry no details must keep producing exactly what they
+		// produced before this change.
+		"409 conflict from the typed constructor is unchanged": {
+			in:   testutils.NewAccountAPIError(409, "directory has child resources", "409 Conflict"),
+			want: "API Error: directory has child resources, Code 409",
+		},
+		"409 conflict from a raw body is unchanged": {
+			in:   testutils.NewAccountAPIErrorFromBody([]byte(`{"error":{"code":409,"message":"Subaccount with the same subdomain already exists"}}`), "409 Conflict"),
+			want: "API Error: Subaccount with the same subdomain already exists, Code 409",
+		},
+		"500 with an empty message is unchanged": {
+			in:   testutils.NewAccountAPIError(500, "", "500 Internal Server Error"),
+			want: "API Error: , Code 500",
+		},
+
+		// Anything not shaped like a details array falls back to the general
+		// message instead of failing or leaking a Go-rendered value.
+		"details is not an array": {
+			in:   testutils.NewAccountAPIErrorFromBody([]byte(`{"error":{"code":11000,"message":"Request payload is invalid","details":"nope"}}`), "400 Bad Request"),
+			want: "API Error: Request payload is invalid, Code 11000",
+		},
+		"details entry is not an object": {
+			in:   testutils.NewAccountAPIErrorFromBody([]byte(`{"error":{"code":11000,"message":"Request payload is invalid","details":["nope"]}}`), "400 Bad Request"),
+			want: "API Error: Request payload is invalid, Code 11000",
+		},
+		"details entry has no message": {
+			in:   testutils.NewAccountAPIErrorFromBody([]byte(`{"error":{"code":11000,"message":"Request payload is invalid","details":[{"code":11001}]}}`), "400 Bad Request"),
+			want: "API Error: Request payload is invalid, Code 11000",
+		},
+		"details message is not a string": {
+			in:   testutils.NewAccountAPIErrorFromBody([]byte(`{"error":{"code":11000,"message":"Request payload is invalid","details":[{"message":123}]}}`), "400 Bad Request"),
+			want: "API Error: Request payload is invalid, Code 11000",
+		},
+		"details message is null": {
+			in:   testutils.NewAccountAPIErrorFromBody([]byte(`{"error":{"code":11000,"message":"Request payload is invalid","details":[{"message":null}]}}`), "400 Bad Request"),
+			want: "API Error: Request payload is invalid, Code 11000",
+		},
+		"details message is blank": {
+			in:   testutils.NewAccountAPIErrorFromBody([]byte(`{"error":{"code":11000,"message":"Request payload is invalid","details":[{"message":"   "}]}}`), "400 Bad Request"),
+			want: "API Error: Request payload is invalid, Code 11000",
+		},
+		"details array is empty": {
+			in:   testutils.NewAccountAPIErrorFromBody([]byte(`{"error":{"code":11000,"message":"Request payload is invalid","details":[]}}`), "400 Bad Request"),
+			want: "API Error: Request payload is invalid, Code 11000",
+		},
+		"unusable details are skipped, usable ones kept": {
+			in: testutils.NewAccountAPIErrorFromBody([]byte(`{
+				"error": {
+					"code": 11000,
+					"message": "Request payload is invalid",
+					"details": ["nope", {"code": 11002}, {"message": "subdomain: Subdomain is already taken"}]
+				}
+			}`), "400 Bad Request"),
+			want: `API Error: Request payload is invalid, Code 11000; details: subdomain: Subdomain is already taken`,
+		},
+		"code and message are both absent": {
+			in:   testutils.NewAccountAPIErrorFromBody([]byte(`{"error":{"target":"/accounts/v1/subaccounts"}}`), "400 Bad Request"),
+			want: "API Error: , Code 0",
+		},
+
+		// No decodable model, so the raw body is the best available detail.
+		"body only falls back to the raw body": {
+			in:   testutils.NewAccountAPIErrorBodyOnly([]byte(`{"unexpected":"shape"}`), "502 Bad Gateway"),
+			want: `API Error: {"unexpected":"shape"}`,
+		},
+		"neither model nor body returns the original error": {
+			in:       testutils.NewAccountAPIErrorBodyOnly(nil, "503 Service Unavailable"),
+			want:     "503 Service Unavailable",
+			wantSame: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := FromAccounts(tc.in)
+
+			if tc.in == nil {
+				if got != nil {
+					t.Fatalf("FromAccounts(nil) = %v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("FromAccounts() = nil, want an error")
+			}
+			if tc.wantSame && got != tc.in {
+				t.Errorf("FromAccounts() returned a new error %v, want the original untouched", got)
+			}
+			if got.Error() != tc.want {
+				t.Errorf("FromAccounts() = %q, want %q", got.Error(), tc.want)
+			}
+		})
+	}
+}

--- a/internal/clients/directory/directory.go
+++ b/internal/clients/directory/directory.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sap/crossplane-provider-btp/apis/account/v1alpha1"
 	"github.com/sap/crossplane-provider-btp/btp"
 	"github.com/sap/crossplane-provider-btp/internal"
+	"github.com/sap/crossplane-provider-btp/internal/apierror"
 	accountclient "github.com/sap/crossplane-provider-btp/internal/openapi_clients/btp-accounts-service-api-go/pkg"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -233,13 +234,5 @@ func (d *DirectoryClient) toCreateApiPayload() accountclient.CreateDirectoryRequ
 var _ DirectoryClientI = &DirectoryClient{}
 
 func specifyAPIError(err error) error {
-	if genericErr, ok := err.(*accountclient.GenericOpenAPIError); ok {
-		if accountError, ok := genericErr.Model().(accountclient.ApiExceptionResponseObject); ok {
-			return fmt.Errorf("API Error: %v, Code %v", internal.Val(accountError.Error.Message), internal.Val(accountError.Error.Code))
-		}
-		if genericErr.Body() != nil {
-			return fmt.Errorf("API Error: %s", string(genericErr.Body()))
-		}
-	}
-	return err
+	return apierror.FromAccounts(err)
 }

--- a/internal/clients/servicemanager/service_instance_proxy_client.go
+++ b/internal/clients/servicemanager/service_instance_proxy_client.go
@@ -2,9 +2,8 @@ package servicemanager
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/sap/crossplane-provider-btp/internal"
+	"github.com/sap/crossplane-provider-btp/internal/apierror"
 	accountsserviceclient "github.com/sap/crossplane-provider-btp/internal/openapi_clients/btp-accounts-service-api-go/pkg"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -181,13 +180,5 @@ func mapBindingCredentialTypes(in *accountsserviceclient.ServiceManagerBindingRe
 
 // specifyAccountsAPIError surfaces the BTP accounts-service error body when present.
 func specifyAccountsAPIError(err error) error {
-	if genericErr, ok := err.(*accountsserviceclient.GenericOpenAPIError); ok {
-		if accountError, ok := genericErr.Model().(accountsserviceclient.ApiExceptionResponseObject); ok {
-			return fmt.Errorf("API Error: %v, Code %v", internal.Val(accountError.Error.Message), internal.Val(accountError.Error.Code))
-		}
-		if genericErr.Body() != nil {
-			return fmt.Errorf("API Error: %s", string(genericErr.Body()))
-		}
-	}
-	return err
+	return apierror.FromAccounts(err)
 }

--- a/internal/controller/account/globalaccount/globalaccount.go
+++ b/internal/controller/account/globalaccount/globalaccount.go
@@ -15,9 +15,8 @@ import (
 	apisv1alpha1 "github.com/sap/crossplane-provider-btp/apis/account/v1alpha1"
 	providerv1alpha1 "github.com/sap/crossplane-provider-btp/apis/v1alpha1"
 	"github.com/sap/crossplane-provider-btp/btp"
-	"github.com/sap/crossplane-provider-btp/internal"
+	"github.com/sap/crossplane-provider-btp/internal/apierror"
 	"github.com/sap/crossplane-provider-btp/internal/controller/providerconfig"
-	accountclient "github.com/sap/crossplane-provider-btp/internal/openapi_clients/btp-accounts-service-api-go/pkg"
 	"github.com/sap/crossplane-provider-btp/internal/tracking"
 )
 
@@ -156,13 +155,5 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) (managed.Ext
 }
 
 func specifyAPIError(err error) error {
-	if genericErr, ok := err.(*accountclient.GenericOpenAPIError); ok {
-		if accountError, ok := genericErr.Model().(accountclient.ApiExceptionResponseObject); ok {
-			return fmt.Errorf("API Error: %v, Code %v", internal.Val(accountError.Error.Message), internal.Val(accountError.Error.Code))
-		}
-		if genericErr.Body() != nil {
-			return fmt.Errorf("API Error: %s", string(genericErr.Body()))
-		}
-	}
-	return err
+	return apierror.FromAccounts(err)
 }

--- a/internal/controller/account/subaccount/subaccount.go
+++ b/internal/controller/account/subaccount/subaccount.go
@@ -22,6 +22,7 @@ import (
 	providerv1alpha1 "github.com/sap/crossplane-provider-btp/apis/v1alpha1"
 	"github.com/sap/crossplane-provider-btp/btp"
 	"github.com/sap/crossplane-provider-btp/internal"
+	"github.com/sap/crossplane-provider-btp/internal/apierror"
 	"github.com/sap/crossplane-provider-btp/internal/controller/providerconfig"
 	accountclient "github.com/sap/crossplane-provider-btp/internal/openapi_clients/btp-accounts-service-api-go/pkg"
 	"github.com/sap/crossplane-provider-btp/internal/recovery"
@@ -576,15 +577,7 @@ func emptyDirectoryRef(spec *apisv1alpha1.SubaccountParameters) bool {
 }
 
 func specifyAPIError(err error) error {
-	if genericErr, ok := err.(*accountclient.GenericOpenAPIError); ok {
-		if accountError, ok := genericErr.Model().(accountclient.ApiExceptionResponseObject); ok {
-			return errors.New(fmt.Sprintf("API Error: %v, Code %v", internal.Val(accountError.Error.Message), internal.Val(accountError.Error.Code)))
-		}
-		if genericErr.Body() != nil {
-			return fmt.Errorf("API Error: %s", string(genericErr.Body()))
-		}
-	}
-	return err
+	return apierror.FromAccounts(err)
 }
 
 func changedLabels(specLabels map[string]apisv1alpha1.SubaccountLabelValueList, statusLabels *map[string][]string) bool {

--- a/internal/testutils/openapi_errors.go
+++ b/internal/testutils/openapi_errors.go
@@ -1,6 +1,7 @@
 package testutils
 
 import (
+	"encoding/json"
 	"reflect"
 	"unsafe"
 
@@ -36,4 +37,50 @@ func NewAccountAPIError(code float32, message, transportErr string) error {
 			Elem().SetString(transportErr)
 	}
 	return err
+}
+
+// NewAccountAPIErrorFromBody builds a *accountclient.GenericOpenAPIError from a
+// raw accounts-service response body, decoding it into the model the same way
+// the SDK does and keeping the body alongside it.
+//
+// Use this rather than NewAccountAPIError when a test needs parts of the
+// response the typed constructor cannot express — notably the "details" array,
+// which the generated model has no field for and which only survives in
+// ApiExceptionResponseObjectError.AdditionalProperties after unmarshaling.
+//
+// Panics on a body that is not a valid ApiExceptionResponseObject, so a typo in
+// a test fixture fails loudly instead of silently producing an empty model.
+func NewAccountAPIErrorFromBody(body []byte, transportErr string) error {
+	var apiException accountclient.ApiExceptionResponseObject
+	if err := json.Unmarshal(body, &apiException); err != nil {
+		panic("testutils: invalid ApiExceptionResponseObject body: " + err.Error())
+	}
+
+	err := &accountclient.GenericOpenAPIError{}
+	setUnexportedAccountErrField(err, "model", reflect.ValueOf(apiException))
+	setUnexportedAccountErrField(err, "body", reflect.ValueOf(body))
+	setUnexportedAccountErrField(err, "error", reflect.ValueOf(transportErr))
+	return err
+}
+
+// NewAccountAPIErrorBodyOnly builds a *accountclient.GenericOpenAPIError that
+// carries a response body but no model, as the SDK does when it cannot decode
+// the payload into a known type.
+func NewAccountAPIErrorBodyOnly(body []byte, transportErr string) error {
+	err := &accountclient.GenericOpenAPIError{}
+	setUnexportedAccountErrField(err, "body", reflect.ValueOf(body))
+	setUnexportedAccountErrField(err, "error", reflect.ValueOf(transportErr))
+	return err
+}
+
+// setUnexportedAccountErrField writes one of GenericOpenAPIError's unexported
+// fields. Same unsafe-pointer approach and same caveat as NewAccountAPIError: a
+// regenerated SDK that renames a field makes this a no-op, and this is the one
+// place to fix it.
+func setUnexportedAccountErrField(err *accountclient.GenericOpenAPIError, name string, value reflect.Value) {
+	field := reflect.ValueOf(err).Elem().FieldByName(name)
+	if !field.IsValid() {
+		return
+	}
+	reflect.NewAt(field.Type(), unsafe.Pointer(field.UnsafeAddr())).Elem().Set(value)
 }


### PR DESCRIPTION
Fixes #92.

### The cause

The details were already being parsed — they just never reached the user.

`ApiExceptionResponseObjectError` has no `Details` field, but its generated `UnmarshalJSON` deletes only `code`, `correlationID`, `message` and `target` and collects every remaining key into `AdditionalProperties`. So for the response in the issue, `details` is sitting in there as a `[]interface{}` the whole time:

```
AdditionalProperties: map[string]interface{}{
  "details": []interface{}{
    map[string]interface{}{"code": float64(11001), "message": "displayName: Display name can't contain / "},
  },
}
```

`specifyAPIError` formatted only the top-level `message` and `code` and dropped the rest, which is why the reason was only visible by reading the raw response in dev mode.

### What this changes

`API Error: Request payload is invalid, Code 11000`

becomes

`API Error: Request payload is invalid, Code 11000; details: displayName: Display name can't contain /`

The conversion existed as four byte-identical copies — `internal/clients/directory`, `internal/clients/servicemanager` (as `specifyAccountsAPIError`), and the `globalaccount` and `subaccount` controllers. Since the issue asks for this on any accounts request rather than just the POST, I moved it to `internal/apierror.FromAccounts` and pointed all four at it, instead of applying the same fix four times.

### Backwards compatibility

This is the part the issue calls out, so it is where most of the tests went. When there are no usable details the message is byte-identical to before — same `fmt.Sprintf("API Error: %v, Code %v", ...)` with the same `internal.Val` derefs — so 409 conflicts and everything else convert exactly as they did. The `; details: ` suffix appears only when at least one detail message survives parsing.

Everything coming out of `AdditionalProperties` is untyped JSON, so each step is checked: `details` missing, not an array, elements not objects, `message` absent, null, non-string or blank all fall back to the general message rather than failing or leaking a Go-rendered value. Malformed entries are skipped individually, so one bad entry doesn't discard its usable siblings.

### Tests

18 cases in `internal/apierror/accounts_test.go`, 100% statement coverage of the new package. They drive the real `FromAccounts` entry point rather than an inner function, and build inputs by unmarshaling raw response JSON so the actual `AdditionalProperties` path is exercised instead of a hand-built map.

`GenericOpenAPIError` has only unexported fields and no constructor, so I extended the existing `internal/testutils` reflection helper with `NewAccountAPIErrorFromBody` (model + body from a raw response, which is what makes a `details` test possible at all) and `NewAccountAPIErrorBodyOnly` (body without a model, for the raw-body fallback). The existing `NewAccountAPIError` is untouched and its four current callers are unaffected.

Verified by mutation — each of these makes the suite fail, and I reverted each after checking:
- never appending details
- dropping the `strings.TrimSpace`
- changing `len(details) > 0` to `>= 0` so the suffix is always appended

### Verification

- `go build ./...`, `go vet`, `gofmt` clean
- full suite green: 61 packages, 0 failures
- `make lint` (golangci-lint v2.12.2): 0 issues
- `make check-diff` is unaffected — this touches no `apis/` types, CRDs or OpenAPI specs, only hand-written files under `internal/`

### What I could not verify, and two things to decide

**Not exercised against a live BTP account.** I have no global account to hit, so the parsing, the fallback and the 409 behaviour are covered by unit tests against the documented response shape from the issue. If the real API returns a `details` shape I haven't anticipated, that path is untested. Worth a maintainer sanity-check against a real tenant before merging.

**I kept only the detail `message`, not the detail `code`** (11001 in the example), on the grounds that the message already names the field and the reason. Easy to include if you'd rather have it for support tickets — say the word.

**The new package is optional.** If you'd rather not take `internal/apierror`, I'm happy to inline `FromAccounts` at the call sites instead; it just means the details logic exists in four places again. Same for `NewAccountAPIErrorBodyOnly` — it guards the raw-body fallback branch, which this PR doesn't change, so it's the easiest piece to drop if you want a smaller diff.

### Two accounts-API paths that still bypass the conversion

Both pre-existing, both deliberately left alone, both worth your call:

**`createBTPSubaccount`'s 409 branch** (`internal/controller/account/subaccount/subaccount.go:473`) wraps the raw error, so a subaccount name conflict surfaces as `...adopt the existing resource: 409 Conflict` rather than going through the conversion. `CreateDirectory` handles the same situation the other way — it wraps `specifyAPIError(err)` — so the two are inconsistent. Given requirement (d) you may well want this routed through `FromAccounts` too, but it changes a message that `subaccount_test.go:1306` currently pins, which makes it a behaviour decision rather than part of this fix. Say the word and I'll do it here or in a follow-up.

To be clear about what this means for the reported bug: the `/` in a display name is a 400/11000, which takes the `return specifyAPIError(err)` path, so the case in the issue is fixed. Only the 409 branch is unconverted.

**`btp/subaccount.go:GetBTPSubaccount`** calls the accounts API and returns the error raw. It has no callers anywhere in the repo, so it looks like dead code — happy to wire it in or delete it separately.
