### PR TITLE
[Backport release/v1_10_x] fix(subaccountapicredential): set key as sensitive

### DIFF
--- a/apis/security/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/security/v1alpha1/zz_generated.deepcopy.go
@@ -699,11 +699,6 @@ func (in *SubaccountApiCredentialObservation) DeepCopyInto(out *SubaccountApiCre
 		*out = new(string)
 		**out = **in
 	}
-	if in.Key != nil {
-		in, out := &in.Key, &out.Key
-		*out = new(string)
-		**out = **in
-	}
 	if in.Name != nil {
 		in, out := &in.Name, &out.Name
 		*out = new(string)

--- a/apis/security/v1alpha1/zz_subaccountapicredential_terraformed.go
+++ b/apis/security/v1alpha1/zz_subaccountapicredential_terraformed.go
@@ -33,7 +33,7 @@ func (mg *SubaccountApiCredential) GetTerraformResourceType() string {
 
 // GetConnectionDetailsMapping for this SubaccountApiCredential
 func (tr *SubaccountApiCredential) GetConnectionDetailsMapping() map[string]string {
-	return map[string]string{"api_url": "status.atProvider.apiUrl", "client_id": "status.atProvider.clientId", "client_secret": "status.atProvider.clientSecret", "token_url": "status.atProvider.tokenUrl"}
+	return map[string]string{"api_url": "status.atProvider.apiUrl", "client_id": "status.atProvider.clientId", "client_secret": "status.atProvider.clientSecret", "key": "status.atProvider.key", "token_url": "status.atProvider.tokenUrl"}
 }
 
 // GetObservation of this SubaccountApiCredential

--- a/apis/security/v1alpha1/zz_subaccountapicredential_types.go
+++ b/apis/security/v1alpha1/zz_subaccountapicredential_types.go
@@ -72,10 +72,6 @@ type SubaccountApiCredentialObservation struct {
 
 	ID *string `json:"id,omitempty" tf:"id,omitempty"`
 
-	// (String) RSA key generated if the API credential is created with a certificate.
-	// RSA key generated if the API credential is created with a certificate.
-	Key *string `json:"key,omitempty" tf:"key,omitempty"`
-
 	// The name if left unset defaults to managedsubbaccountapicredential
 	// The name for the API credential.
 	Name *string `json:"name,omitempty" tf:"name,omitempty"`

--- a/config/btp_subaccount_api_credential/config.go
+++ b/config/btp_subaccount_api_credential/config.go
@@ -36,6 +36,8 @@ func Configure(p *config.Provider) {
 		r.TerraformResource.Schema["client_id"].Sensitive = true
 		r.TerraformResource.Schema["token_url"].Sensitive = true
 		r.TerraformResource.Schema["api_url"].Sensitive = true
+		// key must not be stored in cluster-scoped CR status
+		r.TerraformResource.Schema["key"].Sensitive = true
 
 		r.ExternalName.SetIdentifierArgumentFn = func(base map[string]any, name string) {
 			if name == "" {

--- a/package/crds/security.btp.sap.crossplane.io_subaccountapicredentials.yaml
+++ b/package/crds/security.btp.sap.crossplane.io_subaccountapicredentials.yaml
@@ -467,11 +467,6 @@ spec:
                     type: string
                   id:
                     type: string
-                  key:
-                    description: |-
-                      (String) RSA key generated if the API credential is created with a certificate.
-                      RSA key generated if the API credential is created with a certificate.
-                    type: string
                   name:
                     description: |-
                       The name if left unset defaults to managedsubbaccountapicredential


### PR DESCRIPTION
# Description
Backport of #928 to `release/v1_10_x`.