### PR TITLE
fix(cloudmanagement): preserve binding ID in external-name on re-entered Create

### DIFF
--- a/internal/controller/account/cloudmanagement/cloudmanagement.go
+++ b/internal/controller/account/cloudmanagement/cloudmanagement.go
@@ -316,6 +316,16 @@ func (c *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 	if err != nil {
 		return managed.ExternalCreation{}, errors.Wrap(err, errCreate)
 	}
+	// Keep an already-complete instanceID/bindingID external-name intact when a
+	// re-entered Create returns an empty binding ID; only a real binding ID
+	// overwrites it (#289).
+	existingSID, existingBID := splitExternalName(meta.GetExternalName(cr))
+	if sID == "" {
+		sID = existingSID
+	}
+	if bID == "" {
+		bID = existingBID
+	}
 	meta.SetExternalName(cr, formExternalName(sID, bID))
 
 	return managed.ExternalCreation{}, nil
@@ -391,6 +401,18 @@ func formExternalName(serviceInstanceID, serviceBindingID string) string {
 		return serviceInstanceID
 	}
 	return serviceInstanceID + "/" + serviceBindingID
+}
+
+// splitExternalName is the inverse of formExternalName: it splits an
+// external-name of the form "serviceInstanceID/serviceBindingID" back into its
+// two segments. A bare "serviceInstanceID" (no separator) yields an empty
+// binding ID.
+func splitExternalName(externalName string) (serviceInstanceID, serviceBindingID string) {
+	instanceID, bindingID, found := strings.Cut(externalName, "/")
+	if !found {
+		return externalName, ""
+	}
+	return instanceID, bindingID
 }
 
 func mapToInstance(src *apisv1alpha1.SubaccountServiceInstanceObservation) *apisv1beta1.Instance {

--- a/internal/controller/account/cloudmanagement/cloudmanagement_test.go
+++ b/internal/controller/account/cloudmanagement/cloudmanagement_test.go
@@ -513,6 +513,116 @@ func TestCreate(t *testing.T) {
 				),
 			},
 		},
+		{
+			// First-ever provisioning, phase-1: external-name is unset. The guard
+			// has no existing binding ID to preserve and must write the bare
+			// instance ID (phase-2 later appends the binding). Confirms the guard
+			// is a no-op at creation time and never blocks a normal first create.
+			name: "FirstCreatePhase1NoExternalNameYet",
+			args: args{
+				cr: NewCloudManagement("test"),
+				tfClient: &TfClientFake{
+					createFn: func() (string, string, error) {
+						return "someID", "", nil
+					},
+				},
+			},
+			want: want{
+				err: nil,
+				cr: NewCloudManagement("test",
+					WithExternalName("someID"),
+					WithConditions(xpv1.Creating()),
+				),
+			},
+		},
+		{
+			// Regression for #289: a phase-1 re-entry (CreateResources returns an
+			// empty binding ID) must NOT truncate an already-complete
+			// instanceID/bindingID external-name down to the bare instanceID.
+			// That truncation strands the CM in a permanent "Service Binding
+			// (Subaccount): Conflict" loop because the binding ID is then lost
+			// from the CR while the binding still exists in BTP.
+			name: "Phase1ReEntryPreservesExistingBindingID",
+			args: args{
+				cr: NewCloudManagement("test", WithExternalName("someID/anotherID")),
+				tfClient: &TfClientFake{
+					createFn: func() (string, string, error) {
+						return "someID", "", nil
+					},
+				},
+			},
+			want: want{
+				err: nil,
+				cr: NewCloudManagement("test",
+					WithExternalName("someID/anotherID"),
+					WithConditions(xpv1.Creating()),
+				),
+			},
+		},
+		{
+			// A phase-1 re-entry that also loses the instance ID must keep both
+			// segments from the existing external-name rather than blanking it.
+			name: "Phase1ReEntryPreservesBothIDs",
+			args: args{
+				cr: NewCloudManagement("test", WithExternalName("someID/anotherID")),
+				tfClient: &TfClientFake{
+					createFn: func() (string, string, error) {
+						return "", "", nil
+					},
+				},
+			},
+			want: want{
+				err: nil,
+				cr: NewCloudManagement("test",
+					WithExternalName("someID/anotherID"),
+					WithConditions(xpv1.Creating()),
+				),
+			},
+		},
+		{
+			// Genuine self-heal: instance still there, binding was deleted in BTP,
+			// so phase-2 creates a NEW binding and returns its real ID. The guard
+			// must NOT block this — the new binding ID replaces the old one.
+			name: "Phase2NewBindingReplacesOldID",
+			args: args{
+				cr: NewCloudManagement("test", WithExternalName("someID/oldBinding")),
+				tfClient: &TfClientFake{
+					createFn: func() (string, string, error) {
+						return "someID", "newBinding", nil
+					},
+				},
+			},
+			want: want{
+				err: nil,
+				cr: NewCloudManagement("test",
+					WithExternalName("someID/newBinding"),
+					WithConditions(xpv1.Creating()),
+				),
+			},
+		},
+		{
+			// Both instance and binding gone in BTP (a formerly-healthy CM whose
+			// external-name is still the complete instanceID/bindingID): the
+			// re-create attempt returns an error, so Create() returns before the
+			// external-name is written. The guard must leave the existing
+			// external-name untouched rather than truncating it.
+			name: "BothGoneCreateErrorLeavesExternalNameIntact",
+			args: args{
+				cr: NewCloudManagement("test", WithExternalName("someID/anotherID")),
+				tfClient: &TfClientFake{
+					createFn: func() (string, string, error) {
+						return "", "", errors.New("createError")
+					},
+				},
+			},
+			want: want{
+				err: errors.Wrap(errors.New("createError"), "while creating resources"),
+				cr: NewCloudManagement("test",
+					WithExternalName("someID/anotherID"),
+					WithConditions(xpv1.Creating()),
+				),
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Problem
A `CloudManagement`'s `external-name` encodes two IDs as `instanceID/bindingID`. `Create()` wrote it unconditionally from the two-phase `CreateResources` result. When a re-entered `Create` returns an empty binding ID — a phase-1 re-entry, or a phase-2 create whose binding external-name isn't populated yet — `formExternalName` truncated a previously-complete `instanceID/bindingID` down to the bare `instanceID`.

Once truncated, the binding ID is lost from the CR while the binding still exists in BTP. Every subsequent reconcile rebuilds the internal binding CR with an empty external-name, so:
- **provisioning** loops forever on `API Error Creating Resource Service Binding (Subaccount): Conflict`
- **deprovision** deadlocks on BTP 400 `1 existing binding` (the binding delete is a no-op)

## Fix
In `Create()`, preserve any ID segment already present in the external-name before writing: an empty `sID`/`bID` no longer discards a known segment. A genuine phase-2 create still returns a real binding ID and overwrites as intended, so self-healing of a deleted binding is unaffected.

The guard only ever re-asserts an ID already present in the current external-name — it never invents one — and is a no-op at first creation (external-name not yet complete).

## Tests
- Unit (`TestCreate`): re-entry preserves existing binding ID; preserves both IDs when both empty; phase-2 with a new binding ID overwrites (self-heal); create-error leaves external-name intact; first-create phase-1 writes bare instance ID.
- E2E against real BTP (kind + `cis`/`local` subaccount): healthy provisioning → compound external-name; truncated state recovers without Conflict loop or duplicate binding; deleted binding self-heals to a new binding ID.
