### PR TITLE
chore(renovate): reduce dependency-update PR volume

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
+    "config:best-practices",
     ":dependencyDashboard"
   ],
   "schedule": ["* * 1,15 * *"],
+  "minimumReleaseAge": "7 days",
+  "internalChecksFilter": "strict",
   "baseBranchPatterns": ["main", "release/v1_10_x"],
   "ignorePresets": ["group:goOpenapi"],
   "postUpdateOptions": [
@@ -52,6 +54,10 @@
     {
       "groupName": "github actions",
       "matchManagers": ["github-actions"]
+    },
+    {
+      "groupName": "docker images",
+      "matchManagers": ["dockerfile"]
     }
   ],
   "customManagers": [

--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,11 @@
       "groupName": "release/v1_10_x dependencies"
     },
     {
+      "groupName": "other dependencies",
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["minor", "patch", "digest", "pin"]
+    },
+    {
       "groupName": "crossplane and upjet",
       "matchPackageNames": [
         "github.com/crossplane/**",
@@ -43,10 +48,6 @@
         "k8s.io/**",
         "sigs.k8s.io/**"
       ]
-    },
-    {
-      "groupName": "golang.org/x",
-      "matchPackageNames": ["golang.org/x/**"]
     },
     {
       "groupName": "github actions",

--- a/renovate.json
+++ b/renovate.json
@@ -2,9 +2,9 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    ":dependencyDashboard",
-    "schedule:weekly"
+    ":dependencyDashboard"
   ],
+  "schedule": ["* * 1,15 * *"],
   "baseBranchPatterns": ["main", "release/v1_10_x"],
   "ignorePresets": ["group:goOpenapi"],
   "postUpdateOptions": [


### PR DESCRIPTION
## Why

Renovate opens too many small PRs. Every batch also runs the e2e cluster, so both cost and manual-merge work scale with PR count. Three sources drive the volume: standalone go-module bumps each get their own PR, updates land weekly, and prior batches often needed hand-reverting of day-old deps. This PR addresses all three - fewer batches, loose modules folded into one PR, and a release-age hold - while keeping majors isolated so breaking bumps stay reviewable.

## Changes

- **Schedule:** replace `schedule:weekly` with `"schedule": ["* * 1,15 * *"]` (1st + 15th).
- **Grouping:** add an `"other dependencies"` group (`matchManagers: ["gomod"]`, non-major types) that collapses the standalone modules (`go-cfclient/v3`, `logr`, `kubelogin`, `golang.org/x/*`, ...) into one PR; majors like `jwt/v4 -> v5` stay split.
- **Base preset:** swap `config:recommended` for `config:best-practices` (adds `docker:pinDigests`, `helpers:pinGitHubActionDigests`, `:configMigration`; npm/lockfile presets are no-ops here).
- **Digest batching:** add a `"docker images"` group so the new Docker digest bumps batch; action digest pins already batch in the existing `"github actions"` group.
- **Release-age hold:** add `minimumReleaseAge: "7 days"` + `internalChecksFilter: "strict"` to hold fresh releases.

## Notes

- Verified with `renovate-config-validator --strict` and a local `--dry-run=full`.