### PR TITLE
chore(config): enable and group dependency updates for v1 release branch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
     ":dependencyDashboard",
     "schedule:weekly"
   ],
+  "baseBranches": ["main", "release/v1_10_x"],
   "ignorePresets": ["group:goOpenapi"],
   "postUpdateOptions": [
     "gomodTidy"
@@ -13,6 +14,11 @@
   "prConcurrentLimit": 10,
   "prHourlyLimit": 0,
   "packageRules": [
+    {
+      "matchBaseBranches": ["release/v1_10_x"],
+      "matchUpdateTypes": ["major", "minor"],
+      "enabled": false
+    },
     {
       "groupName": "crossplane and upjet",
       "matchPackageNames": [
@@ -40,6 +46,10 @@
     {
       "groupName": "github actions",
       "matchManagers": ["github-actions"]
+    },
+    {
+      "matchBaseBranches": ["release/v1_10_x"],
+      "groupName": "other dependencies"
     }
   ],
   "customManagers": [

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
     ":dependencyDashboard",
     "schedule:weekly"
   ],
-  "baseBranches": ["main", "release/v1_10_x"],
+  "baseBranchPatterns": ["main", "release/v1_10_x"],
   "ignorePresets": ["group:goOpenapi"],
   "postUpdateOptions": [
     "gomodTidy"
@@ -16,8 +16,13 @@
   "packageRules": [
     {
       "matchBaseBranches": ["release/v1_10_x"],
-      "matchUpdateTypes": ["major", "minor"],
+      "matchUpdateTypes": ["major", "minor", "pin", "replacement", "rollback", "bump"],
       "enabled": false
+    },
+    {
+      "matchBaseBranches": ["release/v1_10_x"],
+      "matchUpdateTypes": ["patch", "digest"],
+      "groupName": "release/v1_10_x dependencies"
     },
     {
       "groupName": "crossplane and upjet",
@@ -46,10 +51,6 @@
     {
       "groupName": "github actions",
       "matchManagers": ["github-actions"]
-    },
-    {
-      "matchBaseBranches": ["release/v1_10_x"],
-      "groupName": "other dependencies"
     }
   ],
   "customManagers": [

--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
     "gomodTidy"
   ],
   "labels": ["release-notes/dependencies"],
-  "prConcurrentLimit": 10,
+  "prConcurrentLimit": 20,
   "prHourlyLimit": 0,
   "packageRules": [
     {


### PR DESCRIPTION
Enable renovate dependency updates on the `release/v1_10_x` branch. Restricted to patch/digest updates (no major/minor), with ungrouped deps folded into one "other dependencies" PR.

Dry-run:
- `main` was unchanged (still 10 existing PRs)
- `release/v1_10_x` branch gets 4 grouped PRs, all patch/digest