### PR TITLE
fix(kyma): set landscapeLabel on KymaEnvironment create

### DIFF
--- a/apis/environment/v1alpha1/kymaenvironment_types.go
+++ b/apis/environment/v1alpha1/kymaenvironment_types.go
@@ -27,6 +27,13 @@ type KymaEnvironmentParameters struct {
 	// +kubebuilder:validation:Optional
 	Name *string `json:"name"`
 
+	// LandscapeLabel is the name of the landscape within the logged-in region on which the
+	// environment instance is created. Only required when the region has more than one landscape;
+	// single-landscape regions default it server-side. Set at create only - landscape is fixed
+	// once the environment exists.
+	// +kubebuilder:validation:Optional
+	LandscapeLabel *string `json:"landscapeLabel,omitempty"`
+
 	// Provisioning parameters for the instance.
 	//
 	// The Parameters field is NOT secret or secured in any way and should

--- a/apis/environment/v1alpha1/kymaenvironment_types.go
+++ b/apis/environment/v1alpha1/kymaenvironment_types.go
@@ -32,6 +32,8 @@ type KymaEnvironmentParameters struct {
 	// single-landscape regions default it server-side. Set at create only - landscape is fixed
 	// once the environment exists.
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="landscapeLabel is immutable after creation"
 	LandscapeLabel *string `json:"landscapeLabel,omitempty"`
 
 	// Provisioning parameters for the instance.

--- a/apis/environment/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/environment/v1alpha1/zz_generated.deepcopy.go
@@ -586,6 +586,11 @@ func (in *KymaEnvironmentParameters) DeepCopyInto(out *KymaEnvironmentParameters
 		*out = new(string)
 		**out = **in
 	}
+	if in.LandscapeLabel != nil {
+		in, out := &in.LandscapeLabel, &out.LandscapeLabel
+		*out = new(string)
+		**out = **in
+	}
 	in.Parameters.DeepCopyInto(&out.Parameters)
 }
 

--- a/btp/kyma_environment.go
+++ b/btp/kyma_environment.go
@@ -40,11 +40,12 @@ func (c *Client) GetKymaEnvironment(
 	return c.GetEnvironmentByNameAndType(ctx, instanceName, environmentType)
 }
 
-func (c *Client) CreateKymaEnvironment(ctx context.Context, instanceName string, planeName string, parameters InstanceParameters, resourceUID string, serviceAccountEmail string) (string, error) {
+func (c *Client) CreateKymaEnvironment(ctx context.Context, instanceName string, planeName string, parameters InstanceParameters, resourceUID string, serviceAccountEmail string, landscapeLabel *string) (string, error) {
 	envType := KymaEnvironmentType()
 	payload := provisioningclient.CreateEnvironmentInstanceRequestPayload{
 		Description:     internal.Ptr("created via crossplane-provider-btp-account"),
 		EnvironmentType: envType.Identifier,
+		LandscapeLabel:  landscapeLabel,
 		Name:            &instanceName,
 		Origin:          nil,
 		Parameters:      parameters,

--- a/btp/kyma_environment_test.go
+++ b/btp/kyma_environment_test.go
@@ -1,0 +1,75 @@
+package btp
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	provisioningclient "github.com/sap/crossplane-provider-btp/internal/openapi_clients/btp-provisioning-service-api-go/pkg"
+)
+
+// newTestClientCapturingPayload spins up an httptest server that captures the create-environment
+// request body and returns a Client wired to hit it. This exercises the real JSON serialization
+// path, which is where issue #910 manifested: landscapeLabel was never put on the payload, so it
+// was omitted from the wire request.
+func newTestClientCapturingPayload(t *testing.T, captured *provisioningclient.CreateEnvironmentInstanceRequestPayload) (*Client, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("read body: %v", err)
+		}
+		if err := json.Unmarshal(body, captured); err != nil {
+			t.Fatalf("unmarshal payload: %v", err)
+		}
+		id := "created-id"
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(provisioningclient.CreatedEnvironmentInstanceResponseObject{Id: &id})
+	}))
+
+	cfg := provisioningclient.NewConfiguration()
+	cfg.HTTPClient = srv.Client()
+	cfg.Servers = provisioningclient.ServerConfigurations{{URL: srv.URL}}
+	api := provisioningclient.NewAPIClient(cfg).EnvironmentsAPI
+
+	return &Client{ProvisioningServiceClient: api}, srv
+}
+
+func TestCreateKymaEnvironment_LandscapeLabel(t *testing.T) {
+	landscape := "cf-eu12"
+	tests := map[string]struct {
+		landscapeLabel *string
+		wantSet        bool
+		wantValue      string
+	}{
+		"set on multi-landscape region": {landscapeLabel: &landscape, wantSet: true, wantValue: landscape},
+		"unset on single-landscape region stays absent": {landscapeLabel: nil, wantSet: false},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var got provisioningclient.CreateEnvironmentInstanceRequestPayload
+			c, srv := newTestClientCapturingPayload(t, &got)
+			defer srv.Close()
+
+			_, err := c.CreateKymaEnvironment(
+				context.Background(), "inst", "plan",
+				InstanceParameters{}, "uid", "user@example.com", tc.landscapeLabel,
+			)
+			if err != nil {
+				t.Fatalf("CreateKymaEnvironment: %v", err)
+			}
+
+			val, ok := got.GetLandscapeLabelOk()
+			if ok != tc.wantSet {
+				t.Fatalf("landscapeLabel present=%v, want %v", ok, tc.wantSet)
+			}
+			if tc.wantSet && *val != tc.wantValue {
+				t.Fatalf("landscapeLabel=%q, want %q", *val, tc.wantValue)
+			}
+		})
+	}
+}

