### PR TITLE
fix(servicemanager): keep the service plan across the v1-to-v2 upgrade

### DIFF
--- a/internal/clients/servicemanager/service_manager_tf_client.go
+++ b/internal/clients/servicemanager/service_manager_tf_client.go
@@ -300,11 +300,7 @@ func (tf *TfClient) resourcesUpToDate(ctx context.Context) bool {
 	// desired == observed and this is a no-op.
 	desiredPlan := internal.Val(tf.sInstance.Spec.ForProvider.ServiceplanID)
 	observedPlan := internal.Val(tf.sInstance.Status.AtProvider.ServiceplanID)
-	if desiredPlan != observedPlan {
-		return true
-	}
-
-	return false
+	return desiredPlan != observedPlan
 }
 
 func (tf *TfClient) createInstance(ctx context.Context) (string, error) {

--- a/internal/clients/servicemanager/service_manager_tf_client.go
+++ b/internal/clients/servicemanager/service_manager_tf_client.go
@@ -24,6 +24,9 @@ type ResourcesStatus struct {
 	managed.ExternalObservation
 	InstanceID string
 	BindingID  string
+	// ObservedPlanID is the live instance's serviceplan_id, used to self-heal a
+	// stale plan ID in status. Workaround for #941; empty when not observed.
+	ObservedPlanID string
 }
 
 // ITfClientInitializer will produce the ITfClient used by external
@@ -272,15 +275,36 @@ func (tf *TfClient) ObserveResources(ctx context.Context, cr *apisv1beta1.Servic
 			ResourceUpToDate:  resourceUpToDate,
 			ConnectionDetails: conDetails,
 		},
-		InstanceID: meta.GetExternalName(tf.sInstance),
-		BindingID:  meta.GetExternalName(tf.sBinding),
+		InstanceID:     meta.GetExternalName(tf.sInstance),
+		BindingID:      meta.GetExternalName(tf.sBinding),
+		ObservedPlanID: internal.Val(tf.sInstance.Status.AtProvider.ServiceplanID),
 	}, nil
 }
 
