### PR TITLE
fix(ci): pin e2e crossplane chart to 2.1.8 to unblock provider install

### DIFF
--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -47,11 +47,14 @@ env:
   E2E_BUILD_REGISTRY: index.docker.io/e2e
   E2E_PROVIDER_IMAGE: index.docker.io/e2e/provider-btp-amd64
   CROSSPLANE_CLI_VERSION: v2.0.2
-  # renovate: datasource=helm depName=crossplane registryUrl=https://charts.crossplane.io/stable
-  CROSSPLANE_CHART_VERSION: '2.3.4'
-  # SHA256 of crossplane-2.3.4.tgz downloaded from charts.crossplane.io/stable
+  # renovate: datasource=helm depName=crossplane registryUrl=https://charts.crossplane.io/stable versioning=semver allowedVersions=<2.2.0
+  # Pinned to last 2.1.x: 2.2.0+ (crossplane/crossplane#6981) resolves spec.package
+  # against a real registry before the cache, breaking the local :latest install path.
+  # Hold below 2.2.0 until the digest-pinned side-load fix lands.
+  CROSSPLANE_CHART_VERSION: '2.1.8'
+  # SHA256 of crossplane-2.1.8.tgz downloaded from charts.crossplane.io/stable
   # Compute with: curl -sL https://charts.crossplane.io/stable/crossplane-<version>.tgz | sha256sum
-  CROSSPLANE_CHART_SHA256: '72c349c911a7ba521208538caf9ea48b31974403a64534bc00dae750e2f95b30'
+  CROSSPLANE_CHART_SHA256: '958f331eeab96d4f1c1153c9c0ed36cc91659b79b0779f52e4fc0ffe230863ed'
 
 jobs:
   prepare-matrix:

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -48,9 +48,6 @@ const (
 	// switches to the chart-tarball path. The fallback also lets local
 	// developers run e2e tests without pre-staging the chart.
 	crossplaneChartPathEnv = "CROSSPLANE_CHART_PATH"
-	// crossplaneVersion is the Crossplane chart version. Must match the
-	// version that was pulled into the tarball at CROSSPLANE_CHART_PATH.
-	crossplaneVersion = "2.1.3"
 
 	// reuseClusterEnv mirrors xp-testing's E2E_REUSE_CLUSTER semantics: when
 	// set, the cluster, Crossplane, and provider are reused across runs and
@@ -67,6 +64,18 @@ const (
 var (
 	testenv  env.Environment
 	BUILD_ID string
+
+	// crossplaneVersion is the Crossplane chart version to install. It reads the
+	// workflow's CROSSPLANE_CHART_VERSION env so CI and the chart tarball at
+	// CROSSPLANE_CHART_PATH share a single source of truth (the workflow pin);
+	// falls back to the current pinned version for local dev without the env set.
+	// Keep the fallback in sync with CROSSPLANE_CHART_VERSION in e2e_test.yaml.
+	crossplaneVersion = func() string {
+		if v := os.Getenv("CROSSPLANE_CHART_VERSION"); v != "" {
+			return v
+		}
+		return "2.1.8"
+	}()
 )
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
- **Pin the e2e Crossplane chart to 2.1.8** (from 2.3.4). Chart 2.2.0+
  (crossplane/crossplane#6981) resolves `spec.package` against a real registry before the package
  cache resulting in 401s responses by Docker hub failing all E2E tests. 2.1.8 is
  the last release before that breaking change
- **Constrain renovate to `allowedVersions=<2.2.0`** so it stops re-proposing the breaking bump.

We already hit this exact issue and fixed it the same way in #820 (revert to 2.1.7); #856 then bumped
to 2.3.4 and reintroduced it. The renovate pin prevents a third round.

See [v2.2.0 crossplane release notes](https://github.com/crossplane/crossplane/releases/tag/v2.2.0):
```
The on-disk structure of the package cache has changed. This breaks an undocumented behavior via which packages could be side-loaded into Crossplane, which was especially useful for testing. See https://github.com/crossplane/crossplane/pull/6981 for details on the change and https://github.com/crossplane/crossplane/issues/7147 for discussion of the test changes necessary to accommodate it.
```