### PR TITLE
chore(servicebinding): align controller setup with other ersources by using `DefaultSetupWithoutDefaultInitializer`

### DIFF
--- a/internal/controller/account/servicebinding/zz_setup.go
+++ b/internal/controller/account/servicebinding/zz_setup.go
@@ -21,7 +21,7 @@ import (
 func Setup(mgr ctrl.Manager, o internalopts.CrossplaneOptions) error {
 	name := managed.ControllerName(v1alpha1.ServiceBindingGroupKind)
 	recorder := event.NewAPIRecorder(mgr.GetEventRecorderFor(name)) //nolint:staticcheck // NewAPIRecorder requires the legacy event recorder type.
-	return providerconfig.DefaultSetup(mgr, o, &v1alpha1.ServiceBinding{}, v1alpha1.ServiceBindingGroupKind, v1alpha1.ServiceBindingGroupVersionKind, func(kube client.Client, usage providerconfig.LegacyTracker, resourcetracker tracking.ReferenceResolverTracker) managed.ExternalConnector {
+	return providerconfig.DefaultSetupWithoutDefaultInitializer(mgr, o, &v1alpha1.ServiceBinding{}, v1alpha1.ServiceBindingGroupKind, v1alpha1.ServiceBindingGroupVersionKind, func(kube client.Client, usage providerconfig.LegacyTracker, resourcetracker tracking.ReferenceResolverTracker) managed.ExternalConnector {
 		tfConnector := newTfConnectorFn(kube)
 		return &connector{
 			kube:              kube,


### PR DESCRIPTION
Closes #944.

## Summary
Swap `providerconfig.DefaultSetup` for `DefaultSetupWithoutDefaultInitializer` in `internal/controller/account/servicebinding/zz_setup.go`. ServiceBinding was the only account resource still on the deprecated setup.