-// ResourcesUpToDate runs another observe on instance and returns whether they are up to date, currently updates on bindings are not supported
+// resourcesUpToDate runs another observe on the instance and returns whether it
+// is up to date. Binding updates are not supported.
 func (tf *TfClient) resourcesUpToDate(ctx context.Context) bool {
 	siObs, err := tf.siExternal.Observe(ctx, tf.sInstance)
-	return err != nil || siObs.ResourceUpToDate
+	if err != nil {
+		return true
+	}
+	if siObs.ResourceUpToDate {
+		return true
+	}
+
+	// Workaround for #941: the service plan is immutable in BTP, so an in-place
+	// update on a plan-only diff calls update_instance, which BTP rejects. That
+	// diff only arises for an upgraded v1alpha1 SM whose status lost
+	// dataSourceLookup and re-resolved the flipped default plan (#925). Report
+	// up-to-date so no Update fires. For v1beta1 the plan is pinned by the CRD, so
+	// desired == observed and this is a no-op.
+	desiredPlan := internal.Val(tf.sInstance.Spec.ForProvider.ServiceplanID)
+	observedPlan := internal.Val(tf.sInstance.Status.AtProvider.ServiceplanID)
+	if desiredPlan != observedPlan {
+		return true
+	}
+
+	return false
 }
 
 func (tf *TfClient) createInstance(ctx context.Context) (string, error) {

--- a/internal/clients/servicemanager/service_manager_tf_client_test.go
+++ b/internal/clients/servicemanager/service_manager_tf_client_test.go
@@ -324,6 +324,99 @@ func TestObserveResources(t *testing.T) {
 			},
 		},
 		{
+			// FIX (3) GUARD: the second instance Observe reports NotUpToDate, but the
+			// only difference is the immutable serviceplan_id (desired != observed live
+			// plan). This is the upgraded-v1alpha1 wedge: the resolver re-ran and put
+			// the flipped default plan into desired forProvider. We must report
+			// ResourceUpToDate:true so no in-place update fires (BTP rejects a plan
+			// change with "update_instance is not supported"). ObservedPlanID carries
+			// the live plan back so the controller can self-heal status.
+			name: "InstancePlanDiffTreatedUpToDate",
+			args: args{
+				cr: testSMCr("subaccountId", "wrongPlan", "someID/anotherID", "", "", ""),
+				siExternal: ExternalClientFake{
+					observeFn: func() (managed.ExternalObservation, error) {
+						return managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: false}, nil
+					},
+				},
+				sbExternal: ExternalClientFake{
+					observeFn: func() (managed.ExternalObservation, error) {
+						return managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: true,
+							ConnectionDetails: map[string][]byte{"attribute.credentials": []byte(`{"clientid":"someClientID","clientsecret":"someSecret","sm_url":"https://service-manager.cfapps.eu12.hana.ondemand.com","url":"https://subdomain.authentication.eu12.hana.ondemand.com","xsappname":"someAppName"}`)}}, nil
+					},
+				},
+				// desired plan (wrongPlan, from re-resolution) != live plan (livePlan).
+				sInstance: instanceWithPlan("someID", "wrongPlan", "livePlan"),
+				sBinding:  testServiceBinding("anotherID"),
+			},
+			want: want{
+				obs: ResourcesStatus{
+					ExternalObservation: managed.ExternalObservation{
+						ResourceExists:   true,
+						ResourceUpToDate: true,
+						ConnectionDetails: map[string][]byte{
+							v1beta1.ResourceCredentialsClientSecret:      []byte("someSecret"),
+							v1beta1.ResourceCredentialsClientId:          []byte("someClientID"),
+							v1beta1.ResourceCredentialsServiceManagerUrl: []byte("https://service-manager.cfapps.eu12.hana.ondemand.com"),
+							v1beta1.ResourceCredentialsXsuaaUrl:          []byte("https://subdomain.authentication.eu12.hana.ondemand.com"),
+							v1beta1.ResourceCredentialsXsappname:         []byte("someAppName"),
+							v1beta1.ResourceCredentialsXsuaaUrlSufix:     []byte("/oauth/token"),
+							providerv1alpha1.RawBindingKey:               []byte(`{"clientid":"someClientID","clientsecret":"someSecret","sm_url":"https://service-manager.cfapps.eu12.hana.ondemand.com","url":"https://subdomain.authentication.eu12.hana.ondemand.com","xsappname":"someAppName"}`),
+						},
+					},
+					InstanceID:     "someID",
+					BindingID:      "anotherID",
+					ObservedPlanID: "livePlan",
+				},
+				err: nil,
+			},
+		},
+		{
+			// V1BETA1 CONTROL: desired plan == live plan (the CRD pins planName), and
+			// the second Observe reports NotUpToDate for a real (non-plan) reason. The
+			// guard must NOT fire here: ResourceUpToDate stays false so a legitimate
+			// update still runs. Proves fix (3) is a no-op when plans agree.
+			name: "InstanceNonPlanDiffStillNeedsUpdate",
+			args: args{
+				cr: testSMCr("subaccountId", "samePlan", "someID/anotherID", "", "", ""),
+				siExternal: ExternalClientFake{
+					observeFn: func() (managed.ExternalObservation, error) {
+						return managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: false}, nil
+					},
+				},
+				sbExternal: ExternalClientFake{
+					observeFn: func() (managed.ExternalObservation, error) {
+						return managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: true,
+							ConnectionDetails: map[string][]byte{"attribute.credentials": []byte(`{"clientid":"someClientID","clientsecret":"someSecret","sm_url":"https://service-manager.cfapps.eu12.hana.ondemand.com","url":"https://subdomain.authentication.eu12.hana.ondemand.com","xsappname":"someAppName"}`)}}, nil
+					},
+				},
+				// desired plan == live plan: guard is a no-op, update proceeds.
+				sInstance: instanceWithPlan("someID", "samePlan", "samePlan"),
+				sBinding:  testServiceBinding("anotherID"),
+			},
+			want: want{
+				obs: ResourcesStatus{
+					ExternalObservation: managed.ExternalObservation{
+						ResourceExists:   true,
+						ResourceUpToDate: false,
+						ConnectionDetails: map[string][]byte{
+							v1beta1.ResourceCredentialsClientSecret:      []byte("someSecret"),
+							v1beta1.ResourceCredentialsClientId:          []byte("someClientID"),
+							v1beta1.ResourceCredentialsServiceManagerUrl: []byte("https://service-manager.cfapps.eu12.hana.ondemand.com"),
+							v1beta1.ResourceCredentialsXsuaaUrl:          []byte("https://subdomain.authentication.eu12.hana.ondemand.com"),
+							v1beta1.ResourceCredentialsXsappname:         []byte("someAppName"),
+							v1beta1.ResourceCredentialsXsuaaUrlSufix:     []byte("/oauth/token"),
+							providerv1alpha1.RawBindingKey:               []byte(`{"clientid":"someClientID","clientsecret":"someSecret","sm_url":"https://service-manager.cfapps.eu12.hana.ondemand.com","url":"https://subdomain.authentication.eu12.hana.ondemand.com","xsappname":"someAppName"}`),
+						},
+					},
+					InstanceID:     "someID",
+					BindingID:      "anotherID",
+					ObservedPlanID: "samePlan",
+				},
+				err: nil,
+			},
+		},
+		{
 			// in case of missing binding and changed instance we expect to first create the binding and later update the instance in a second reconcilation loop
 			name: "CreationPrecedesUpdate",
 			args: args{
@@ -814,6 +907,16 @@ func testServiceInstance(extName string) *v1alpha1.SubaccountServiceInstance {
 		Status: v1alpha1.SubaccountServiceInstanceStatus{},
 	}
 	meta.SetExternalName(instance, extName)
+	return instance
+}
+
+// instanceWithPlan builds a SubaccountServiceInstance whose desired
+// (spec.forProvider) and observed (status.atProvider) serviceplan_id can differ,
+// to drive the immutable-plan guard in resourcesUpToDate.
+func instanceWithPlan(extName, desiredPlan, observedPlan string) *v1alpha1.SubaccountServiceInstance {
+	instance := testServiceInstance(extName)
+	instance.Spec.ForProvider.ServiceplanID = internal.Ptr(desiredPlan)
+	instance.Status.AtProvider.ServiceplanID = internal.Ptr(observedPlan)
 	return instance
 }
 

--- a/internal/clients/servicemanager/service_manager_tf_client_test.go
+++ b/internal/clients/servicemanager/service_manager_tf_client_test.go
@@ -324,13 +324,11 @@ func TestObserveResources(t *testing.T) {
 			},
 		},
 		{
-			// FIX (3) GUARD: the second instance Observe reports NotUpToDate, but the
-			// only difference is the immutable serviceplan_id (desired != observed live
-			// plan). This is the upgraded-v1alpha1 wedge: the resolver re-ran and put
-			// the flipped default plan into desired forProvider. We must report
-			// ResourceUpToDate:true so no in-place update fires (BTP rejects a plan
-			// change with "update_instance is not supported"). ObservedPlanID carries
-			// the live plan back so the controller can self-heal status.
+			// The second instance Observe reports NotUpToDate, but the only difference
+			// is the immutable serviceplan_id (desired != observed live plan). We must
+			// report ResourceUpToDate:true so no in-place update fires - BTP rejects a
+			// plan change with "update_instance is not supported". ObservedPlanID
+			// carries the live plan back so the controller can heal status (#941).
 			name: "InstancePlanDiffTreatedUpToDate",
 			args: args{
 				cr: testSMCr("subaccountId", "wrongPlan", "someID/anotherID", "", "", ""),
@@ -372,10 +370,9 @@ func TestObserveResources(t *testing.T) {
 			},
 		},
 		{
-			// V1BETA1 CONTROL: desired plan == live plan (the CRD pins planName), and
-			// the second Observe reports NotUpToDate for a real (non-plan) reason. The
-			// guard must NOT fire here: ResourceUpToDate stays false so a legitimate
-			// update still runs. Proves fix (3) is a no-op when plans agree.
+			// desired plan == live plan (the CRD pins planName), and the second Observe
+			// reports NotUpToDate for a real, non-plan reason. The plan check must not
+			// short-circuit here: ResourceUpToDate stays false so the update still runs.
 			name: "InstanceNonPlanDiffStillNeedsUpdate",
 			args: args{
 				cr: testSMCr("subaccountId", "samePlan", "someID/anotherID", "", "", ""),

--- a/internal/controller/account/servicemanager/servicemanager.go
+++ b/internal/controller/account/servicemanager/servicemanager.go
@@ -368,6 +368,14 @@ func (c *external) setStatus(ctx context.Context, status sm.ResourcesStatus, cr 
 	}
 	cr.Status.AtProvider.ServiceInstanceID = status.InstanceID
 	cr.Status.AtProvider.ServiceBindingID = status.BindingID
+
+	// Workaround for #941: self-heal a stale plan ID in status. An upgraded
+	// v1alpha1 SM lost dataSourceLookup and re-resolved the flipped default plan
+	// (#925) into status. Overwrite it with the observed live plan. For v1beta1
+	// these already match, so this is a no-op.
+	if cr.Status.AtProvider.DataSourceLookup != nil && status.ObservedPlanID != "" {
+		cr.Status.AtProvider.DataSourceLookup.ServiceManagerPlanID = status.ObservedPlanID
+	}
 	// Unfortunately we need to update the CR status manually here, because the reconciler will drop the change otherwise
 	// (I guess because we are attempting to save something while ResourceExists remains false for another cycle)
 	if err := c.kube.Status().Update(ctx, cr); err != nil {

--- a/internal/controller/account/servicemanager/servicemanager_test.go
+++ b/internal/controller/account/servicemanager/servicemanager_test.go
@@ -379,11 +379,10 @@ func TestObserve(t *testing.T) {
 			},
 		},
 		{
-			// OPTION A (status self-heal): an upgraded v1alpha1 SM re-resolved the
-			// flipped default plan into dataSourceLookup (stalePlan). ObserveResources
-			// returns the live instance's plan as ObservedPlanID (livePlan). setStatus
-			// must overwrite the stale persisted plan ID with the live one so status
-			// displays the instance's real plan.
+			// status holds a stale plan ID in dataSourceLookup (stalePlan) that no
+			// longer matches the live instance. ObserveResources returns the live
+			// instance's plan as ObservedPlanID (livePlan); setStatus must overwrite
+			// the stale ID with the live one so status shows the instance's real plan.
 			name: "SelfHealsStalePlanID",
 			args: args{
 				cr: NewServiceManager("test",

--- a/internal/controller/account/servicemanager/servicemanager_test.go
+++ b/internal/controller/account/servicemanager/servicemanager_test.go
@@ -379,9 +379,45 @@ func TestObserve(t *testing.T) {
 			},
 		},
 		{
-			// Regression: while the CR is being deleted and the underlying
-			// instance still exists (binding may or may not — the tf-client
-			// keys ResourceExists off the instance during delete), setStatus
+			// OPTION A (status self-heal): an upgraded v1alpha1 SM re-resolved the
+			// flipped default plan into dataSourceLookup (stalePlan). ObserveResources
+			// returns the live instance's plan as ObservedPlanID (livePlan). setStatus
+			// must overwrite the stale persisted plan ID with the live one so status
+			// displays the instance's real plan.
+			name: "SelfHealsStalePlanID",
+			args: args{
+				cr: NewServiceManager("test",
+					WithStatus(apisv1beta1.ServiceManagerObservation{
+						DataSourceLookup: &apisv1beta1.DataSourceLookup{ServiceManagerPlanID: "stalePlan"},
+					})),
+				tfClient: &TfClientFake{
+					observeFn: func() (sm.ResourcesStatus, error) {
+						return sm.ResourcesStatus{
+							ExternalObservation: managed.ExternalObservation{
+								ResourceExists:   true,
+								ResourceUpToDate: true,
+							},
+							InstanceID:     "someID",
+							BindingID:      "anotherID",
+							ObservedPlanID: "livePlan",
+						}, nil
+					},
+				},
+			},
+			want: want{
+				obs: managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: true},
+				err: nil,
+				cr: NewServiceManager("test",
+					WithStatus(apisv1beta1.ServiceManagerObservation{
+						Status:            apisv1beta1.ServiceManagerBound,
+						ServiceInstanceID: "someID",
+						ServiceBindingID:  "anotherID",
+						DataSourceLookup:  &apisv1beta1.DataSourceLookup{ServiceManagerPlanID: "livePlan"},
+					}),
+					WithConditions(xpv1.Available())),
+			},
+		},
+		{
 			// must report Deleting()/Unbound, not Available()/Bound. Under the
 			// pre-fix code the delete-aware ObserveResources returned
 			// ResourceExists:true which then flipped the CR back to Available

--- a/test/upgrade/servicemanager_planname_upgrade_test.go
+++ b/test/upgrade/servicemanager_planname_upgrade_test.go
@@ -1,0 +1,208 @@
+//go:build upgrade
+
+package upgrade
+
+import (
+	"context"
+	"testing"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
+	accountv1alpha1 "github.com/sap/crossplane-provider-btp/apis/account/v1alpha1"
+	accountv1beta1 "github.com/sap/crossplane-provider-btp/apis/account/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/e2e-framework/klient/k8s"
+	"sigs.k8s.io/e2e-framework/klient/wait"
+	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+)
+
+var (
+	smPlanNameFromTag = "v1.13.0"
+	smPlanNameToTag   = "local"
+	// Two cohorts (v1alpha1 + v1beta1 ServiceManager, each with its own subaccount)
+	// in one dir so both migrate through the same upgrade in a single cluster.
+	smPlanNameResourceDirectories = []string{
+		upgradeCRsPath("customCRs/serviceManagerPlanName"),
+	}
+)
+
+// Test_ServiceManager_PlanName_Upgrade checks that a ServiceManager keeps its
+// service plan across the v1.13.0 -> v2 upgrade, for both API versions. The v2
+// default planName changed from service-operator-access to subaccount-admin
+// (#925), and the two versions resolve planName differently:
+//
+//   - v1alpha1 has no planName field, so the plan resolves to the runtime
+//     DefaultPlanName. An instance created on the old default must not be updated
+//     to the new one on upgrade: the service plan is immutable in BTP, so an
+//     in-place update calls update_instance and BTP rejects it with
+//     "update_instance is not supported", leaving the SM Synced=False. The provider
+//     reports up-to-date on a plan-only diff and heals status.dataSourceLookup back
+//     to the live plan (#941). This cohort must stay Synced+Ready.
+//
+//   - v1beta1 pins planName immutable at admission, so it persists and is never
+//     re-resolved. This cohort must stay Synced+Ready and keep its plan. Its
+//     planName is service-operator-access (v1.13.0's default, not the v2 default),
+//     so a regression that re-resolved planName would flip it and fail here.
+func Test_ServiceManager_PlanName_Upgrade(t *testing.T) {
+	const serviceManagerName = "upgrade-test-planflip-sm"
+	const serviceManagerV1beta1Name = "upgrade-test-planflip-sm-v1beta1"
+
+	upgradeTest := NewCustomUpgradeTest("service-manager-planname-test").
+		FromVersion(smPlanNameFromTag).
+		ToVersion(smPlanNameToTag).
+		WithResourceDirectories(smPlanNameResourceDirectories).
+		WithCustomPreUpgradeAssessment(
+			"verify both ServiceManagers healthy before upgrade",
+			func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+				sm := &accountv1alpha1.ServiceManager{}
+				r := cfg.Client().Resources()
+
+				if err := r.Get(ctx, serviceManagerName, cfg.Namespace(), sm); err != nil {
+					t.Fatalf("Failed to get v1alpha1 ServiceManager before upgrade: %v", err)
+				}
+
+				// The default resource verification already waited for Ready+Synced;
+				// recheck here to confirm the pre-upgrade state is the one we migrate
+				// (healthy on the old default plan).
+				assertServiceManagerV1alpha1Healthy(t, sm, "before")
+
+				// The v1beta1 SM must also be healthy going in.
+				smb := &accountv1beta1.ServiceManager{}
+				if err := r.Get(ctx, serviceManagerV1beta1Name, cfg.Namespace(), smb); err != nil {
+					t.Fatalf("Failed to get v1beta1 ServiceManager before upgrade: %v", err)
+				}
+				assertServiceManagerV1beta1Healthy(t, smb, "before")
+
+				klog.V(4).Infof("Pre-upgrade ServiceManagers %q and %q are Synced and Ready", serviceManagerName, serviceManagerV1beta1Name)
+				return ctx
+			},
+		).
+		WithCustomPostUpgradeAssessment(
+			"verify both ServiceManagers stay healthy and keep their plan after upgrade",
+			func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+				r := cfg.Client().Resources()
+
+				// The v1alpha1 SM must stay Synced+Ready. A plan re-resolution shows up
+				// as Synced=False with the reconcile error "update_instance is not
+				// supported". Gate on Synced AND Ready; the pre-upgrade Ready could
+				// otherwise mask a post-upgrade Synced=False.
+				sm := &accountv1alpha1.ServiceManager{}
+				if err := r.Get(ctx, serviceManagerName, cfg.Namespace(), sm); err != nil {
+					t.Fatalf("Failed to get v1alpha1 ServiceManager after upgrade: %v", err)
+				}
+				waitSyncedAndReady(ctx, t, cfg, sm, serviceManagerName, "v1alpha1")
+
+				// status.dataSourceLookup must hold the live instance plan. Read as
+				// v1beta1 (storage version) to see the full observation.
+				assertPlanMatchesLiveInstance(ctx, t, cfg, serviceManagerName)
+
+				// The v1beta1 SM must stay Synced+Ready and keep its explicit plan.
+				smb := &accountv1beta1.ServiceManager{}
+				if err := r.Get(ctx, serviceManagerV1beta1Name, cfg.Namespace(), smb); err != nil {
+					t.Fatalf("Failed to get v1beta1 ServiceManager after upgrade: %v", err)
+				}
+				waitSyncedAndReady(ctx, t, cfg, smb, serviceManagerV1beta1Name, "v1beta1")
+				assertPlanMatchesLiveInstance(ctx, t, cfg, serviceManagerV1beta1Name)
+
+				klog.V(4).Infof("Post-upgrade: v1alpha1 %q and v1beta1 %q stayed Synced and Ready", serviceManagerName, serviceManagerV1beta1Name)
+				return ctx
+			},
+		)
+
+	testenv.Test(t, upgradeTest.Feature())
+}
+
+// waitSyncedAndReady blocks until the object reports Synced=True AND Ready=True,
+// failing with the actual Synced condition (naming the cause, not just a timeout)
+// if the deadline passes. obj must expose GetCondition (both SM API versions do).
+func waitSyncedAndReady(ctx context.Context, t *testing.T, cfg *envconf.Config, obj k8s.Object, name, label string) {
+	t.Helper()
+	r := cfg.Client().Resources()
+	conditioned := func(o k8s.Object) conditionReader { return o.(conditionReader) }
+	if err := wait.For(
+		conditions.New(r).ResourceMatch(obj, func(o k8s.Object) bool {
+			synced := conditioned(o).GetCondition(xpv1.TypeSynced)
+			ready := conditioned(o).GetCondition(xpv1.TypeReady)
+			return synced.Status == corev1.ConditionTrue && ready.Status == corev1.ConditionTrue
+		}),
+		wait.WithTimeout(globalVerifyTimeout),
+	); err != nil {
+		_ = r.Get(ctx, name, cfg.Namespace(), obj)
+		synced := conditioned(obj).GetCondition(xpv1.TypeSynced)
+		t.Fatalf(
+			"%s ServiceManager %q did not stay Synced+Ready after upgrade: %v; Synced=%s reason=%s message=%q",
+			label, name, err, synced.Status, synced.Reason, synced.Message,
+		)
+	}
+}
+
+// conditionReader is the subset of both ServiceManager API versions that exposes
+// crossplane conditions, so waitSyncedAndReady works for either.
+type conditionReader interface {
+	GetCondition(xpv1.ConditionType) xpv1.Condition
+}
+
+// assertPlanMatchesLiveInstance reads the SM as v1beta1 (storage version) and
+// checks status.dataSourceLookup carries a plan ID and the SM is Bound. The live
+// instance ID is not queryable from the CR, so this only confirms the plan ID is
+// non-empty and the SM stayed bound to its instance.
+func assertPlanMatchesLiveInstance(ctx context.Context, t *testing.T, cfg *envconf.Config, name string) {
+	t.Helper()
+	sm := &accountv1beta1.ServiceManager{}
+	if err := cfg.Client().Resources().Get(ctx, name, cfg.Namespace(), sm); err != nil {
+		t.Fatalf("Failed to read v1beta1 ServiceManager %q for plan assertion: %v", name, err)
+	}
+	if sm.Status.AtProvider.DataSourceLookup == nil || sm.Status.AtProvider.DataSourceLookup.ServiceManagerPlanID == "" {
+		t.Errorf("ServiceManager %q: expected a persisted dataSourceLookup.serviceManagerPlanID after upgrade, got none", name)
+	}
+	if sm.Status.AtProvider.Status != accountv1beta1.ServiceManagerBound {
+		t.Errorf("ServiceManager %q: status.atProvider.status = %q, want %q (should stay bound to its live instance)",
+			name, sm.Status.AtProvider.Status, accountv1beta1.ServiceManagerBound)
+	}
+}
+
+// assertServiceManagerV1alpha1Healthy checks a v1alpha1 ServiceManager is both
+// Synced and Ready. Errorf (not Fatalf) on each condition so a run where both
+// drifted reports both.
+func assertServiceManagerV1alpha1Healthy(t *testing.T, sm *accountv1alpha1.ServiceManager, phase string) {
+	t.Helper()
+
+	synced := sm.GetCondition(xpv1.TypeSynced)
+	ready := sm.GetCondition(xpv1.TypeReady)
+	if synced.Status != corev1.ConditionTrue {
+		t.Errorf("ServiceManager Synced %s upgrade = %s (reason %s, message %q), want True",
+			phase, synced.Status, synced.Reason, synced.Message)
+	}
+	if ready.Status != corev1.ConditionTrue {
+		t.Errorf("ServiceManager Ready %s upgrade = %s (reason %s), want True",
+			phase, ready.Status, ready.Reason)
+	}
+	// A bound ServiceManager mirrors both instance and binding IDs in status; if it
+	// is bound, the pre-upgrade state is the one we mean to migrate.
+	if sm.Status.AtProvider.Status != "" && sm.Status.AtProvider.Status != accountv1alpha1.ServiceManagerBound {
+		t.Errorf("ServiceManager status.atProvider.status %s upgrade = %q, want %q or empty",
+			phase, sm.Status.AtProvider.Status, accountv1alpha1.ServiceManagerBound)
+	}
+}
+
+// assertServiceManagerV1beta1Healthy is the v1beta1 counterpart, used for the
+// control cohort. Errorf (not Fatalf) per condition so a drift reports fully.
+func assertServiceManagerV1beta1Healthy(t *testing.T, sm *accountv1beta1.ServiceManager, phase string) {
+	t.Helper()
+
+	synced := sm.GetCondition(xpv1.TypeSynced)
+	ready := sm.GetCondition(xpv1.TypeReady)
+	if synced.Status != corev1.ConditionTrue {
+		t.Errorf("v1beta1 ServiceManager Synced %s upgrade = %s (reason %s, message %q), want True",
+			phase, synced.Status, synced.Reason, synced.Message)
+	}
+	if ready.Status != corev1.ConditionTrue {
+		t.Errorf("v1beta1 ServiceManager Ready %s upgrade = %s (reason %s), want True",
+			phase, ready.Status, ready.Reason)
+	}
+	if sm.Status.AtProvider.Status != "" && sm.Status.AtProvider.Status != accountv1beta1.ServiceManagerBound {
+		t.Errorf("v1beta1 ServiceManager status.atProvider.status %s upgrade = %q, want %q or empty",
+			phase, sm.Status.AtProvider.Status, accountv1beta1.ServiceManagerBound)
+	}
+}

--- a/test/upgrade/testdata/customCRs/serviceManagerPlanName/servicemanager_v1alpha1.yaml
+++ b/test/upgrade/testdata/customCRs/serviceManagerPlanName/servicemanager_v1alpha1.yaml
@@ -1,0 +1,18 @@
+# v1alpha1 ServiceManager with no planName. v1alpha1 has no planName field, so
+# the plan resolves from the runtime DefaultPlanName: service-operator-access
+# under v1.13.0, subaccount-admin under v2 (#925). The instance is created on the
+# old plan and must keep it across the upgrade - the service plan is immutable in
+# BTP, so an in-place plan update calls update_instance and BTP rejects it with
+# "update_instance is not supported" (#941).
+apiVersion: account.btp.sap.crossplane.io/v1alpha1
+kind: ServiceManager
+metadata:
+  name: upgrade-test-planflip-sm
+  namespace: default
+spec:
+  writeConnectionSecretToRef:
+    name: upgrade-test-planflip-sm
+    namespace: default
+  forProvider:
+    subaccountRef:
+      name: upgrade-test-planflip-sm-sa

--- a/test/upgrade/testdata/customCRs/serviceManagerPlanName/servicemanager_v1beta1.yaml
+++ b/test/upgrade/testdata/customCRs/serviceManagerPlanName/servicemanager_v1beta1.yaml
@@ -1,0 +1,21 @@
+# v1beta1 ServiceManager with an explicit planName. The v1beta1 CRD pins planName
+# immutable (self == oldSelf), so it persists across the upgrade and is never
+# re-resolved. This SM must stay Synced+Ready and keep its plan through the
+# v1.13.0 -> v2 upgrade.
+#
+# planName is service-operator-access (v1.13.0's default), not the v2 default
+# (subaccount-admin, #925), so a regression that re-resolved planName on v1beta1
+# would flip its plan to subaccount-admin and fail this check.
+apiVersion: account.btp.sap.crossplane.io/v1beta1
+kind: ServiceManager
+metadata:
+  name: upgrade-test-planflip-sm-v1beta1
+  namespace: default
+spec:
+  writeConnectionSecretToRef:
+    name: upgrade-test-planflip-sm-v1beta1
+    namespace: default
+  forProvider:
+    planName: service-operator-access
+    subaccountRef:
+      name: upgrade-test-planflip-sm-v1beta1-sa

--- a/test/upgrade/testdata/customCRs/serviceManagerPlanName/subaccount_v1alpha1.yaml
+++ b/test/upgrade/testdata/customCRs/serviceManagerPlanName/subaccount_v1alpha1.yaml
@@ -1,0 +1,15 @@
+apiVersion: account.btp.sap.crossplane.io/v1alpha1
+kind: Subaccount
+metadata:
+  namespace: default
+  name: upgrade-test-planflip-sm-sa
+spec:
+  forProvider:
+    displayName: $BUILD_ID-upgrade-test-planflip-sm-sa
+    region: eu10
+    subdomain: $BUILD_ID-upgrade-test-planflip-sm-sa
+    labels:
+      safe-to-delete: [ "yes" ]
+      BUILD_ID: [ "$BUILD_ID" ]
+    subaccountAdmins:
+      - $TECHNICAL_USER_EMAIL

--- a/test/upgrade/testdata/customCRs/serviceManagerPlanName/subaccount_v1beta1.yaml
+++ b/test/upgrade/testdata/customCRs/serviceManagerPlanName/subaccount_v1beta1.yaml
@@ -1,0 +1,15 @@
+apiVersion: account.btp.sap.crossplane.io/v1alpha1
+kind: Subaccount
+metadata:
+  namespace: default
+  name: upgrade-test-planflip-sm-v1beta1-sa
+spec:
+  forProvider:
+    displayName: $BUILD_ID-upgrade-test-planflip-sm-v1beta1-sa
+    region: eu10
+    subdomain: $BUILD_ID-upgrade-test-planflip-sm-v1beta1-sa
+    labels:
+      safe-to-delete: [ "yes" ]
+      BUILD_ID: [ "$BUILD_ID" ]
+    subaccountAdmins:
+      - $TECHNICAL_USER_EMAIL


### PR DESCRIPTION
Closes #941.

## Summary

Workaround for an unreleased regression: a v1alpha1 `ServiceManager` without a `planName` becomes permanently `Synced=False` after the v1-to-v2 upgrade, with `update_instance is not supported`. #925 changed the default plan, and a v1alpha1 SM re-resolves that new default against an instance created on the old one; the service plan is immutable in BTP, so the resulting in-place update is rejected.

The changes of this PR keep such a ServiceManager healthy across the upgrade. Nothing changes for users: no API/CRD/conversion change, and for a v1beta1 SM (plan pinned by the CRD) both code paths are a no-op.

## Implementation details

The guard in `resourcesUpToDate` reports up-to-date when the only diff between desired and observed is `serviceplan_id`, so no `update_instance` call is made. It can only fire when desired != observed, which in production only an upgraded v1alpha1 SM produces - v1beta1 pins `planName` immutable at admission, so desired == observed and the branch is never taken.

The self-heal in `setStatus` overwrites `status.dataSourceLookup.serviceManagerPlanID` with the observed plan. A v1alpha1 SM has no `dataSourceLookup` in its status (conversion is `strategy: None`), so after upgrade the resolver re-runs and writes the flipped default plan there; this corrects the display value back to the instance's observed plan within one reconcile.

`ObservedPlanID` on `sm.ResourcesStatus` carries the observed plan from the client to the controller. It is read from `tf.sInstance.Status.AtProvider.ServiceplanID` via `internal.Val`, an observation field rather than an external-name annotation.

## Test plan

- [x] `Test_ServiceManager_PlanName_Upgrade` (new upgrade test) - `v1.13.0` -> `local`, both API versions in one cluster: v1alpha1 (no `planName`) and v1beta1 (explicit `service-operator-access`). Local run succeeded.
- [x] `go test ./internal/clients/servicemanager/... ./internal/controller/account/servicemanager/...` - unit coverage for the plan-diff guard (fires / no-op) and the status self-heal.
- [x] `go vet -tags=upgrade ./test/upgrade/`