### PR TITLE
docs: use relative file-path links so GitHub previews resolve

### DIFF
--- a/docs/contribution-notes/external-name-handling.md
+++ b/docs/contribution-notes/external-name-handling.md
@@ -213,7 +213,7 @@ Else, if we have an error in our request, return with error.
 
 Comments in this format should be on top of the CRDs which will support external name.
 Script (see below) will use it for the docs generation.
-And append the file [docs/end-user-guides/import-landscape/external-name.md](/docs/crossplane-provider-btp/docs/end-user-guides/import-landscape/external-name)
+And append the file [docs/end-user-guides/import-landscape/external-name.md](../end-user-guides/import-landscape/external-name.md)
 
 ```go
 //

--- a/docs/contribution-notes/overview.mdx
+++ b/docs/contribution-notes/overview.mdx
@@ -26,7 +26,7 @@ If you have a question always feel free to reach out on our official crossplane 
 
 ## Guides
 
-- [External Name Handling](/docs/crossplane-provider-btp/docs/contribution-notes/external-name-handling) — How external names are structured, the generation script, and how to annotate new resource types correctly.
-- [Service Binding Rotation](/docs/crossplane-provider-btp/docs/contribution-notes/service-binding-rotation) — The rotation mechanism for service bindings and relevant implementation details.
-- [Upgrade Tests](/docs/crossplane-provider-btp/docs/contribution-notes/upgrade-tests) — How to run and interpret the upgrade test suite.
-- [Resource Implementation Approaches](/docs/crossplane-provider-btp/docs/contribution-notes/resource-implementation-approaches) — Overview of the three controller implementation patterns (native, upjet, hybrid) and which resources use each.
+- [External Name Handling](./external-name-handling.md) — How external names are structured, the generation script, and how to annotate new resource types correctly.
+- [Service Binding Rotation](./service-binding-rotation.md) — The rotation mechanism for service bindings and relevant implementation details.
+- [Upgrade Tests](./upgrade-tests.md) — How to run and interpret the upgrade test suite.
+- [Resource Implementation Approaches](./resource-implementation-approaches.md) — Overview of the three controller implementation patterns (native, upjet, hybrid) and which resources use each.

--- a/docs/end-user-guides/account/subaccount.mdx
+++ b/docs/end-user-guides/account/subaccount.mdx
@@ -9,7 +9,7 @@ This guide shows how to provision and set up an SAP BTP subaccount in an existin
 ## 🚧 Prerequisites
 
 - You've created a control plane.
-- You've [installed](/docs/crossplane-provider-btp/docs/end-user-guides/setup/install-provider-btp) and [configured](/docs/crossplane-provider-btp/docs/end-user-guides/setup/configure-provider-btp) the BTP provider.
+- You've [installed](../setup/install-provider-btp.mdx) and [configured](../setup/configure-provider-btp.mdx) the BTP provider.
 - You're connected to your control plane.
 
 ## Create a `Subaccount`
@@ -40,7 +40,7 @@ This guide shows how to provision and set up an SAP BTP subaccount in an existin
     Make sure to replace all placeholders:
 
     - `<display-name>`: The subaccount name as it should appear in the BTP cockpit
-    - `<admin-email>`: The email address of [your technical user](/docs/crossplane-provider-btp/docs/end-user-guides/setup/configure-provider-btp/#create-and-validate-a-technical-user)
+    - `<admin-email>`: The email address of [your technical user](../setup/configure-provider-btp.mdx#create-and-validate-a-technical-user)
     - `<subaccount-subdomain>`: A unique subdomain name for your subaccount
     <p></p>
 
@@ -121,7 +121,7 @@ The Cloud Management service is essential for provisioning and maintaining other
 
 More information on the Cloud Management service can be found [in the SAP Help Portal](https://help.sap.com/docs/btp/sap-business-technology-platform/account-administration-using-apis-of-sap-cloud-management-service?locale=en-US&version=LATEST).
 
-To create a Cloud Management service instance, you first need to entitle it. You can do that in code using [our `Entitlement` custom resource](/docs/crossplane-provider-btp/docs/end-user-guides/services/create-services#create-an-entitlement).
+To create a Cloud Management service instance, you first need to entitle it. You can do that in code using [our `Entitlement` custom resource](../services/create-services.mdx#create-an-entitlement).
 
 1. Save the following YAML content to `entitlement-service-manager.yaml`.
 
@@ -147,7 +147,7 @@ To create a Cloud Management service instance, you first need to entitle it. You
     kubectl create -f entitlement-service-manager.yaml
     ```
 
