### PR TITLE
fix(cloudmanagement): self-adopt a truncated compound external-name

### DIFF
--- a/internal/controller/account/cloudmanagement/cloudmanagement.go
+++ b/internal/controller/account/cloudmanagement/cloudmanagement.go
@@ -206,13 +206,13 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		return managed.ExternalObservation{}, errors.Wrap(statusErr, errSetStatus)
 	}
 
-	// Recovery: BTP has a resource matching this managed CR, but our
-	// external-name is still a fallback — semantic lookup + ownership check
-	// (see internal/recovery). Fires only on TRUE fallback: a single-UUID
-	// external-name is the natural output of phase-1 Create and must NOT
-	// re-trigger recovery (would trap CM in an infinite loop before phase-2).
+	// Recovery: BTP has a matching resource but our external-name is a fallback
+	// or a truncated compound (bare instance UUID). Fires only when
+	// ResourceExists is false, so a healthy phase-1→phase-2 create is untouched.
+	extName := meta.GetExternalName(cr)
 	if err == nil && !resStatus.ResourceExists &&
-		recovery.IsFallbackExternalName(cr.Name, meta.GetExternalName(cr)) {
+		(recovery.IsFallbackExternalName(cr.Name, extName) ||
+			recovery.IsTruncatedCompoundExternalName(cr.Name, extName)) {
 		if healErr := c.healExternalName(ctx, cr); healErr != nil {
 			return managed.ExternalObservation{}, healErr
 		}
@@ -254,9 +254,17 @@ func (c *external) healExternalName(ctx context.Context, cr *apisv1beta1.CloudMa
 		return nil
 	}
 
-	// Uses the instance's created_at (phase-1 creates the instance first — if
-	// the instance isn't ours, the binding inside it isn't either).
-	if !recovery.IsOwnedByCR(cr, instanceCreatedAt) {
+	// Ownership proof, either of:
+	//  - the time window vs external-create-pending (IsOwnedByCR); or
+	//  - the truncated-compound match: external-name is truncated (existingBID
+	//    == ""), the lookup found a real binding (sbID != ""), and the instance
+	//    UUID we hold equals the found instance.
+	// Requiring sbID != "" leaves a healthy phase-1 (no binding yet) untouched.
+	externalNameInstanceID, existingBID := splitExternalName(meta.GetExternalName(cr))
+	ownedByTime := recovery.IsOwnedByCR(cr, instanceCreatedAt)
+	ownedByTruncatedMatch := existingBID == "" && sbID != "" &&
+		recovery.IsOwnedByExternalNameInstanceID(externalNameInstanceID, siID)
+	if !ownedByTime && !ownedByTruncatedMatch {
 		log.FromContext(ctx).Info("external-name recovery refused: BTP cloud management is outside our Create-attempt window (brownfield)",
 			"serviceInstanceID", siID, "serviceBindingID", sbID, "planID", planID,
 			"crCreatedAt", cr.GetCreationTimestamp().Time, "btpCreatedAt", instanceCreatedAt)

--- a/internal/controller/account/cloudmanagement/cloudmanagement.go
+++ b/internal/controller/account/cloudmanagement/cloudmanagement.go
@@ -269,7 +269,7 @@ func (c *external) healExternalName(ctx context.Context, cr *apisv1beta1.CloudMa
 		return nil
 	}
 
-	externalNameInstanceID, existingBID := splitExternalName(meta.GetExternalName(cr))
+	externalNameInstanceID, _ := splitExternalName(meta.GetExternalName(cr))
 
 	// Truncated external-name (bare instance UUID) with no binding found in BTP
 	// is a healthy phase-1: the instance UUID is already correct and there is no
@@ -280,15 +280,20 @@ func (c *external) healExternalName(ctx context.Context, cr *apisv1beta1.CloudMa
 		return nil
 	}
 
-	// Ownership proof, either of:
-	//  - the time window vs external-create-pending (IsOwnedByCR); or
-	//  - the truncated-compound match: external-name is truncated (existingBID
-	//    == ""), the lookup found a real binding (sbID != ""), and the instance
-	//    UUID we hold equals the found instance.
-	ownedByTime := recovery.IsOwnedByCR(cr, instanceCreatedAt)
-	ownedByTruncatedMatch := existingBID == "" && sbID != "" &&
-		recovery.IsOwnedByExternalNameInstanceID(externalNameInstanceID, siID)
-	if !ownedByTime && !ownedByTruncatedMatch {
+	// Ownership proof depends on which state we're in:
+	//  - truncated: external-name holds our phase-1 instance UUID; ownership is
+	//    proven by matching that UUID against the found instance (stronger than
+	//    the time window, which cannot pass while a Conflict retry loop keeps
+	//    rewriting external-create-pending).
+	//  - fallback (external-name == "" or metadata.name): we have no UUID to
+	//    match, so fall back to the time window.
+	var owned bool
+	if truncated {
+		owned = sbID != "" && recovery.IsOwnedByExternalNameInstanceID(externalNameInstanceID, siID)
+	} else {
+		owned = recovery.IsOwnedByCR(cr, instanceCreatedAt)
+	}
+	if !owned {
 		log.FromContext(ctx).Info("external-name recovery refused: BTP cloud management is outside our Create-attempt window (brownfield)",
 			"serviceInstanceID", siID, "serviceBindingID", sbID, "planID", planID,
 			"crCreatedAt", cr.GetCreationTimestamp().Time, "btpCreatedAt", instanceCreatedAt)

--- a/internal/controller/account/cloudmanagement/cloudmanagement.go
+++ b/internal/controller/account/cloudmanagement/cloudmanagement.go
@@ -254,13 +254,22 @@ func (c *external) healExternalName(ctx context.Context, cr *apisv1beta1.CloudMa
 		return nil
 	}
 
+	externalNameInstanceID, existingBID := splitExternalName(meta.GetExternalName(cr))
+
+	// Truncated external-name (bare instance UUID) with no binding found in BTP
+	// is a healthy phase-1: the instance UUID is already correct and there is no
+	// binding to heal. Do nothing so the two-phase Create runs phase-2 — healing
+	// here would rewrite the same bare UUID and requeue, starving phase-2.
+	truncated := recovery.IsTruncatedCompoundExternalName(cr.Name, meta.GetExternalName(cr))
+	if truncated && sbID == "" {
+		return nil
+	}
+
 	// Ownership proof, either of:
 	//  - the time window vs external-create-pending (IsOwnedByCR); or
 	//  - the truncated-compound match: external-name is truncated (existingBID
 	//    == ""), the lookup found a real binding (sbID != ""), and the instance
 	//    UUID we hold equals the found instance.
-	// Requiring sbID != "" leaves a healthy phase-1 (no binding yet) untouched.
-	externalNameInstanceID, existingBID := splitExternalName(meta.GetExternalName(cr))
 	ownedByTime := recovery.IsOwnedByCR(cr, instanceCreatedAt)
 	ownedByTruncatedMatch := existingBID == "" && sbID != "" &&
 		recovery.IsOwnedByExternalNameInstanceID(externalNameInstanceID, siID)

--- a/internal/controller/account/cloudmanagement/cloudmanagement.go
+++ b/internal/controller/account/cloudmanagement/cloudmanagement.go
@@ -224,7 +224,6 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	// Recovery: BTP has a matching resource but our external-name is a fallback
 	// or a truncated compound (bare instance UUID). Fires only when
 	// ResourceExists is false, so a healthy phase-1→phase-2 create is untouched.
-	extName := meta.GetExternalName(cr)
 	if err == nil && !resStatus.ResourceExists &&
 		(recovery.IsFallbackExternalName(cr.Name, extName) ||
 			recovery.IsTruncatedCompoundExternalName(cr.Name, extName)) {

--- a/internal/controller/account/cloudmanagement/cloudmanagement_recovery_test.go
+++ b/internal/controller/account/cloudmanagement/cloudmanagement_recovery_test.go
@@ -157,15 +157,18 @@ func TestObserve_CloudManagementAdoption(t *testing.T) {
 		}
 	})
 
-	// A healthy phase-1 (bare UUID, binding not yet created) must not heal: the
-	// lookup finds no binding (sbID == ""), so the instance-ID proof does not
-	// apply and the two-phase Create resumes on its own.
+	// A healthy phase-1 (bare UUID, binding not yet created) must not heal or
+	// requeue: the lookup finds no binding (sbID == ""), so there is nothing to
+	// heal and the two-phase Create must run phase-2 on its own. The instance is
+	// freshly created (in the ownership time window), which is the normal path —
+	// healing here would rewrite external-name to the same bare UUID and requeue,
+	// starving phase-2.
 	t.Run("healthy phase-1 (bare UUID, no binding in BTP) does NOT heal", func(t *testing.T) {
 		cr := cmForAdoption("cis-5", "plan-5")
 		meta.SetExternalName(cr, "80540c06-2955-4bce-9c43-ad78fecc7f62") // real instance UUID, non-compound
-		// Lookup finds our instance but NO binding yet (phase-1). Time window is
-		// also broken so only the (inapplicable) instance-ID proof could fire.
-		lk := &cmLookuperFake{siID: "80540c06-2955-4bce-9c43-ad78fecc7f62", sbID: "", siCreatedAt: createPendingAtCM.Add(-time.Hour), found: true}
+		// Lookup finds our instance but NO binding yet (phase-1). Instance is
+		// freshly created → within the ownership time window.
+		lk := &cmLookuperFake{siID: "80540c06-2955-4bce-9c43-ad78fecc7f62", sbID: "", siCreatedAt: createPendingAtCM.Add(2 * time.Second), found: true}
 		e := external{
 			kube: &test.MockClient{
 				MockUpdate:       test.NewMockUpdateFn(nil),

--- a/internal/controller/account/cloudmanagement/cloudmanagement_recovery_test.go
+++ b/internal/controller/account/cloudmanagement/cloudmanagement_recovery_test.go
@@ -157,13 +157,15 @@ func TestObserve_CloudManagementAdoption(t *testing.T) {
 		}
 	})
 
-	// Regression: single-UUID external-name is NOT a fallback, so adoption
-	// must NOT fire even though the compound scheme would benefit from it.
-	// See internal/recovery/recovery.go for background.
-	t.Run("single-UUID external-name does NOT trigger adoption (phase-1 output)", func(t *testing.T) {
+	// A healthy phase-1 (bare UUID, binding not yet created) must not heal: the
+	// lookup finds no binding (sbID == ""), so the instance-ID proof does not
+	// apply and the two-phase Create resumes on its own.
+	t.Run("healthy phase-1 (bare UUID, no binding in BTP) does NOT heal", func(t *testing.T) {
 		cr := cmForAdoption("cis-5", "plan-5")
-		meta.SetExternalName(cr, "80540c06-2955-4bce-9c43-ad78fecc7f62") // real UUID, non-compound
-		lk := &cmLookuperFake{siID: "should-not-be-set", sbID: "should-not-be-set", found: true}
+		meta.SetExternalName(cr, "80540c06-2955-4bce-9c43-ad78fecc7f62") // real instance UUID, non-compound
+		// Lookup finds our instance but NO binding yet (phase-1). Time window is
+		// also broken so only the (inapplicable) instance-ID proof could fire.
+		lk := &cmLookuperFake{siID: "80540c06-2955-4bce-9c43-ad78fecc7f62", sbID: "", siCreatedAt: createPendingAtCM.Add(-time.Hour), found: true}
 		e := external{
 			kube: &test.MockClient{
 				MockUpdate:       test.NewMockUpdateFn(nil),
@@ -174,13 +176,10 @@ func TestObserve_CloudManagementAdoption(t *testing.T) {
 		}
 		_, err := e.Observe(context.TODO(), cr)
 		if err != nil {
-			t.Fatalf("expected nil error (adoption skipped), got %v", err)
+			t.Fatalf("expected nil error (recovery must not fire on healthy phase-1), got %v", err)
 		}
 		if got := meta.GetExternalName(cr); got != "80540c06-2955-4bce-9c43-ad78fecc7f62" {
-			t.Errorf("external-name must be unchanged (adoption must not run), got %q", got)
-		}
-		if lk.gotPlan != "" {
-			t.Errorf("lookup must NOT have been invoked, got planID=%q", lk.gotPlan)
+			t.Errorf("external-name must be unchanged (phase-1 not altered), got %q", got)
 		}
 	})
 
@@ -241,6 +240,99 @@ func TestObserve_CloudManagementAdoption(t *testing.T) {
 		}
 		if lk.gotPlan != "" {
 			t.Errorf("lookup must NOT be invoked when Create was never attempted, got planID=%q", lk.gotPlan)
+		}
+	})
+
+	// Truncated-compound state: bare instance UUID, binding still in BTP. Heals
+	// back to the compound name via the instance-ID match. The time window is
+	// broken (siCreatedAt before pending) to model the Conflict loop where
+	// IsOwnedByCR can never pass.
+	t.Run("truncated compound external-name heals via instance-ID match despite broken time window", func(t *testing.T) {
+		cr := cmForAdoption("cis-truncated", "plan-1")
+		meta.SetExternalName(cr, "11111111-1111-1111-1111-111111111111") // bare instance UUID, binding-ID lost
+		lk := &cmLookuperFake{
+			siID:        "11111111-1111-1111-1111-111111111111", // same instance we already hold
+			sbID:        "22222222-2222-2222-2222-222222222222",
+			siCreatedAt: createPendingAtCM.Add(-time.Hour), // window broken: brownfield by time
+			found:       true,
+		}
+		e := external{
+			kube: &test.MockClient{
+				MockUpdate:       test.NewMockUpdateFn(nil),
+				MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
+			},
+			tfClient:           TfClientFake{observeFn: notExisting},
+			newAdminLookuperFn: cmFactory(lk),
+		}
+		_, err := e.Observe(context.TODO(), cr)
+		if !errors.Is(err, recovery.ErrRequeueAfterRecovery) {
+			t.Fatalf("expected ErrRequeueAfterRecovery, got %v", err)
+		}
+		if got := meta.GetExternalName(cr); got != "11111111-1111-1111-1111-111111111111/22222222-2222-2222-2222-222222222222" {
+			t.Errorf("external-name = %q, want the healed compound name", got)
+		}
+	})
+
+	// Safety: a truncated external-name whose instance UUID does not match the
+	// found instance is brownfield (time window also broken) — refuse, leave
+	// external-name untouched.
+	t.Run("truncated compound external-name with mismatched instance ID is refused brownfield", func(t *testing.T) {
+		cr := cmForAdoption("cis-mismatch", "plan-1")
+		meta.SetExternalName(cr, "11111111-1111-1111-1111-111111111111") // bare UUID we hold
+		lk := &cmLookuperFake{
+			siID:        "33333333-3333-3333-3333-333333333333", // DIFFERENT instance found by lookup
+			sbID:        "44444444-4444-4444-4444-444444444444",
+			siCreatedAt: createPendingAtCM.Add(-time.Hour), // window also broken
+			found:       true,
+		}
+		rec := &cmRecorderFake{}
+		e := external{
+			kube: &test.MockClient{
+				MockUpdate:       test.NewMockUpdateFn(nil),
+				MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
+			},
+			tfClient:           TfClientFake{observeFn: notExisting},
+			newAdminLookuperFn: cmFactory(lk),
+			recorder:           rec,
+		}
+		_, err := e.Observe(context.TODO(), cr)
+		if err != nil {
+			t.Fatalf("expected nil error (recovery declined), got %v", err)
+		}
+		if got := meta.GetExternalName(cr); got != "11111111-1111-1111-1111-111111111111" {
+			t.Errorf("external-name must be unchanged, got %q", got)
+		}
+		if !rec.has(recovery.EventReasonRefusedBrownfield) {
+			t.Errorf("expected %q event, got %+v", recovery.EventReasonRefusedBrownfield, rec.events)
+		}
+	})
+
+	// A bare UUID with ResourceExists=true is a healthy phase-1 intermediate:
+	// the guard requires !ResourceExists, so the heal must not fire.
+	t.Run("bare-UUID external-name with ResourceExists=true does NOT trigger recovery", func(t *testing.T) {
+		existing := func() (cmclient.ResourcesStatus, error) {
+			return cmclient.ResourcesStatus{ExternalObservation: managed.ExternalObservation{ResourceExists: true}}, nil
+		}
+		cr := cmForAdoption("cis-phase1", "plan-1")
+		meta.SetExternalName(cr, "11111111-1111-1111-1111-111111111111")
+		lk := &cmLookuperFake{siID: "must-not-be-used", sbID: "must-not-be-used", found: true}
+		e := external{
+			kube: &test.MockClient{
+				MockUpdate:       test.NewMockUpdateFn(nil),
+				MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
+			},
+			tfClient:           TfClientFake{observeFn: existing},
+			newAdminLookuperFn: cmFactory(lk),
+		}
+		_, err := e.Observe(context.TODO(), cr)
+		if err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+		if got := meta.GetExternalName(cr); got != "11111111-1111-1111-1111-111111111111" {
+			t.Errorf("external-name must be unchanged, got %q", got)
+		}
+		if lk.gotPlan != "" {
+			t.Errorf("lookup must NOT be invoked while ResourceExists, got planID=%q", lk.gotPlan)
 		}
 	})
 }

--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -19,6 +19,7 @@
 package recovery
 
 import (
+	"strings"
 	"time"
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/meta"
@@ -99,4 +100,24 @@ var ErrRequeueAfterRecovery = errors.New(
 // infinite loop where phase-2 never ran.
 func IsFallbackExternalName(metadataName, externalName string) bool {
 	return externalName == "" || externalName == metadataName
+}
+
+// IsTruncatedCompoundExternalName reports whether externalName is a compound
+// external-name ("instanceID/bindingID") truncated down to the bare instanceID
+// (binding-ID segment lost). Distinct from a fallback ("" or == metadata.name)
+// and from a healthy compound name (containing "/"). Only meaningful for the
+// two-phase resources (CloudManagement / ServiceManager).
+func IsTruncatedCompoundExternalName(metadataName, externalName string) bool {
+	return externalName != "" &&
+		externalName != metadataName &&
+		!strings.Contains(externalName, "/")
+}
+
+// IsOwnedByExternalNameInstanceID is the ownership proof for the
+// truncated-compound path: the instance UUID our own phase-1 Create wrote into
+// external-name equals the instance the spec-scoped lookup found. Used instead
+// of IsOwnedByCR here, whose time window can never pass while a Conflict retry
+// loop keeps rewriting external-create-pending. The fallback path is unaffected.
+func IsOwnedByExternalNameInstanceID(externalNameInstanceID, foundInstanceID string) bool {
+	return externalNameInstanceID != "" && externalNameInstanceID == foundInstanceID
 }

--- a/internal/recovery/recovery_test.go
+++ b/internal/recovery/recovery_test.go
@@ -123,6 +123,54 @@ func TestIsOwnedByCR_PendingWindow(t *testing.T) {
 	}
 }
 
+// TestIsTruncatedCompoundExternalName: a compound external-name
+// (instanceID/bindingID) truncated to the bare instanceID, distinguished from a
+// fallback and from a healthy compound name.
+func TestIsTruncatedCompoundExternalName(t *testing.T) {
+	tests := []struct {
+		name         string
+		metadataName string
+		externalName string
+		want         bool
+	}{
+		{name: "bare instance UUID (truncated compound) is truncated", metadataName: "cis-abc", externalName: "11111111-1111-1111-1111-111111111111", want: true},
+		{name: "healthy compound instanceID/bindingID is not truncated", metadataName: "cis-abc", externalName: "11111111-1111-1111-1111-111111111111/22222222-2222-2222-2222-222222222222", want: false},
+		{name: "empty external-name is not truncated (it is a fallback)", metadataName: "cis-abc", externalName: "", want: false},
+		{name: "external-name equal to metadata.name is not truncated (it is a fallback)", metadataName: "cis-abc", externalName: "cis-abc", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsTruncatedCompoundExternalName(tc.metadataName, tc.externalName); got != tc.want {
+				t.Errorf("IsTruncatedCompoundExternalName(%q,%q) = %v, want %v", tc.metadataName, tc.externalName, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIsOwnedByExternalNameInstanceID: the instance UUID our phase-1 Create
+// wrote into external-name must equal the instance the lookup found. Used
+// instead of the time window on the truncated-compound path.
+func TestIsOwnedByExternalNameInstanceID(t *testing.T) {
+	tests := []struct {
+		name                 string
+		externalNameInstance string
+		foundInstance        string
+		want                 bool
+	}{
+		{name: "matching non-empty instance IDs: owned", externalNameInstance: "11111111-1111-1111-1111-111111111111", foundInstance: "11111111-1111-1111-1111-111111111111", want: true},
+		{name: "different instance IDs: not owned", externalNameInstance: "11111111-1111-1111-1111-111111111111", foundInstance: "33333333-3333-3333-3333-333333333333", want: false},
+		{name: "empty external-name instance ID: not owned", externalNameInstance: "", foundInstance: "11111111-1111-1111-1111-111111111111", want: false},
+		{name: "both empty: not owned", externalNameInstance: "", foundInstance: "", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsOwnedByExternalNameInstanceID(tc.externalNameInstance, tc.foundInstance); got != tc.want {
+				t.Errorf("IsOwnedByExternalNameInstanceID(%q,%q) = %v, want %v", tc.externalNameInstance, tc.foundInstance, got, tc.want)
+			}
+		})
+	}
+}
+
 // TestHasCreateBeenAttempted is a thin wrapper around
 // meta.GetExternalCreatePending; it exists so callers can name-check the
 // intent (short-circuit before running a semantic lookup) rather than


### PR DESCRIPTION
## Problem

A `CloudManagement`'s `external-name` encodes two IDs as `instanceID/bindingID`. In this failure mode it is truncated down to the **bare instance UUID** (the binding-ID segment is lost) while the binding still exists and is ready in BTP. `Observe` then reports `ResourceExists=false`, so the CR loops forever on `API Error Creating Resource Service Binding (Subaccount): Conflict` — the binding already exists in BTP, so the re-create 409s. Downstream, the connection secret is never written, so consumers of the CloudManagement credentials cannot proceed.

The prevention fix (`Create()` no longer truncates the external-name) is already merged, but the truncated state can still be reached — so this adds a **recovery** path that heals it instead of requiring a manual `kubectl annotate`.

## Why the existing recovery path did not fire

`healExternalName` already does the right thing on a match (`LookupInstanceAndBinding` → rewrite the full `instanceID/bindingID`). Two gates blocked it for this state:

1. **`recovery.IsFallbackExternalName`** treats only `"" || == metadata.name` as a fallback; a bare-UUID external-name (the legitimate phase-1 intermediate) is deliberately not a fallback, so `healExternalName` was never called.
2. **`recovery.IsOwnedByCR`** (time window vs `external-create-pending`) cannot pass here: in the Conflict retry loop `create-pending` is rewritten to "now" on every retry while the instance `created_at` stays fixed, so the window flips to brownfield within ~1 minute of instance birth.

## Fix

Two small helpers + wiring; `healExternalName` itself is unchanged.

- **`recovery.IsTruncatedCompoundExternalName`** — recognizes the bare-UUID compound state (non-empty, `!= metadata.name`, no `/`). The Observe guard now fires on it **in addition to** the fallback case, and only when `ResourceExists == false` (so a healthy phase-1→phase-2 create is untouched).
- **`recovery.IsOwnedByExternalNameInstanceID`** — ownership proof for the truncated path: the instance UUID our own phase-1 `Create` already wrote into `external-name` equals the instance the spec-scoped semantic lookup (plan + name, unique) finds in BTP. Used **instead of** the time window on this path. The fallback path keeps `IsOwnedByCR` unchanged.
- The instance-ID proof additionally requires that the lookup found a **real binding** (`sbID != ""`). This keeps a healthy phase-1 (instance in BTP, binding not yet created → `sbID == ""`) from healing to the same bare UUID and spuriously requeuing every reconcile.

## Tests

- `recovery_test.go`: `IsTruncatedCompoundExternalName` (bare-UUID→true; compound/empty/==name→false); `IsOwnedByExternalNameInstanceID` (match/empty/differ).
- `cloudmanagement_recovery_test.go`: truncated external-name + broken time window + instance-ID match → heals to compound name, requeues; truncated + mismatched instance ID → refused brownfield; bare-UUID with `ResourceExists=true` → recovery not triggered; healthy phase-1 (bare UUID, no binding in BTP) → does not heal. Existing fallback-path tests unchanged.
- `go build ./...`, `go vet`, and `go test ./internal/recovery/ ./internal/controller/account/... ./internal/clients/servicemanager/...` green.
- Verified end-to-end against a real BTP subaccount on a kind cluster: truncating a healthy CloudManagement's external-name to the bare instance UUID (with instance+binding IDs also cleared from status to exclude the migration path) heals back to the compound name purely via the BTP lookup.

## Out of scope

The halted `ExternalCreateIncomplete` variant (`create-pending` newer than `create-failed`, no `create-succeeded`) is frozen by crossplane-runtime **before** `Observe` runs (`Requeue:false`, "cannot determine creation result"), so an Observe-based heal cannot reach it.