### PR TITLE
ci: remove deployment from prepare and cleanup job

### DIFF
--- a/.github/workflows/e2e_test.yaml
+++ b/.github/workflows/e2e_test.yaml
@@ -59,7 +59,9 @@ env:
 jobs:
   prepare-matrix:
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}  # approval here for the entire workflow, later jobs use no approval environment
+    environment:
+      name: ${{ inputs.environment }}  # approval here for the entire workflow, later jobs use no approval environment
+      deployment: false
     outputs:
       test-names: ${{ steps.set-matrix.outputs.test-names }}
       # Resolve the checkout ref to a fixed commit SHA once, inside the gated job. Downstream jobs
@@ -413,7 +415,9 @@ jobs:
   cleanup-e2e:
     runs-on: ubuntu-latest
     needs: [prepare-matrix, e2e-test]
-    environment: pr-e2e-no-approval
+    environment:
+      name: pr-e2e-no-approval
+      deployment: false
     if: always() && needs.prepare-matrix.result == 'success'  # only run if prepare-matrix was successful (requires manual approval) and then always run after e2e-test
     steps:
       - name: checkout repo


### PR DESCRIPTION
see https://github.com/SAP/crossplane-provider-btp/pull/951

after that succeeded, we can also remove the deployments from the cleanup and prepare jobs. 

note that the approval requirements will be unaffected by this, see https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/control-deployments#interaction-with-protection-rules