--- a/internal/clients/kymaenvironment/kymaenvironment.go
+++ b/internal/clients/kymaenvironment/kymaenvironment.go
@@ -69,6 +69,7 @@ func (c KymaEnvironments) CreateInstance(ctx context.Context, cr v1alpha1.KymaEn
 		parameters,
 		string(cr.UID),
 		c.btp.Credential.UserCredential.Email,
+		cr.Spec.ForProvider.LandscapeLabel,
 	)
 	if err != nil {
 		return "", errors.Wrap(err, errKymaInstanceCreateFailed)

--- a/package/crds/environment.btp.sap.crossplane.io_kymaenvironments.yaml
+++ b/package/crds/environment.btp.sap.crossplane.io_kymaenvironments.yaml
@@ -168,7 +168,11 @@ spec:
                       environment instance is created. Only required when the region has more than one landscape;
                       single-landscape regions default it server-side. Set at create only - landscape is fixed
                       once the environment exists.
+                    minLength: 1
                     type: string
+                    x-kubernetes-validations:
+                    - message: landscapeLabel is immutable after creation
+                      rule: self == oldSelf
                   name:
                     description: |-
                       Can be provided, if empty the client will use metadata.name as the default value.

--- a/package/crds/environment.btp.sap.crossplane.io_kymaenvironments.yaml
+++ b/package/crds/environment.btp.sap.crossplane.io_kymaenvironments.yaml
@@ -162,6 +162,13 @@ spec:
                 description: KymaEnvironmentParameters are the configurable fields
                   of a KymaEnvironment.
                 properties:
+                  landscapeLabel:
+                    description: |-
+                      LandscapeLabel is the name of the landscape within the logged-in region on which the
+                      environment instance is created. Only required when the region has more than one landscape;
+                      single-landscape regions default it server-side. Set at create only - landscape is fixed
+                      once the environment exists.
+                    type: string
                   name:
                     description: |-
                       Can be provided, if empty the client will use metadata.name as the default value.


### PR DESCRIPTION
Closes #910.

## Summary

- **Add optional `forProvider.landscapeLabel` to `KymaEnvironment`**: `KymaEnvironmentParameters` had no landscape field, so users could not target a landscape on multi-landscape regions.
- **Set `landscapeLabel` on the create payload**: the create path never set it, so it was dropped from the request (`omitempty`), causing `Missing required parameter: landscape (landscapeLabel)` (code 11005) on multi-landscape regions. Mirrors `CloudFoundryEnvironment`'s `forProvider.landscape`.
- **Create-only**: the provisioning PATCH payload has no landscape field as it is fixed at create.
- **Not breaking for existing resources**: the field is optional and unset passes a nil pointer that serializes as absent, so existing `KymaEnvironment`s send the exact same create request as before. Behaviour changes only when a user sets it.
- **Unit test via httptest, not e2e**: e2e can't cover this (we don't run against a multi-landscape subaccount). It is tested against an `httptest` server and asserts `landscapeLabel` is part of the actual payload when set and not part of it when unset. Method used before in `internal/clients/entitlement/entitlement_test.go`.

## User-visible changes

| CR / Surface | Change | Notes |
| --- | --- | --- |
| `KymaEnvironment.spec.forProvider.landscapeLabel` | new optional string | Unset = unchanged behaviour (single-landscape regions default it server-side). Set to the target landscape on multi-landscape regions. Immutable after create in practice: the API ignores it on update. |