### PR TITLE
docs(providerconfig): note globalAccount and cisCredentials should be the same global account

### DIFF
--- a/apis/v1alpha1/providerconfig_types.go
+++ b/apis/v1alpha1/providerconfig_types.go
@@ -15,7 +15,7 @@ type ProviderConfigSpec struct {
 	// Reference to a secret containing the CIS Accounts service credentials.
 	// The Cloud Management (CIS) instance must be of plan `central`.
 	// The Service Binding should be created with the following parameters `{"grantType": "clientCredentials"}`
-	// See [Setup](https://pages.github.tools.sap/cloud-orchestration/docs/sap-services/btp-services/account-managment/provider) for more details
+	// See [Setup](https://sap.github.io/crossplane-provider-docs/docs/crossplane-provider-btp/docs/end-user-guides/setup/configure-provider-btp) for more details
 	CISSecret ProviderCredentials `json:"cisCredentials"`
 
 	// A user available in BTP.
@@ -33,7 +33,8 @@ type ProviderConfigSpec struct {
 
 	CliServerUrl string `json:"cliServerUrl,omitempty"`
 
-	// GlobalAccount is the Global Account Subdomain.
+	// GlobalAccount is the Global Account Subdomain. It must be the subdomain
+	// of the same global account that the cisCredentials binding points at.
 	GlobalAccount string `json:"globalAccount,omitempty"`
 }
 

--- a/docs/end-user-guides/setup/configure-provider-btp.mdx
+++ b/docs/end-user-guides/setup/configure-provider-btp.mdx
@@ -95,7 +95,7 @@ To learn how to set up the SAP Cloud Management service, choose your preferred t
 
         Replace `<subaccount-id>` with the ID of your newly created subaccount.
 
-    4. From the output of the previous commands, copy the binding credentials to your clipboard. You'll need the credentials to create a Kubernetes secret.
+    5. From the output of the previous commands, copy the binding credentials to your clipboard. You'll need the credentials to create a Kubernetes secret.
   </TabItem>
   <TabItem value="btp-cockpit" label="Using the SAP BTP cockpit">
 
@@ -359,7 +359,7 @@ In the `ProviderConfig`, you'll reference the Kubernetes secrets created in [Cre
             source: Secret
     ```
 
-    Replace `<global-account-subdomain>` with the subdomain of your BTP global account.
+    Replace `<global-account-subdomain>` with the subdomain of your BTP global account. It must be the same global account whose subaccount holds the Cloud Management service binding referenced in `cisCredentials`.
 
 2. Apply the configuration:
 

--- a/package/crds/btp.sap.crossplane.io_providerconfigs.yaml
+++ b/package/crds/btp.sap.crossplane.io_providerconfigs.yaml
@@ -53,7 +53,7 @@ spec:
                   Reference to a secret containing the CIS Accounts service credentials.
                   The Cloud Management (CIS) instance must be of plan `central`.
                   The Service Binding should be created with the following parameters `{"grantType": "clientCredentials"}`
-                  See [Setup](https://pages.github.tools.sap/cloud-orchestration/docs/sap-services/btp-services/account-managment/provider) for more details
+                  See [Setup](https://sap.github.io/crossplane-provider-docs/docs/crossplane-provider-btp/docs/end-user-guides/setup/configure-provider-btp) for more details
                 properties:
                   env:
                     description: |-
@@ -111,7 +111,9 @@ spec:
               cliServerUrl:
                 type: string
               globalAccount:
-                description: GlobalAccount is the Global Account Subdomain.
+                description: |-
+                  GlobalAccount is the Global Account Subdomain. It must be the subdomain
+                  of the same global account that the cisCredentials binding points at.
                 type: string
               serviceAccountSecret:
                 description: |-


### PR DESCRIPTION
Closes #948.

## Summary

Small documentation improvement by making it explicit that the configured global accounts (through `cisCredentials` and `globalAccoun`) should / must match.

Additionally replaced outdated link.

## Follow-up

We may want to validate this and go into an error state. But this need refinement first.