-    Learn more about how to entitle services from our guide: [Order service instances and subscriptions](/docs/crossplane-provider-btp/docs/end-user-guides/services/create-services).
+    Learn more about how to entitle services from our guide: [Order service instances and subscriptions](../services/create-services.mdx).
 
 You can then create a Cloud Management service using the `CloudManagement` custom resource, as explained in the following steps.
 
@@ -180,14 +180,14 @@ You can then create a Cloud Management service using the `CloudManagement` custo
 
 ## Next steps
 
-- [Configure the user access to your subaccount](/docs/crossplane-provider-btp/docs/end-user-guides/account/usermanagement).
+- [Configure the user access to your subaccount](./usermanagement.mdx).
 
 ## ⁉ FAQs
 
 ### How can I manage BTP subaccount admins?
 
 There is no reconciliation of `.spec.forProvider.subaccountAdmins` after initial creation, and the field can't be updated once set. This is a limitation of the underlying SAP BTP API.
-To manage subaccount admins, use offerings such as [XSUAA](/docs/crossplane-provider-btp/docs/end-user-guides/account/usermanagement).
+To manage subaccount admins, use offerings such as [XSUAA](./usermanagement.mdx).
 
 ### When creating a `ServiceManager` instance, I receive the error message `Cannot create: Login failed. Check your credentials (401)`.
 
@@ -197,7 +197,7 @@ This error indicates an authentication failure. Please make sure the users in th
 
 The error indicates that the client cannot recognize the specified subaccount. To resolve this issue, please verify the following:
 
