### PR TITLE
fix(servicemanager): self-adopt a truncated compound external-name

### DIFF
--- a/internal/controller/account/servicemanager/servicemanager.go
+++ b/internal/controller/account/servicemanager/servicemanager.go
@@ -220,7 +220,7 @@ func (c *external) healExternalName(ctx context.Context, cr *apisv1beta1.Service
 		return nil
 	}
 
-	externalNameInstanceID, existingBID, _ := strings.Cut(meta.GetExternalName(cr), "/")
+	externalNameInstanceID, _, _ := strings.Cut(meta.GetExternalName(cr), "/")
 
 	// Truncated external-name (bare instance UUID) with no binding found in BTP
 	// is a healthy phase-1: the instance UUID is already correct and there is no
@@ -231,15 +231,20 @@ func (c *external) healExternalName(ctx context.Context, cr *apisv1beta1.Service
 		return nil
 	}
 
-	// Ownership proof, either of:
-	//  - the time window vs external-create-pending (IsOwnedByCR); or
-	//  - the truncated-compound match: external-name is truncated (existingBID
-	//    == ""), the lookup found a real binding (sbID != ""), and the instance
-	//    UUID we hold equals the found instance.
-	ownedByTime := recovery.IsOwnedByCR(cr, instanceCreatedAt)
-	ownedByTruncatedMatch := existingBID == "" && sbID != "" &&
-		recovery.IsOwnedByExternalNameInstanceID(externalNameInstanceID, siID)
-	if !ownedByTime && !ownedByTruncatedMatch {
+	// Ownership proof depends on which state we're in:
+	//  - truncated: external-name holds our phase-1 instance UUID; ownership is
+	//    proven by matching that UUID against the found instance (stronger than
+	//    the time window, which cannot pass while a Conflict retry loop keeps
+	//    rewriting external-create-pending).
+	//  - fallback (external-name == "" or metadata.name): we have no UUID to
+	//    match, so fall back to the time window.
+	var owned bool
+	if truncated {
+		owned = sbID != "" && recovery.IsOwnedByExternalNameInstanceID(externalNameInstanceID, siID)
+	} else {
+		owned = recovery.IsOwnedByCR(cr, instanceCreatedAt)
+	}
+	if !owned {
 		log.FromContext(ctx).Info("external-name recovery refused: BTP service manager is outside our Create-attempt window (brownfield)",
 			"serviceInstanceID", siID, "serviceBindingID", sbID, "planID", planID,
 			"crCreatedAt", cr.GetCreationTimestamp().Time, "btpCreatedAt", instanceCreatedAt)

--- a/internal/controller/account/servicemanager/servicemanager.go
+++ b/internal/controller/account/servicemanager/servicemanager.go
@@ -3,6 +3,7 @@ package servicemanager
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
@@ -171,13 +172,13 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 		return managed.ExternalObservation{}, errors.Wrap(statusErr, errSetStatus)
 	}
 
-	// Recovery: BTP has a resource matching this managed CR, but our
-	// external-name is still a fallback — semantic lookup + ownership check
-	// (see internal/recovery). Fires only on TRUE fallback: a single-UUID
-	// external-name is the natural output of phase-1 Create and must NOT
-	// re-trigger recovery (would trap SM in an infinite loop before phase-2).
+	// Recovery: BTP has a matching resource but our external-name is a fallback
+	// or a truncated compound (bare instance UUID). Fires only when
+	// ResourceExists is false, so a healthy phase-1→phase-2 create is untouched.
+	extName := meta.GetExternalName(cr)
 	if err == nil && !resStatus.ResourceExists &&
-		recovery.IsFallbackExternalName(cr.Name, meta.GetExternalName(cr)) {
+		(recovery.IsFallbackExternalName(cr.Name, extName) ||
+			recovery.IsTruncatedCompoundExternalName(cr.Name, extName)) {
 		if healErr := c.healExternalName(ctx, cr); healErr != nil {
 			return managed.ExternalObservation{}, healErr
 		}
@@ -219,9 +220,26 @@ func (c *external) healExternalName(ctx context.Context, cr *apisv1beta1.Service
 		return nil
 	}
 
-	// Uses the instance's created_at (phase-1 creates the instance first — if
-	// the instance isn't ours, the binding inside it isn't either).
-	if !recovery.IsOwnedByCR(cr, instanceCreatedAt) {
+	externalNameInstanceID, existingBID, _ := strings.Cut(meta.GetExternalName(cr), "/")
+
+	// Truncated external-name (bare instance UUID) with no binding found in BTP
+	// is a healthy phase-1: the instance UUID is already correct and there is no
+	// binding to heal. Do nothing so the two-phase Create runs phase-2 — healing
+	// here would rewrite the same bare UUID and requeue, starving phase-2.
+	truncated := recovery.IsTruncatedCompoundExternalName(cr.Name, meta.GetExternalName(cr))
+	if truncated && sbID == "" {
+		return nil
+	}
+
+	// Ownership proof, either of:
+	//  - the time window vs external-create-pending (IsOwnedByCR); or
+	//  - the truncated-compound match: external-name is truncated (existingBID
+	//    == ""), the lookup found a real binding (sbID != ""), and the instance
+	//    UUID we hold equals the found instance.
+	ownedByTime := recovery.IsOwnedByCR(cr, instanceCreatedAt)
+	ownedByTruncatedMatch := existingBID == "" && sbID != "" &&
+		recovery.IsOwnedByExternalNameInstanceID(externalNameInstanceID, siID)
+	if !ownedByTime && !ownedByTruncatedMatch {
 		log.FromContext(ctx).Info("external-name recovery refused: BTP service manager is outside our Create-attempt window (brownfield)",
 			"serviceInstanceID", siID, "serviceBindingID", sbID, "planID", planID,
 			"crCreatedAt", cr.GetCreationTimestamp().Time, "btpCreatedAt", instanceCreatedAt)

--- a/internal/controller/account/servicemanager/servicemanager_recovery_test.go
+++ b/internal/controller/account/servicemanager/servicemanager_recovery_test.go
@@ -195,14 +195,16 @@ func TestObserve_ServiceManagerAdoption(t *testing.T) {
 		}
 	})
 
-	// Regression: single-UUID external-name is NOT a fallback, so adoption
-	// must NOT fire even though the compound scheme would benefit from it.
-	// This is the phase-1 output during two-phase Create and used to trap the
-	// SM controller in an infinite adoption loop. See internal/recovery/recovery.go.
-	t.Run("single-UUID external-name does NOT trigger adoption (phase-1 output)", func(t *testing.T) {
+	// A healthy phase-1 (bare UUID, binding not yet created) must not heal or
+	// requeue: the lookup finds no binding (sbID == ""), so there is nothing to
+	// heal and the two-phase Create must run phase-2. The instance is freshly
+	// created (in the ownership time window), which is the normal path — healing
+	// here would rewrite external-name to the same bare UUID and requeue,
+	// starving phase-2.
+	t.Run("healthy phase-1 (bare UUID, no binding in BTP) does NOT heal", func(t *testing.T) {
 		cr := smForAdoption("sm-5", "plan-5")
-		meta.SetExternalName(cr, "80540c06-2955-4bce-9c43-ad78fecc7f62") // real UUID, non-compound
-		lk := &smLookuperFake{siID: "must-not-be-used", sbID: "must-not-be-used", found: true}
+		meta.SetExternalName(cr, "80540c06-2955-4bce-9c43-ad78fecc7f62") // real instance UUID, non-compound
+		lk := &smLookuperFake{siID: "80540c06-2955-4bce-9c43-ad78fecc7f62", sbID: "", siCreatedAt: createPendingAtSM.Add(2 * time.Second), found: true}
 		e := external{
 			kube: &test.MockClient{
 				MockUpdate:       test.NewMockUpdateFn(nil),
@@ -213,13 +215,74 @@ func TestObserve_ServiceManagerAdoption(t *testing.T) {
 		}
 		_, err := e.Observe(context.TODO(), cr)
 		if err != nil {
-			t.Fatalf("expected nil error (adoption skipped), got %v", err)
+			t.Fatalf("expected nil error (recovery must not fire on healthy phase-1), got %v", err)
 		}
 		if got := meta.GetExternalName(cr); got != "80540c06-2955-4bce-9c43-ad78fecc7f62" {
-			t.Errorf("external-name must be unchanged (adoption must not run), got %q", got)
+			t.Errorf("external-name must be unchanged (phase-1 not altered), got %q", got)
 		}
-		if lk.gotPlan != "" {
-			t.Errorf("lookup must NOT have been invoked, got planID=%q", lk.gotPlan)
+	})
+
+	// Truncated-compound state: bare instance UUID, binding still in BTP. Heals
+	// back to the compound name via the instance-ID match. The time window is
+	// broken (siCreatedAt before pending) to model the Conflict loop where
+	// IsOwnedByCR can never pass.
+	t.Run("truncated compound external-name heals via instance-ID match despite broken time window", func(t *testing.T) {
+		cr := smForAdoption("sm-truncated", "plan-1")
+		meta.SetExternalName(cr, "11111111-1111-1111-1111-111111111111") // bare instance UUID, binding-ID lost
+		lk := &smLookuperFake{
+			siID:        "11111111-1111-1111-1111-111111111111",
+			sbID:        "22222222-2222-2222-2222-222222222222",
+			siCreatedAt: createPendingAtSM.Add(-time.Hour), // window broken
+			found:       true,
+		}
+		e := external{
+			kube: &test.MockClient{
+				MockUpdate:       test.NewMockUpdateFn(nil),
+				MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
+			},
+			tfClient:           &TfClientFake{observeFn: notExisting},
+			newAdminLookuperFn: smFactory(lk),
+		}
+		_, err := e.Observe(context.TODO(), cr)
+		if !errors.Is(err, recovery.ErrRequeueAfterRecovery) {
+			t.Fatalf("expected ErrRequeueAfterRecovery, got %v", err)
+		}
+		if got := meta.GetExternalName(cr); got != "11111111-1111-1111-1111-111111111111/22222222-2222-2222-2222-222222222222" {
+			t.Errorf("external-name = %q, want the healed compound name", got)
+		}
+	})
+
+	// Safety: a truncated external-name whose instance UUID does not match the
+	// found instance is brownfield (time window also broken) — refuse, leave
+	// external-name untouched.
+	t.Run("truncated compound external-name with mismatched instance ID is refused brownfield", func(t *testing.T) {
+		cr := smForAdoption("sm-mismatch", "plan-1")
+		meta.SetExternalName(cr, "11111111-1111-1111-1111-111111111111")
+		lk := &smLookuperFake{
+			siID:        "33333333-3333-3333-3333-333333333333", // DIFFERENT instance found
+			sbID:        "44444444-4444-4444-4444-444444444444",
+			siCreatedAt: createPendingAtSM.Add(-time.Hour),
+			found:       true,
+		}
+		rec := &smRecorderFake{}
+		e := external{
+			kube: &test.MockClient{
+				MockUpdate:       test.NewMockUpdateFn(nil),
+				MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
+			},
+			tfClient:           &TfClientFake{observeFn: notExisting},
+			newAdminLookuperFn: smFactory(lk),
+			recorder:           rec,
+		}
+		_, err := e.Observe(context.TODO(), cr)
+		if err != nil {
+			t.Fatalf("expected nil error (recovery declined), got %v", err)
+		}
+		if got := meta.GetExternalName(cr); got != "11111111-1111-1111-1111-111111111111" {
+			t.Errorf("external-name must be unchanged, got %q", got)
+		}
+		if !rec.has(recovery.EventReasonRefusedBrownfield) {
+			t.Errorf("expected %q event, got %+v", recovery.EventReasonRefusedBrownfield, rec.events)
 		}
 	})
 
@@ -276,6 +339,35 @@ func TestObserve_ServiceManagerAdoption(t *testing.T) {
 		}
 		if lk.gotPlan != "" {
 			t.Errorf("lookup must NOT be invoked when Create was never attempted, got planID=%q", lk.gotPlan)
+		}
+	})
+
+	// A bare UUID with ResourceExists=true is a healthy phase-1 intermediate:
+	// the guard requires !ResourceExists, so the heal must not fire.
+	t.Run("bare-UUID external-name with ResourceExists=true does NOT trigger recovery", func(t *testing.T) {
+		existing := func() (sm.ResourcesStatus, error) {
+			return sm.ResourcesStatus{ExternalObservation: managed.ExternalObservation{ResourceExists: true}}, nil
+		}
+		cr := smForAdoption("sm-phase1", "plan-1")
+		meta.SetExternalName(cr, "11111111-1111-1111-1111-111111111111")
+		lk := &smLookuperFake{siID: "must-not-be-used", sbID: "must-not-be-used", found: true}
+		e := external{
+			kube: &test.MockClient{
+				MockUpdate:       test.NewMockUpdateFn(nil),
+				MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
+			},
+			tfClient:           &TfClientFake{observeFn: existing},
+			newAdminLookuperFn: smFactory(lk),
+		}
+		_, err := e.Observe(context.TODO(), cr)
+		if err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+		if got := meta.GetExternalName(cr); got != "11111111-1111-1111-1111-111111111111" {
+			t.Errorf("external-name must be unchanged, got %q", got)
+		}
+		if lk.gotPlan != "" {
+			t.Errorf("lookup must NOT be invoked while ResourceExists, got planID=%q", lk.gotPlan)
 		}
 	})
 }

--- a/internal/recovery/recovery_test.go
+++ b/internal/recovery/recovery_test.go
@@ -133,10 +133,10 @@ func TestIsTruncatedCompoundExternalName(t *testing.T) {
 		externalName string
 		want         bool
 	}{
-		{name: "bare instance UUID (truncated compound) is truncated", metadataName: "cis-abc", externalName: "11111111-1111-1111-1111-111111111111", want: true},
-		{name: "healthy compound instanceID/bindingID is not truncated", metadataName: "cis-abc", externalName: "11111111-1111-1111-1111-111111111111/22222222-2222-2222-2222-222222222222", want: false},
-		{name: "empty external-name is not truncated (it is a fallback)", metadataName: "cis-abc", externalName: "", want: false},
-		{name: "external-name equal to metadata.name is not truncated (it is a fallback)", metadataName: "cis-abc", externalName: "cis-abc", want: false},
+		{name: "bare instance UUID (truncated compound) is truncated", metadataName: "sm-abc", externalName: "11111111-1111-1111-1111-111111111111", want: true},
+		{name: "healthy compound instanceID/bindingID is not truncated", metadataName: "sm-abc", externalName: "11111111-1111-1111-1111-111111111111/22222222-2222-2222-2222-222222222222", want: false},
+		{name: "empty external-name is not truncated (it is a fallback)", metadataName: "sm-abc", externalName: "", want: false},
+		{name: "external-name equal to metadata.name is not truncated (it is a fallback)", metadataName: "sm-abc", externalName: "sm-abc", want: false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Problem

A `ServiceManager`'s `external-name` encodes two IDs as `instanceID/bindingID`. It can be truncated down to the **bare instance UUID** (binding-ID segment lost) while the binding still exists and is ready in BTP. `Observe` then reports `ResourceExists=false`, so the CR loops forever on `API Error Creating Resource Service Binding (Subaccount): Conflict` — the binding already exists in BTP, so the re-create 409s.

This is the same failure mode and the same fix as the CloudManagement recovery path — ServiceManager is the other two-phase resource with a compound external-name.

## Why the existing recovery path did not fire

`healExternalName` already does the right thing on a match (`LookupInstanceAndBinding` → rewrite the full `instanceID/bindingID`). Two gates blocked it for this state:

1. **`recovery.IsFallbackExternalName`** treats only `"" || == metadata.name` as a fallback; a bare-UUID external-name (the legitimate phase-1 intermediate) is deliberately not a fallback, so `healExternalName` was never called.
2. **`recovery.IsOwnedByCR`** (time window vs `external-create-pending`) cannot pass in the Conflict retry loop: `create-pending` is rewritten to "now" on every retry while the instance `created_at` stays fixed, so the window flips to brownfield within ~1 minute.

## Fix

- **`recovery.IsTruncatedCompoundExternalName`** — recognizes the bare-UUID compound state. The Observe guard now fires on it **in addition to** the fallback case, and only when `ResourceExists == false` (so a healthy phase-1→phase-2 create is untouched).
- **`recovery.IsOwnedByExternalNameInstanceID`** — ownership proof for the truncated path: the instance UUID our own phase-1 `Create` already wrote into `external-name` equals the instance the spec-scoped semantic lookup (plan + name, unique) finds in BTP. Used **instead of** the time window on this path. The fallback path keeps `IsOwnedByCR` unchanged.
- The truncated path additionally does nothing when the lookup found no binding (`sbID == ""`): a healthy phase-1 (instance created, binding not yet) is in the time window, and without this guard it would rewrite external-name to the same bare UUID and requeue, starving phase-2.

`healExternalName` itself is unchanged.

## Tests

- `recovery_test.go`: `IsTruncatedCompoundExternalName`, `IsOwnedByExternalNameInstanceID`.
- `servicemanager_recovery_test.go`: truncated external-name + broken time window + instance-ID match → heals to compound name, requeues; truncated + mismatched instance ID → refused brownfield; healthy phase-1 (fresh instance, no binding) → does not heal; bare-UUID with `ResourceExists=true` → recovery not triggered. Existing fallback-path tests unchanged.
- `go build ./...`, `go vet`, and `go test ./internal/recovery/ ./internal/controller/account/servicemanager/ ./internal/clients/servicemanager/` green.

## Note on shared helpers

The two `recovery` helpers are also added by the CloudManagement fix in a separate PR. They are identical; whichever lands first brings them to `main`, and the other rebases onto it with a trivial (identical) resolution.