### PR TITLE
ci: suppress deployment on e2e test env use

### DIFF
--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -275,7 +275,9 @@ jobs:
   e2e-test:
     runs-on: ubuntu-latest
     needs: [prepare-matrix, fetch-chart, build] # fetch-chart provides crossplane-chart artifact; build provides image/xpkg/tools artifacts
-    environment: pr-e2e-no-approval  # approval is on the preceding prepare-matrix job
+    environment:
+      name: pr-e2e-no-approval  # approval is on the preceding prepare-matrix job
+      deployment: false
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
https://github.tools.sap/cloud-orchestration/provider-stream-items/issues/140

GH Docs: https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments#using-environments-without-deployments

Do not create a deployment to reduce visual clutter of PRs 

Example before: 
<img width="943" height="1248" alt="image" src="https://github.com/user-attachments/assets/2d3c56f5-a582-4f8a-8160-2377b44eb669" />