-1. [The `ProviderConfig`](/docs/crossplane-provider-btp/docs/end-user-guides/setup/configure-provider-btp#create-a-providerconfig) references the correct global account subdomain.
+1. [The `ProviderConfig`](../setup/configure-provider-btp.mdx#create-a-providerconfig) references the correct global account subdomain.
 2. The `ServiceManager` references the correct `Subaccount` name.
 
 ###  When creating a `ServiceManager` instance, I receive a response with unexpected status (403/405).

--- a/docs/end-user-guides/account/usermanagement.mdx
+++ b/docs/end-user-guides/account/usermanagement.mdx
@@ -14,8 +14,8 @@ This guide shows how to use Crossplane to configure user access to your global a
 ## 🚧 Prerequisites
 
 - You've created a control plane.
-- You've [configured the BTP provider](/docs/crossplane-provider-btp/docs/end-user-guides/setup/configure-provider-btp).
-- You've [created and set up a subaccount managed in code](/docs/crossplane-provider-btp/docs/end-user-guides/account/subaccount).
+- You've [configured the BTP provider](../setup/configure-provider-btp.mdx).
+- You've [created and set up a subaccount managed in code](./subaccount.mdx).
 - You're connected to your control plane.
 
 ## Enable XSUAA
@@ -342,7 +342,7 @@ With the following steps, you can create a custom role collection for your subac
 
 ## Next steps
 
-- [Create managed services and subscriptions](/docs/crossplane-provider-btp/docs/end-user-guides/services/create-services).
+- [Create managed services and subscriptions](../services/create-services.mdx).
 
 ## ⁉ FAQs
 

--- a/docs/end-user-guides/btp.mdx
+++ b/docs/end-user-guides/btp.mdx
@@ -9,11 +9,11 @@ The guides in our end user guides section will walk you through a complete end-t
 
 To realize the use case, you'll:
 
-- [Install](/docs/crossplane-provider-btp/docs/end-user-guides/setup/install-provider-btp) and [configure](/docs/crossplane-provider-btp/docs/end-user-guides/setup/configure-provider-btp) the BTP provider.
-- [Create and set up an orchestrated subaccount](/docs/crossplane-provider-btp/docs/end-user-guides/account/subaccount).
-- [Configure the user access to your orchestrated subaccount](/docs/crossplane-provider-btp/docs/end-user-guides/account/usermanagement).
-- [Create an instance of the HANA Cloud service](/docs/crossplane-provider-btp/docs/end-user-guides/services/create-services).
-- [Create a schema on the HANA Cloud service instance](/docs/crossplane-provider-btp/docs/end-user-guides/services/consume-service).
+- [Install](./setup/install-provider-btp.mdx) and [configure](./setup/configure-provider-btp.mdx) the BTP provider.
+- [Create and set up an orchestrated subaccount](./account/subaccount.mdx).
+- [Configure the user access to your orchestrated subaccount](./account/usermanagement.mdx).
+- [Create an instance of the HANA Cloud service](./services/create-services.mdx).
+- [Create a schema on the HANA Cloud service instance](./services/consume-service.mdx).
 
 :::image-light
 ![Big picture](/img/overview-orchestrate-service-all.png)

--- a/docs/end-user-guides/import-landscape/overview.mdx
+++ b/docs/end-user-guides/import-landscape/overview.mdx
@@ -14,7 +14,7 @@ Crossplane supports this through the `crossplane.io/external-name` annotation, w
 
 ## Automated: BTP Resource Exporter (recommended for large environments)
 
-The [BTP Resource Exporter](/docs/crossplane-provider-btp/docs/end-user-guides/import-landscape/exporter-user-guide) is a CLI tool that connects to your BTP global account via the [BTP CLI](https://help.sap.com/docs/btp/btp-cli-command-reference/btp-cli-command-reference), discovers existing resources such as subaccounts, entitlements, and service instances, and generates ready-to-apply Crossplane manifests in YAML format. You can then review the output and gradually transition resources to full Crossplane management at your own pace. The approach is based on the [Import Existing Resources](https://docs.crossplane.io/v2.2/guides/import-existing-resources/) Crossplane documentation.
+The [BTP Resource Exporter](./exporter-user-guide.md) is a CLI tool that connects to your BTP global account via the [BTP CLI](https://help.sap.com/docs/btp/btp-cli-command-reference/btp-cli-command-reference), discovers existing resources such as subaccounts, entitlements, and service instances, and generates ready-to-apply Crossplane manifests in YAML format. You can then review the output and gradually transition resources to full Crossplane management at your own pace. The approach is based on the [Import Existing Resources](https://docs.crossplane.io/v2.2/guides/import-existing-resources/) Crossplane documentation.
 
 **Key capabilities:**
 - Interactive and non-interactive modes
@@ -26,7 +26,7 @@ Use this when:
 - You want a consistent, repeatable export process
 - You need to bootstrap a new control plane from an existing BTP landscape
 
-For installation instructions, command reference, and usage examples, see the [BTP Resource Exporter User Guide](/docs/crossplane-provider-btp/docs/end-user-guides/import-landscape/exporter-user-guide).
+For installation instructions, command reference, and usage examples, see the [BTP Resource Exporter User Guide](./exporter-user-guide.md).
 
 ## Manual: External Name Annotation
 
@@ -45,4 +45,4 @@ Use this when:
 
 ## Reference: External Name per Resource Type
 
-Not sure which identifier to use for a given resource type? The [External Name Reference](/docs/crossplane-provider-btp/docs/end-user-guides/import-landscape/external-name) lists the expected format and where to find the identifier for each supported BTP resource — both in the BTP Cockpit UI and via the BTP CLI.
+Not sure which identifier to use for a given resource type? The [External Name Reference](./external-name.md) lists the expected format and where to find the identifier for each supported BTP resource — both in the BTP Cockpit UI and via the BTP CLI.

--- a/docs/end-user-guides/migration/v1-to-v2.mdx
+++ b/docs/end-user-guides/migration/v1-to-v2.mdx
@@ -115,7 +115,7 @@ Any `StoreConfig` left behind is orphaned after the upgrade - see [After you upg
 
 Do this if the check reported **GlobalAccount CRs or refs present**.
 
-The `GlobalAccount` managed resource is removed. If `ProviderConfig.spec.globalAccount` is not set yet, set it to your global account subdomain (see [Configure the provider](/docs/crossplane-provider-btp/docs/end-user-guides/setup/configure-provider-btp)):
+The `GlobalAccount` managed resource is removed. If `ProviderConfig.spec.globalAccount` is not set yet, set it to your global account subdomain (see [Configure the provider](../setup/configure-provider-btp.mdx)):
 
 ```yaml
 apiVersion: btp.sap.crossplane.io/v1alpha1

--- a/docs/end-user-guides/services/consume-service.mdx
+++ b/docs/end-user-guides/services/consume-service.mdx
@@ -13,8 +13,8 @@ This guide shows how to consume service instances from external tools such as ot
 
 ## 🚧 Prerequisites
 
-- You've [created and set up a subaccount managed in code](/docs/crossplane-provider-btp/docs/end-user-guides/account/subaccount).
-- You've [created an `Entitlement` and a `ServiceInstance` for the SAP HANA Cloud service](/docs/crossplane-provider-btp/docs/end-user-guides/services/create-services).
+- You've [created and set up a subaccount managed in code](../account/subaccount.mdx).
+- You've [created an `Entitlement` and a `ServiceInstance` for the SAP HANA Cloud service](./create-services.mdx).
 
 ## Create a `ServiceBinding`
 

--- a/docs/end-user-guides/services/create-services.mdx
+++ b/docs/end-user-guides/services/create-services.mdx
@@ -12,8 +12,8 @@ This guide shows how to create entitlements, service instances, and subscription
 ## 🚧 Prerequisites
 
 - You've created a running control plane.
-- You've [configured the BTP provider](/docs/crossplane-provider-btp/docs/end-user-guides/setup/configure-provider-btp).
-- You've [created and set up a subaccount managed in code](/docs/crossplane-provider-btp/docs/end-user-guides/account/subaccount).
+- You've [configured the BTP provider](../setup/configure-provider-btp.mdx).
+- You've [created and set up a subaccount managed in code](../account/subaccount.mdx).
 - You're connected to your control plane.
 
 ## Service instance
@@ -189,12 +189,12 @@ Once the entitlement is in place, you can subscribe to SAP HANA Cloud Administra
     ```
 
 :::tip
-SAP HANA Cloud Administration Tools provides [multiple role collections](https://help.sap.com/docs/hana-cloud/sap-hana-cloud-administration-guide/role-collections-for-sap-hana-cloud?locale=en-US&version=LATEST). To assign these to users or user groups, see [Configure user access](/docs/crossplane-provider-btp/docs/end-user-guides/account/usermanagement).
+SAP HANA Cloud Administration Tools provides [multiple role collections](https://help.sap.com/docs/hana-cloud/sap-hana-cloud-administration-guide/role-collections-for-sap-hana-cloud?locale=en-US&version=LATEST). To assign these to users or user groups, see [Configure user access](../account/usermanagement.mdx).
 :::
 
 ## Next steps
 
-- [Consume services](/docs/crossplane-provider-btp/docs/end-user-guides/services/consume-service.mdx)
+- [Consume services](./consume-service.mdx)
 
 ## ⁉ FAQs
 

--- a/docs/end-user-guides/setup/configure-provider-btp.mdx
+++ b/docs/end-user-guides/setup/configure-provider-btp.mdx
@@ -19,7 +19,7 @@ Once the provider is set up, you can orchestrate other subaccounts in code, such
 ##  🚧 Prerequisites
 
 - Your organization has a global account on SAP BTP.
-- You've [installed the BTP provider on your control plane](/docs/crossplane-provider-btp/docs/end-user-guides/setup/install-provider-btp).
+- You've [installed the BTP provider on your control plane](./install-provider-btp.mdx).
 - You're connected to your control plane.
 
 ## Set up the SAP Cloud Management service
@@ -370,7 +370,7 @@ In the `ProviderConfig`, you'll reference the Kubernetes secrets created in [Cre
 To learn more about the BTP provider or to extend its functionality, go to [the GitHub repo for the BTP provider](https://github.com/SAP/crossplane-provider-btp).
 
 ## Next steps
-- [Create a subaccount in code](/docs/crossplane-provider-btp/docs/end-user-guides/account/subaccount).
+- [Create a subaccount in code](../account/subaccount.mdx).
 
 ## ⁉ FAQs
 

--- a/docs/end-user-guides/setup/install-provider-btp.mdx
+++ b/docs/end-user-guides/setup/install-provider-btp.mdx
@@ -84,7 +84,7 @@ To install the provider on a managed or self-hosted control plane, choose the ap
 
 ## Next steps
 
-- [Configure the BTP provider](/docs/crossplane-provider-btp/docs/end-user-guides/setup/configure-provider-btp).
+- [Configure the BTP provider](./configure-provider-btp.mdx).
 
 ## ⁉ FAQs
 


### PR DESCRIPTION
Use relative paths in all .md(x) files which resolve correctly in both our published Docusaurus docs (https://sap.github.io/crossplane-provider-docs/) and in the Github .md rendering.

Right now links end in 404s in Github's .md rendering.