### PR TITLE
chore/ci: hardening of approval flow for p2-e2e-approval environment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Force maintainer review on code directly interaction with the pr-e2e-approval environment
+/.github/workflows/  @SAP/crossplane-provider-btp-admin
+/.github/actions/    @SAP/crossplane-provider-btp-admin
+/build/              @SAP/crossplane-provider-btp-admin
+/Makefile            @SAP/crossplane-provider-btp-admin
+/test/e2e/           @SAP/crossplane-provider-btp-admin

--- a/.github/workflows/add-to-backlog-project.yml
+++ b/.github/workflows/add-to-backlog-project.yml
@@ -8,6 +8,9 @@ on:
 env:
   ACTIONS_STEP_DEBUG: true
 
+permissions:
+  contents: read
+
 jobs:
   call-reusable-workflow:
     uses: openmcp-project/.github/workflows/addRefinedIssuesToBacklog.yml@main

--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -62,6 +62,10 @@ jobs:
     environment: ${{ inputs.environment }}  # approval here for the entire workflow, later jobs use no approval environment
     outputs:
       test-names: ${{ steps.set-matrix.outputs.test-names }}
+      # Resolve the checkout ref to a fixed commit SHA once, inside the gated job. Downstream jobs
+      # consume this output instead of inputs.checkout-ref, so every checkout provably uses the same
+      # commit the maintainer reviewed at approval - no time-of-check/time-of-use gap (CodeQL #67).
+      checkout-sha: ${{ steps.pin-sha.outputs.sha }}
     steps:
       - name: checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -71,6 +75,12 @@ jobs:
           # Opt in to checking out fork PR code under pull_request_target. actions/checkout v7 refuses this by default.
           # Safe here: the pr-e2e-approval environment (required_reviewers) gates this job, so a maintainer inspects the fork diff before it runs with secrets.
           allow-unsafe-pr-checkout: true
+
+      - name: Pin resolved checkout SHA
+        id: pin-sha
+        # git rev-parse HEAD is the exact commit checked out above. Emitting it as an output freezes
+        # a single source of truth for all later checkouts.
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Set matrix with test names
         id: set-matrix
@@ -91,8 +101,9 @@ jobs:
       - name: checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ inputs.checkout-ref }}
-          # See prepare-matrix: opt in to fork PR checkout; approval gate on prepare-matrix is the trust boundary.
+          # Use the SHA pinned by the gated prepare-matrix job, not inputs.checkout-ref, so this
+          # checkout provably matches the reviewed commit. See prepare-matrix.checkout-sha.
+          ref: ${{ needs.prepare-matrix.outputs.checkout-sha }}
           allow-unsafe-pr-checkout: true
 
       - name: Install Helm
@@ -176,9 +187,9 @@ jobs:
       - name: checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ inputs.checkout-ref }}
+          # Use the SHA pinned by the gated prepare-matrix job. See prepare-matrix.checkout-sha.
+          ref: ${{ needs.prepare-matrix.outputs.checkout-sha }}
           submodules: true
-          # See prepare-matrix: opt in to fork PR checkout; approval gate on prepare-matrix is the trust boundary.
           allow-unsafe-pr-checkout: true
 
       - name: Set up Go
@@ -273,11 +284,22 @@ jobs:
       - name: checkout repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          #use inputs.checkout-ref to be able to call it from a pull_request_target workflow, since there it needs to be github.event.pull_request.merge_commit_sha and not the default
-          ref: ${{ inputs.checkout-ref }}
+          # Use the SHA pinned by the gated prepare-matrix job, not inputs.checkout-ref. This job
+          # holds the secrets; pinning to the reviewed commit closes any time-of-check/time-of-use
+          # gap (CodeQL #67). See prepare-matrix.checkout-sha.
+          ref: ${{ needs.prepare-matrix.outputs.checkout-sha }}
           submodules: true
-          # See prepare-matrix: opt in to fork PR checkout; approval gate on prepare-matrix is the trust boundary.
           allow-unsafe-pr-checkout: true
+
+      - name: Assert checked-out commit matches the reviewed SHA
+        # Belt-and-suspenders: fail before any secret is used if the checkout ever differs from the
+        # commit prepare-matrix pinned at approval.
+        run: |
+          expected='${{ needs.prepare-matrix.outputs.checkout-sha }}'
+          actual="$(git rev-parse HEAD)"
+          if [ "$actual" != "$expected" ]; then
+            echo "::error::checked-out $actual != approved $expected"; exit 1
+          fi
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:

--- a/.github/workflows/pr-e2e.yaml
+++ b/.github/workflows/pr-e2e.yaml
@@ -20,6 +20,13 @@ on:
 permissions:
   contents: read
 
+# A new push to the PR head starts a new run needing fresh approval; cancel any
+# prior (possibly already-approved) run for the same PR so stale approved code
+# cannot keep running against secrets.
+concurrency:
+  group: pr-e2e-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   run-e2e-test:
     uses: ./.github/workflows/e2e_test.yaml


### PR DESCRIPTION
Hardens the E2E approval gate that #891 re-enabled after the `actions/checkout` v7 bump (#797) blocked it. This PR is not fixing anything in the E2E flow. The current model is safe. Those changes make it clearer and add guardrails.

Closes CodeQL alert [#37](https://github.com/SAP/crossplane-provider-btp/security/code-scanning/37) by defining required job permission.

## Summary

- **`.github/CODEOWNERS`:** require `@SAP/crossplane-provider-btp-admin` review on files that run under the `pr-e2e-approval` environment's secrets (workflows, `build/`, `Makefile`, `test/e2e/`).
- **`concurrency` group on `pr-e2e.yaml`:** cancel any prior (possibly already-approved) run so stale approved code stops running against secrets.
- **Pin the e2e checkout to one SHA** resolved once in the gated `prepare-matrix` job. `fetch-chart`/`build`/`e2e-test` check out `needs.prepare-matrix.outputs.checkout-sha` instead of the raw `checkout-ref`; `e2e-test` asserts `HEAD` matches before using secrets. The checkout was already immutable (`head.sha` is a fixed per-run snapshot); this just makes that machine-checkable.
- **`permissions: contents: read` on `add-to-backlog-project.yml`:** closes CodeQL #37 (`actions/missing-workflow-permissions`). The workflow only calls a reusable workflow that moves issues between Projects. That reusable workflow authenticates its Project/Issue mutations with the passed-in `github-token` secret (`secrets: inherit`), not the caller's `GITHUB_TOKEN`, so the caller token needs only `contents: read` for its `actions/checkout` step. An empty `{}` would break checkout.

## Our trust model / boundary

- E2E runs under `pull_request_target` with `secrets: inherit`, so it needs a trust boundary.
- The `pr-e2e-approval` required-reviewers environment is that boundary - it gates every PR, any author. No secrets run before approval: only `e2e-test` holds them, after the gate.
- `GITHUB_TOKEN` is read-only.

## Background - CodeQL alerts

Seven alerts, all on GitHub Actions workflows.

**Fixed here:**
- [#37](https://github.com/SAP/crossplane-provider-btp/security/code-scanning/37) (`actions/missing-workflow-permissions`, medium) on `add-to-backlog-project.yml`.

**False positives on `e2e_test.yaml`, dismissed as accepted risk:**
- [#67](https://github.com/SAP/crossplane-provider-btp/security/code-scanning/67) (`actions/untrusted-checkout-toctou`, critical)
- [#68](https://github.com/SAP/crossplane-provider-btp/security/code-scanning/68), [#69](https://github.com/SAP/crossplane-provider-btp/security/code-scanning/69) (`actions/cache-poisoning/direct-cache`, high)
- [#70](https://github.com/SAP/crossplane-provider-btp/security/code-scanning/70), [#71](https://github.com/SAP/crossplane-provider-btp/security/code-scanning/71), [#72](https://github.com/SAP/crossplane-provider-btp/security/code-scanning/72) (`actions/cache-poisoning/poisonable-step`, high)

All six fire because CodeQL sees `pull_request_target` running PR code with `secrets: inherit`. It can't see the `pr-e2e-approval` required-reviewers gate, which is our trust boundary - no secrets run before a maintainer approves. That makes the checkout-TOCTOU and cache-poisoning paths unreachable for unapproved code, so the alerts are false positives, dismissed.

This PR doesn't change that trust model. It makes the gate's guarantees **readable** - to reviewers and to tooling - so the accepted-risk stance is auditable rather than implicit: CODEOWNERS names who approves, `concurrency` kills stale approved runs, and the pinned-SHA checkout with a `HEAD` assertion makes the immutability obvious for CodeQL and readers.