### PR TITLE
chore: add safe-to-delete label to directories

### DIFF
--- a/test/e2e/testdata/crs/DirectoryEntitlement/directory.yaml
+++ b/test/e2e/testdata/crs/DirectoryEntitlement/directory.yaml
@@ -15,6 +15,7 @@ spec:
       - "AUTHORIZATIONS"
     displayName: $BUILD_ID-e2e-directory-for-entitlement-testing
     labels:
+      safe-to-delete: [ "yes" ]
       custom_label: ["custom_value"]
       another_label: ["onevalue", "twovalue"]
       BUILD_ID: [ "$BUILD_ID" ]

--- a/test/e2e/testdata/crs/directory/directory.yaml
+++ b/test/e2e/testdata/crs/directory/directory.yaml
@@ -12,6 +12,7 @@ spec:
     - "DEFAULT"
     displayName: $BUILD_ID-e2e-test-directory
     labels:
+      safe-to-delete: [ "yes" ]
       custom_label: ["custom_value"]
       another_label: ["onevalue", "twovalue"]
       BUILD_ID: [ "$BUILD_ID" ]

--- a/test/e2e/testdata/crs/subaccount/directory.yaml
+++ b/test/e2e/testdata/crs/subaccount/directory.yaml
@@ -12,6 +12,7 @@ spec:
       - "DEFAULT"
     displayName: $BUILD_ID-e2e-test-directory-sa
     labels:
+      safe-to-delete: [ "yes" ]
       custom_label: ["custom_value"]
       another_label: ["onevalue", "twovalue"]
       BUILD_ID: [ "$BUILD_ID" ]

--- a/test/upgrade/testdata/baseCRs/directory/directory.yaml
+++ b/test/upgrade/testdata/baseCRs/directory/directory.yaml
@@ -13,6 +13,7 @@ spec:
       - "DEFAULT"
     displayName: $BUILD_ID-upgrade-test-parent-directory
     labels:
+      safe-to-delete: [ "yes" ]
       custom_label: ["custom_value"]
       another_label: ["onevalue", "twovalue"]
       BUILD_ID: ["$BUILD_ID"]
@@ -34,6 +35,7 @@ spec:
       - "DEFAULT"
     displayName: $BUILD_ID-upgrade-test-child-directory
     labels:
+      safe-to-delete: [ "yes" ]
       custom_label: ["custom_value"]
       another_label: ["onevalue", "twovalue"]
       BUILD_ID: ["$BUILD_ID"]

--- a/test/upgrade/testdata/baseCRs/subaccount/directory.yaml
+++ b/test/upgrade/testdata/baseCRs/subaccount/directory.yaml
@@ -12,6 +12,7 @@ spec:
       - "DEFAULT"
     displayName: $BUILD_ID-upgrade-test-directory-sa
     labels:
+      safe-to-delete: [ "yes" ]
       custom_label: ["custom_value"]
       another_label: ["onevalue", "twovalue"]
       BUILD_ID: [ "$BUILD_ID" ]


### PR DESCRIPTION
Adds `safe-to-delete: ["yes"]` to every test `Directory` fixture so CI-created directories carry the same cleanup opt-in label the subaccount fixtures already use. Without it, leaked test directories have no reliable delete indicator