### PR TITLE
fix: resolve plan by name using tf, drop own resolution using service manager API

### DIFF
--- a/internal/clients/cis/cis_tf_client.go
+++ b/internal/clients/cis/cis_tf_client.go
@@ -93,10 +93,13 @@ func (tfI *TfClientInitializer) serviceInstanceCr(cm *apisv1beta1.CloudManagemen
 				ManagementPolicies: []xpv1.ManagementAction{xpv1.ManagementActionAll},
 			},
 			ForProvider: apisv1alpha1.SubaccountServiceInstanceParameters{
-				Name:          getServiceInstanceName(cm),
-				ServiceplanID: &cm.Status.AtProvider.DataSourceLookup.CloudManagementPlanID,
-				SubaccountID:  internal.Ptr(cm.Spec.ForProvider.SubaccountGuid),
-				Parameters:    internal.Ptr(`{"grantType":"clientCredentials"}`),
+				Name: getServiceInstanceName(cm),
+				// Let the upstream instance resolve the plan from name;
+				// serviceplan_name and serviceplan_id are mutually exclusive.
+				ServiceOfferingName: internal.Ptr("cis"),
+				ServiceplanName:     internal.Ptr("local"),
+				SubaccountID:        internal.Ptr(cm.Spec.ForProvider.SubaccountGuid),
+				Parameters:          internal.Ptr(`{"grantType":"clientCredentials"}`),
 			},
 			InitProvider: apisv1alpha1.SubaccountServiceInstanceInitParameters{},
 		},

--- a/internal/clients/cis/cis_tf_client_test.go
+++ b/internal/clients/cis/cis_tf_client_test.go
@@ -49,10 +49,11 @@ func TestConnectResources(t *testing.T) {
 
 	getExpectedInstanceSpec := func(name string) v1alpha1.SubaccountServiceInstanceParameters {
 		return v1alpha1.SubaccountServiceInstanceParameters{
-			Name:          internal.Ptr(name),
-			ServiceplanID: internal.Ptr(defaultPlanId),
-			SubaccountID:  internal.Ptr(defaultSaId),
-			Parameters:    internal.Ptr(`{"grantType":"clientCredentials"}`),
+			Name:                internal.Ptr(name),
+			ServiceOfferingName: internal.Ptr("cis"),
+			ServiceplanName:     internal.Ptr("local"),
+			SubaccountID:        internal.Ptr(defaultSaId),
+			Parameters:          internal.Ptr(`{"grantType":"clientCredentials"}`),
 		}
 	}
 

--- a/internal/clients/servicemanager/service_instance_proxy_client.go
+++ b/internal/clients/servicemanager/service_instance_proxy_client.go
@@ -14,70 +14,15 @@ const ServiceManagerOfferingName = "service-manager"
 func NewServiceManagerInstanceProxyClient(apiClient *accountsserviceclient.APIClient) ServiceManagerInstanceProxyClient {
 	return ServiceManagerInstanceProxyClient{
 		SubaccountOperationsAPI: apiClient.SubaccountOperationsAPI,
-		smServiceFn: func(ctx context.Context, credentials *BindingCredentials) (PlanIdResolver, error) {
-			return NewServiceManagerClient(ctx, credentials)
-		},
 	}
 }
 
-// ServiceManagerInstanceProxyClient is a throw-away implementation, which retrieves a servicePlanID by
-// - creating an intermediate subaccount-admin servicemanager instance via the accountsapi
-// - looksup the servicePLanID via those created credentials binding
-// - deletes this intermediate servicemanager instance
-// -> THIS NEEDS TO BE REPLACED VIA TF DATASOURCES AS SOON AS THOSE ARE AVAILABLE IN UPJET
+// ServiceManagerInstanceProxyClient backs the orphaned-external-name adoption
+// heal for SM/SI/SB/CM: it hands out a SemanticLookuper with full subaccount
+// visibility, minting a temporary subaccount-admin service-manager binding via
+// the accounts-service when none exists yet.
 type ServiceManagerInstanceProxyClient struct {
 	accountsserviceclient.SubaccountOperationsAPI
-
-	// serviceManager API Client needs to be configured with a secret thats not known during initialization
-	smServiceFn func(ctx context.Context, credentials *BindingCredentials) (PlanIdResolver, error)
-}
-
-func (t ServiceManagerInstanceProxyClient) ServiceManagerPlanIDByName(ctx context.Context, subaccountId string, servicePlanName string) (string, error) {
-	// if binding exists we use it to resolve serviceplan
-	binding, err := t.describeAdminBinding(ctx, subaccountId)
-	if err != nil {
-		return "", err
-	}
-	if binding != nil {
-		return t.resolveServicePlan(ctx, servicePlanName)(binding)
-	}
-	// otherwise we dynamically create and delete an instance and resolve the serviceplan using its credentials
-	return t.dynamicServiceInstance(ctx, subaccountId, t.resolveServicePlan(ctx, servicePlanName))
-}
-
-func (t ServiceManagerInstanceProxyClient) dynamicServiceInstance(ctx context.Context, subaccountId string, resolvalFn func(binding *BindingCredentials) (string, error)) (string, error) {
-	binding, err := t.createAdminBinding(ctx, subaccountId)
-	if err != nil {
-		return "", err
-	}
-
-	id, err := resolvalFn(binding)
-	if err != nil {
-		return "", err
-	}
-
-	err = t.deleteAdminBinding(ctx, subaccountId)
-	if err != nil {
-		return "", err
-	}
-
-	return id, nil
-}
-
-func (t ServiceManagerInstanceProxyClient) resolveServicePlan(ctx context.Context, servicePlanName string) func(binding *BindingCredentials) (string, error) {
-	return func(binding *BindingCredentials) (string, error) {
-		resolver, err := t.smServiceFn(ctx, binding)
-
-		if err != nil {
-			return "", err
-		}
-
-		id, err := resolver.PlanIDByName(ctx, ServiceManagerOfferingName, servicePlanName, "")
-		if err != nil {
-			return "", err
-		}
-		return id, err
-	}
 }
 
 func (t ServiceManagerInstanceProxyClient) describeAdminBinding(ctx context.Context, subaccountGuid string) (*BindingCredentials, error) {

--- a/internal/clients/servicemanager/service_instance_proxy_client_test.go
+++ b/internal/clients/servicemanager/service_instance_proxy_client_test.go
@@ -12,179 +12,14 @@ import (
 	saops "github.com/sap/crossplane-provider-btp/internal/openapi_clients/btp-accounts-service-api-go/pkg"
 )
 
-func TestLookup(t *testing.T) {
-	type args struct {
-		CreateMockFn func() (*saops.ServiceManagerBindingResponseObject, *http.Response, error)
-		DeleteMockFn func() (*http.Response, error)
-		GetMockFn    func() (*saops.ServiceManagerBindingResponseObject, *http.Response, error)
-
-		PlanLookupMockFn func() (string, error)
-	}
-	type want struct {
-		err          bool
-		id           string
-		deleteCalled bool
-	}
-	tests := []struct {
-		name string
-		args args
-
-		want want
-	}{
-		{
-			name: "BindingLookupFailure",
-			args: args{
-				GetMockFn: func() (*saops.ServiceManagerBindingResponseObject, *http.Response, error) {
-					return nil, response(500), errors.New("GetBindingError")
-				},
-			},
-			want: want{
-				err: true,
-			},
-		},
-		{
-			name: "BindingCreateFailure",
-			args: args{
-				GetMockFn: func() (*saops.ServiceManagerBindingResponseObject, *http.Response, error) {
-					return nil, response(404), errors.New("GetBindingError")
-				},
-				CreateMockFn: func() (*saops.ServiceManagerBindingResponseObject, *http.Response, error) {
-					return nil, response(500), errors.New("CreateBindingError")
-				},
-			},
-			want: want{
-				err: true,
-			},
-		},
-		{
-			name: "ServicePlanLookupFailure",
-			args: args{
-				GetMockFn: func() (*saops.ServiceManagerBindingResponseObject, *http.Response, error) {
-					return nil, response(404), errors.New("GetBindingError")
-				},
-				CreateMockFn: func() (*saops.ServiceManagerBindingResponseObject, *http.Response, error) {
-					return adminBinding(), response(200), nil
-				},
-				PlanLookupMockFn: func() (string, error) {
-					return "", errors.New("PlanLookupError")
-				},
-			}, want: want{
-				err: true,
-			},
-		},
-		{
-			name: "BindingDeleteFailure",
-			args: args{
-				GetMockFn: func() (*saops.ServiceManagerBindingResponseObject, *http.Response, error) {
-					return nil, response(404), errors.New("GetBindingError")
-				},
-				CreateMockFn: func() (*saops.ServiceManagerBindingResponseObject, *http.Response, error) {
-					return adminBinding(), response(200), nil
-				},
-				PlanLookupMockFn: func() (string, error) {
-					return "someId", nil
-				},
-				DeleteMockFn: func() (*http.Response, error) {
-					return response(500), errors.New("DeleteBindingError")
-				},
-			},
-			want: want{
-				err:          true,
-				deleteCalled: true,
-			},
-		},
-		{
-			name: "SuccessFromFoundSMInstance",
-			args: args{
-				GetMockFn: func() (*saops.ServiceManagerBindingResponseObject, *http.Response, error) {
-					return adminBinding(), response(200), nil
-				},
-				PlanLookupMockFn: func() (string, error) {
-					return "someId", nil
-				},
-			},
-			want: want{
-				err:          false,
-				id:           "someId",
-				deleteCalled: false,
-			},
-		},
-		{
-			name: "SuccessFromCreatedSMInstance",
-			args: args{
-				GetMockFn: func() (*saops.ServiceManagerBindingResponseObject, *http.Response, error) {
-					return nil, response(404), errors.New("GetBindingError")
-				},
-				CreateMockFn: func() (*saops.ServiceManagerBindingResponseObject, *http.Response, error) {
-					return adminBinding(), response(200), nil
-				},
-				PlanLookupMockFn: func() (string, error) {
-					return "someId", nil
-				},
-				DeleteMockFn: func() (*http.Response, error) {
-					return response(200), nil
-				},
-			},
-			want: want{
-				err:          false,
-				id:           "someId",
-				deleteCalled: true,
-			},
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			accountService := &SubaccountServiceFake{
-				CreateMockFn: tc.args.CreateMockFn,
-				DeleteMockFn: tc.args.DeleteMockFn,
-				GetMockFn:    tc.args.GetMockFn,
-			}
-
-			smClient := ServiceManagerInstanceProxyClient{
-				accountService,
-				func(ctx context.Context, credentials *BindingCredentials) (PlanIdResolver, error) {
-					return &PlanIdResolverFake{
-						PlanLookupMockFn: tc.args.PlanLookupMockFn,
-					}, nil
-				},
-			}
-			planID, err := smClient.ServiceManagerPlanIDByName(context.TODO(), "", "")
-
-			if tc.want.err != (err != nil) {
-				t.Errorf("Unexpected error return; Expected error: %v, Returned: %v", tc.want.err, err)
-			}
-			if tc.want.id != planID {
-				t.Errorf("Unexpected returned PlanID; Expected: %s, Returned: %s", tc.want.id, planID)
-			}
-			if tc.want.deleteCalled != accountService.AdminBindingDeleteCalled {
-				t.Errorf("Unexpected delete call attempts: Expected call: %v, Was Called: %v", tc.want.deleteCalled, accountService.AdminBindingDeleteCalled)
-			}
-		})
-	}
-}
-
 func response(code int) *http.Response {
 	return &http.Response{StatusCode: code}
 }
 
-func adminBinding() *saops.ServiceManagerBindingResponseObject {
-	// since we mock all other components, this only needs to be != nil
-	return saops.NewServiceManagerBindingResponseObject()
-}
-
-var _ PlanIdResolver = &PlanIdResolverFake{}
-
-type PlanIdResolverFake struct {
-	PlanLookupMockFn func() (string, error)
-}
-
-func (p *PlanIdResolverFake) PlanIDByName(ctx context.Context, offeringName, planName string, dataCenter string) (string, error) {
-	return p.PlanLookupMockFn()
-}
-
 // TestCreateAdminBindingSurfacesAPIBody asserts that createAdminBinding routes
 // transport errors through specifyAccountsAPIError so the BTP API body is surfaced
-// instead of the opaque "<status> <reason>" string.
+// instead of the opaque "<status> <reason>" string. Driven via EnsureSemanticLookuper,
+// which mints an admin binding when none exists (404 -> create).
 func TestCreateAdminBindingSurfacesAPIBody(t *testing.T) {
 	accountService := &SubaccountServiceFake{
 		GetMockFn: func() (*saops.ServiceManagerBindingResponseObject, *http.Response, error) {
@@ -194,14 +29,9 @@ func TestCreateAdminBindingSurfacesAPIBody(t *testing.T) {
 			return nil, response(500), create500Error()
 		},
 	}
-	smClient := ServiceManagerInstanceProxyClient{
-		accountService,
-		func(ctx context.Context, credentials *BindingCredentials) (PlanIdResolver, error) {
-			return nil, nil
-		},
-	}
+	smClient := ServiceManagerInstanceProxyClient{accountService}
 
-	_, err := smClient.ServiceManagerPlanIDByName(context.TODO(), "", "")
+	_, _, err := smClient.EnsureSemanticLookuper(context.TODO(), "")
 	if err == nil {
 		t.Fatalf("expected error, got nil")
 	}

--- a/internal/clients/servicemanager/service_manager_tf_client.go
+++ b/internal/clients/servicemanager/service_manager_tf_client.go
@@ -93,6 +93,11 @@ func (tfI *TfClientInitializer) serviceInstanceCr(sm *apisv1beta1.ServiceManager
 		name = tfI.defaults.InstanceName
 	}
 
+	// Let the upstream instance resolve the plan from name; serviceplan_name and
+	// serviceplan_id are mutually exclusive, so we set no ID.
+	planName := PlanNameOrDefault(sm)
+	offeringName := ServiceManagerOfferingName
+
 	sInstance := &apisv1alpha1.SubaccountServiceInstance{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       apisv1alpha1.SubaccountServiceInstance_Kind,
@@ -111,9 +116,10 @@ func (tfI *TfClientInitializer) serviceInstanceCr(sm *apisv1beta1.ServiceManager
 				ManagementPolicies: []xpv1.ManagementAction{xpv1.ManagementActionAll},
 			},
 			ForProvider: apisv1alpha1.SubaccountServiceInstanceParameters{
-				Name:          &name,
-				ServiceplanID: &sm.Status.AtProvider.DataSourceLookup.ServiceManagerPlanID,
-				SubaccountID:  internal.Ptr(sm.Spec.ForProvider.SubaccountGuid),
+				Name:                &name,
+				ServiceplanName:     &planName,
+				ServiceOfferingName: &offeringName,
+				SubaccountID:        internal.Ptr(sm.Spec.ForProvider.SubaccountGuid),
 			},
 			InitProvider: apisv1alpha1.SubaccountServiceInstanceInitParameters{},
 		},
@@ -122,6 +128,14 @@ func (tfI *TfClientInitializer) serviceInstanceCr(sm *apisv1beta1.ServiceManager
 	sInstanceId, _ := splitExternalName(meta.GetExternalName(sm))
 	meta.SetExternalName(sInstance, sInstanceId)
 	return sInstance
+}
+
+// PlanNameOrDefault returns the SM's configured plan name, or the CRD default.
+func PlanNameOrDefault(sm *apisv1beta1.ServiceManager) string {
+	if sm.Spec.ForProvider.PlanName != "" {
+		return sm.Spec.ForProvider.PlanName
+	}
+	return apisv1beta1.DefaultPlanName
 }
 
 func (tfI *TfClientInitializer) serviceBindingCr(sm *apisv1beta1.ServiceManager) *apisv1alpha1.SubaccountServiceBinding {
@@ -288,19 +302,7 @@ func (tf *TfClient) resourcesUpToDate(ctx context.Context) bool {
 	if err != nil {
 		return true
 	}
-	if siObs.ResourceUpToDate {
-		return true
-	}
-
-	// Workaround for #941: the service plan is immutable in BTP, so an in-place
-	// update on a plan-only diff calls update_instance, which BTP rejects. That
-	// diff only arises for an upgraded v1alpha1 SM whose status lost
-	// dataSourceLookup and re-resolved the flipped default plan (#925). Report
-	// up-to-date so no Update fires. For v1beta1 the plan is pinned by the CRD, so
-	// desired == observed and this is a no-op.
-	desiredPlan := internal.Val(tf.sInstance.Spec.ForProvider.ServiceplanID)
-	observedPlan := internal.Val(tf.sInstance.Status.AtProvider.ServiceplanID)
-	return desiredPlan != observedPlan
+	return siObs.ResourceUpToDate
 }
 
 func (tf *TfClient) createInstance(ctx context.Context) (string, error) {

--- a/internal/clients/servicemanager/service_manager_tf_client_test.go
+++ b/internal/clients/servicemanager/service_manager_tf_client_test.go
@@ -77,9 +77,10 @@ func TestConnectResources(t *testing.T) {
 				planId:               "planId",
 				instanceExternalName: "instanceID",
 				instanceSpec: v1alpha1.SubaccountServiceInstanceParameters{
-					Name:          internal.Ptr(DefaultServiceName),
-					ServiceplanID: internal.Ptr("planId"),
-					SubaccountID:  internal.Ptr("subaccountId"),
+					Name:                internal.Ptr(DefaultServiceName),
+					ServiceplanName:     internal.Ptr(v1beta1.DefaultPlanName),
+					ServiceOfferingName: internal.Ptr(ServiceManagerOfferingName),
+					SubaccountID:        internal.Ptr("subaccountId"),
 				},
 				bindingSpec: v1alpha1.SubaccountServiceBindingParameters{
 					SubaccountID:      internal.Ptr("subaccountId"),
@@ -102,9 +103,10 @@ func TestConnectResources(t *testing.T) {
 				planId:               "planId",
 				instanceExternalName: "instanceID",
 				instanceSpec: v1alpha1.SubaccountServiceInstanceParameters{
-					Name:          internal.Ptr("custom-name"),
-					ServiceplanID: internal.Ptr("planId"),
-					SubaccountID:  internal.Ptr("subaccountId"),
+					Name:                internal.Ptr("custom-name"),
+					ServiceplanName:     internal.Ptr(v1beta1.DefaultPlanName),
+					ServiceOfferingName: internal.Ptr(ServiceManagerOfferingName),
+					SubaccountID:        internal.Ptr("subaccountId"),
 				},
 				bindingSpec: v1alpha1.SubaccountServiceBindingParameters{
 					SubaccountID:      internal.Ptr("subaccountId"),
@@ -130,9 +132,10 @@ func TestConnectResources(t *testing.T) {
 				planId:               "planId",
 				instanceExternalName: testInstanceUUID,
 				instanceSpec: v1alpha1.SubaccountServiceInstanceParameters{
-					Name:          internal.Ptr("custom-name"),
-					ServiceplanID: internal.Ptr("planId"),
-					SubaccountID:  internal.Ptr("subaccountId"),
+					Name:                internal.Ptr("custom-name"),
+					ServiceplanName:     internal.Ptr(v1beta1.DefaultPlanName),
+					ServiceOfferingName: internal.Ptr(ServiceManagerOfferingName),
+					SubaccountID:        internal.Ptr("subaccountId"),
 				},
 				bindingExternalName: testBindingUUID,
 				bindingSpec: v1alpha1.SubaccountServiceBindingParameters{
@@ -319,52 +322,6 @@ func TestObserveResources(t *testing.T) {
 					},
 					InstanceID: "someID",
 					BindingID:  "anotherID",
-				},
-				err: nil,
-			},
-		},
-		{
-			// The second instance Observe reports NotUpToDate, but the only difference
-			// is the immutable serviceplan_id (desired != observed live plan). We must
-			// report ResourceUpToDate:true so no in-place update fires - BTP rejects a
-			// plan change with "update_instance is not supported". ObservedPlanID
-			// carries the live plan back so the controller can heal status (#941).
-			name: "InstancePlanDiffTreatedUpToDate",
-			args: args{
-				cr: testSMCr("subaccountId", "wrongPlan", "someID/anotherID", "", "", ""),
-				siExternal: ExternalClientFake{
-					observeFn: func() (managed.ExternalObservation, error) {
-						return managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: false}, nil
-					},
-				},
-				sbExternal: ExternalClientFake{
-					observeFn: func() (managed.ExternalObservation, error) {
-						return managed.ExternalObservation{ResourceExists: true, ResourceUpToDate: true,
-							ConnectionDetails: map[string][]byte{"attribute.credentials": []byte(`{"clientid":"someClientID","clientsecret":"someSecret","sm_url":"https://service-manager.cfapps.eu12.hana.ondemand.com","url":"https://subdomain.authentication.eu12.hana.ondemand.com","xsappname":"someAppName"}`)}}, nil
-					},
-				},
-				// desired plan (wrongPlan, from re-resolution) != live plan (livePlan).
-				sInstance: instanceWithPlan("someID", "wrongPlan", "livePlan"),
-				sBinding:  testServiceBinding("anotherID"),
-			},
-			want: want{
-				obs: ResourcesStatus{
-					ExternalObservation: managed.ExternalObservation{
-						ResourceExists:   true,
-						ResourceUpToDate: true,
-						ConnectionDetails: map[string][]byte{
-							v1beta1.ResourceCredentialsClientSecret:      []byte("someSecret"),
-							v1beta1.ResourceCredentialsClientId:          []byte("someClientID"),
-							v1beta1.ResourceCredentialsServiceManagerUrl: []byte("https://service-manager.cfapps.eu12.hana.ondemand.com"),
-							v1beta1.ResourceCredentialsXsuaaUrl:          []byte("https://subdomain.authentication.eu12.hana.ondemand.com"),
-							v1beta1.ResourceCredentialsXsappname:         []byte("someAppName"),
-							v1beta1.ResourceCredentialsXsuaaUrlSufix:     []byte("/oauth/token"),
-							providerv1alpha1.RawBindingKey:               []byte(`{"clientid":"someClientID","clientsecret":"someSecret","sm_url":"https://service-manager.cfapps.eu12.hana.ondemand.com","url":"https://subdomain.authentication.eu12.hana.ondemand.com","xsappname":"someAppName"}`),
-						},
-					},
-					InstanceID:     "someID",
-					BindingID:      "anotherID",
-					ObservedPlanID: "livePlan",
 				},
 				err: nil,
 			},

--- a/internal/controller/account/cloudmanagement/cloudmanagement.go
+++ b/internal/controller/account/cloudmanagement/cloudmanagement.go
@@ -37,7 +37,6 @@ const (
 	errGetCredentialsSecret = "Could not Get Secret"
 	errTrackRUsage          = "cannot track ResourceUsage"
 	errTrackPCUsage         = "cannot track ProviderConfig usage"
-	errInitServicePlanId    = "while initializing service plan ID"
 	errEnsureCompatibility  = "while ensuring compatibility"
 	errConnectResources     = "while connecting resources"
 	errObserve              = "while observing resources"
@@ -45,17 +44,14 @@ const (
 	errCreate               = "while creating resources"
 	errUpdate               = "while updating resources"
 	errDelete               = "while deleting resources"
-	errSaveId               = "while saving ID"
-	errGetPlanId            = "while getting plan ID"
 )
 
 // A connector is expected to produce an ExternalClient when its Connect method
 // is called.
 type connector struct {
-	kube                client.Client
-	usage               providerconfig.LegacyTracker
-	resourcetracker     tracking.ReferenceResolverTracker
-	newPlanIdResolverFn func(ctx context.Context, secretData map[string][]byte) (servicemanager.PlanIdResolver, error)
+	kube            client.Client
+	usage           providerconfig.LegacyTracker
+	resourcetracker tracking.ReferenceResolverTracker
 
 	newClientInitalizerFn func() cmclient.ITfClientInitializer
 
@@ -94,12 +90,7 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 		return nil, errors.Wrap(err, errGetCredentialsSecret)
 	}
 
-	err := c.InitializeServicePlanId(ctx, cr, secret)
-	if err != nil {
-		return nil, errors.Wrap(err, errInitServicePlanId)
-	}
-
-	err = c.ensureCompatibility(ctx, cr)
+	err := c.ensureCompatibility(ctx, cr)
 	if err != nil {
 		return nil, errors.Wrap(err, errEnsureCompatibility)
 	}
@@ -141,36 +132,6 @@ func (c *connector) migrationNeeded(cr *apisv1beta1.CloudManagement) bool {
 	binding := cr.Status.AtProvider.Binding
 
 	return !strings.Contains(extName, "/") && instance != nil && binding != nil
-}
-
-func (c *connector) IsInitialized(cr *apisv1beta1.CloudManagement) bool {
-	return cr.Status.AtProvider.DataSourceLookup != nil
-}
-
-// InitializeServicePlanId ensures the service plan id for cis local is cached in status
-func (c *connector) InitializeServicePlanId(ctx context.Context, cr *apisv1beta1.CloudManagement, secret *corev1.Secret) error {
-	if c.IsInitialized(cr) {
-		return nil
-	}
-
-	sm, err := c.newPlanIdResolverFn(ctx, secret.Data)
-	if err != nil {
-		return errors.Wrap(err, errGetPlanId)
-	}
-
-	id, err := sm.PlanIDByName(ctx, "cis", "local", "")
-	if err != nil {
-		return errors.Wrap(err, errGetPlanId)
-	}
-
-	return errors.Wrap(c.saveId(ctx, cr, id), errSaveId)
-}
-
-func (c *connector) saveId(ctx context.Context, cr *apisv1beta1.CloudManagement, id string) error {
-	cr.Status.AtProvider.DataSourceLookup = &apisv1beta1.CloudManagementDataSourceLookup{
-		CloudManagementPlanID: id,
-	}
-	return c.kube.Status().Update(ctx, cr)
 }
 
 // An ExternalClient observes, then either creates, updates, or deletes an
@@ -420,6 +381,15 @@ func (c *external) setStatus(ctx context.Context, status cmclient.ResourcesStatu
 	if status.Instance.ID != nil {
 		cr.Status.AtProvider.Instance = mapToInstance(&status.Instance)
 		cr.Status.AtProvider.ServiceInstanceID = *status.Instance.ID
+	}
+
+	// Record the live plan ID so healExternalName can filter on it. TF now
+	// resolves the plan from cis/local by name, so this is the only source.
+	if status.Instance.ServiceplanID != nil && *status.Instance.ServiceplanID != "" {
+		if cr.Status.AtProvider.DataSourceLookup == nil {
+			cr.Status.AtProvider.DataSourceLookup = &apisv1beta1.CloudManagementDataSourceLookup{}
+		}
+		cr.Status.AtProvider.DataSourceLookup.CloudManagementPlanID = *status.Instance.ServiceplanID
 	}
 
 	if status.Binding.ID != nil {

--- a/internal/controller/account/cloudmanagement/cloudmanagement_test.go
+++ b/internal/controller/account/cloudmanagement/cloudmanagement_test.go
@@ -29,7 +29,6 @@ func TestConnect(t *testing.T) {
 	type args struct {
 		cr                  *v1beta1.CloudManagement
 		kube                test.MockClient
-		planIdResolverFn    func(ctx context.Context, secretData map[string][]byte) (servicemanager.PlanIdResolver, error)
 		clientInitializerFn func() cmclient.ITfClientInitializer
 	}
 	tests := []struct {
@@ -72,124 +71,6 @@ func TestConnect(t *testing.T) {
 			},
 		},
 		{
-			name: "PlanIdResolverInitError",
-			args: args{
-				kube: test.MockClient{
-					MockGet:          test.NewMockGetFn(nil),
-					MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
-				},
-				cr: NewCloudManagement("test",
-					WithData(v1beta1.CloudManagementParameters{
-						ServiceManagerSecretNamespace: "someNamespace",
-						ServiceManagerSecret:          "someSecret",
-					}),
-				),
-				planIdResolverFn: func(ctx context.Context, secretData map[string][]byte) (servicemanager.PlanIdResolver, error) {
-					return nil, errors.New("ResolverInitError")
-				},
-			},
-			want: want{
-				err: errors.Wrap(errors.Wrap(errors.New("ResolverInitError"), "while getting plan ID"), "while initializing service plan ID"),
-				cr: NewCloudManagement("test",
-					WithData(v1beta1.CloudManagementParameters{
-						ServiceManagerSecretNamespace: "someNamespace",
-						ServiceManagerSecret:          "someSecret",
-					}),
-				),
-			},
-		},
-		{
-			name: "IntializeEmptyResource",
-			args: args{
-				kube: test.MockClient{
-					MockGet:          test.NewMockGetFn(nil),
-					MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
-				},
-				cr: NewCloudManagement("test",
-					WithData(v1beta1.CloudManagementParameters{
-						ServiceManagerSecretNamespace: "someNamespace",
-						ServiceManagerSecret:          "someSecret",
-					}),
-				),
-				planIdResolverFn: func(ctx context.Context, secretData map[string][]byte) (servicemanager.PlanIdResolver, error) {
-					return PlanIDFake{
-						func(ctx context.Context, offeringName string, servicePlanName string, dataCenter string) (string, error) {
-							return "planID", nil
-						},
-					}, nil
-				},
-				clientInitializerFn: func() cmclient.ITfClientInitializer {
-					return &ClientInitializerFake{
-						ConnectResourcesFn: func(ctx context.Context, cr *v1beta1.CloudManagement) (cmclient.ITfClient, error) {
-							return &TfClientFake{}, nil
-						},
-					}
-				},
-			},
-			want: want{
-				err: nil,
-				cr: NewCloudManagement("test",
-					WithData(v1beta1.CloudManagementParameters{
-						ServiceManagerSecretNamespace: "someNamespace",
-						ServiceManagerSecret:          "someSecret",
-					}),
-					WithStatus(v1beta1.CloudManagementObservation{
-						DataSourceLookup: &v1beta1.CloudManagementDataSourceLookup{
-							CloudManagementPlanID: "planID",
-						},
-					}),
-				),
-			},
-		},
-		{
-			name: "AlreadyInitialized",
-			args: args{
-				kube: test.MockClient{
-					MockGet:          test.NewMockGetFn(nil),
-					MockStatusUpdate: test.NewMockSubResourceUpdateFn(nil),
-				},
-				cr: NewCloudManagement("test",
-					WithData(v1beta1.CloudManagementParameters{
-						ServiceManagerSecretNamespace: "someNamespace",
-						ServiceManagerSecret:          "someSecret",
-					}),
-					WithStatus(v1beta1.CloudManagementObservation{
-						DataSourceLookup: &v1beta1.CloudManagementDataSourceLookup{
-							CloudManagementPlanID: "planID",
-						},
-					}),
-				),
-				planIdResolverFn: func(ctx context.Context, secretData map[string][]byte) (servicemanager.PlanIdResolver, error) {
-					return PlanIDFake{
-						func(ctx context.Context, offeringName string, servicePlanName string, dataCenter string) (string, error) {
-							return "planID", nil
-						},
-					}, nil
-				},
-				clientInitializerFn: func() cmclient.ITfClientInitializer {
-					return &ClientInitializerFake{
-						ConnectResourcesFn: func(ctx context.Context, cr *v1beta1.CloudManagement) (cmclient.ITfClient, error) {
-							return &TfClientFake{}, nil
-						},
-					}
-				},
-			},
-			want: want{
-				err: nil,
-				cr: NewCloudManagement("test",
-					WithData(v1beta1.CloudManagementParameters{
-						ServiceManagerSecretNamespace: "someNamespace",
-						ServiceManagerSecret:          "someSecret",
-					}),
-					WithStatus(v1beta1.CloudManagementObservation{
-						DataSourceLookup: &v1beta1.CloudManagementDataSourceLookup{
-							CloudManagementPlanID: "planID",
-						},
-					}),
-				),
-			},
-		},
-		{
 			// we changed the approach from using the API to using tf resources internally, we have to ensure some smooth migration
 			name: "MigrateFromPreviousVersion",
 			args: args{
@@ -213,13 +94,6 @@ func TestConnect(t *testing.T) {
 						},
 					}),
 				),
-				planIdResolverFn: func(ctx context.Context, secretData map[string][]byte) (servicemanager.PlanIdResolver, error) {
-					return PlanIDFake{
-						func(ctx context.Context, offeringName string, servicePlanName string, dataCenter string) (string, error) {
-							return "planID", nil
-						},
-					}, nil
-				},
 				clientInitializerFn: func() cmclient.ITfClientInitializer {
 					return &ClientInitializerFake{
 						ConnectResourcesFn: func(ctx context.Context, cr *v1beta1.CloudManagement) (cmclient.ITfClient, error) {
@@ -237,9 +111,6 @@ func TestConnect(t *testing.T) {
 						ServiceManagerSecret:          "someSecret",
 					}),
 					WithStatus(v1beta1.CloudManagementObservation{
-						DataSourceLookup: &v1beta1.CloudManagementDataSourceLookup{
-							CloudManagementPlanID: "planID",
-						},
 						Instance: &v1beta1.Instance{
 							Id: internal.Ptr("someID"),
 						},
@@ -258,7 +129,6 @@ func TestConnect(t *testing.T) {
 				usage:                 test2.NoOpLegacyTracker{},
 				resourcetracker:       test2.NoOpReferenceResolverTracker{},
 				newClientInitalizerFn: tc.args.clientInitializerFn,
-				newPlanIdResolverFn:   tc.args.planIdResolverFn,
 			}
 			_, err := uua.Connect(context.TODO(), tc.args.cr)
 			if diff := cmp.Diff(err, tc.want.err, test.EquateErrors()); diff != "" {
@@ -359,7 +229,7 @@ func TestObserve(t *testing.T) {
 						// Doesn't matter what observe is returned exactly, as long as its passed through and IDs are persisted
 						return cmclient.ResourcesStatus{
 							ExternalObservation: managed.ExternalObservation{ResourceExists: false},
-							Instance:            v1alpha1.SubaccountServiceInstanceObservation{ID: internal.Ptr("someID")},
+							Instance:            v1alpha1.SubaccountServiceInstanceObservation{ID: internal.Ptr("someID"), ServiceplanID: internal.Ptr("planID")},
 						}, nil
 					},
 				},
@@ -372,7 +242,8 @@ func TestObserve(t *testing.T) {
 					WithStatus(v1beta1.CloudManagementObservation{
 						Status:            v1alpha1.CisStatusUnbound,
 						ServiceInstanceID: "someID",
-						Instance:          &v1beta1.Instance{Id: internal.Ptr("someID")},
+						Instance:          &v1beta1.Instance{Id: internal.Ptr("someID"), ServicePlanId: internal.Ptr("planID")},
+						DataSourceLookup:  &v1beta1.CloudManagementDataSourceLookup{CloudManagementPlanID: "planID"},
 					}),
 					WithConditions(xpv1.Unavailable()),
 				),

--- a/internal/controller/account/cloudmanagement/zz_setup.go
+++ b/internal/controller/account/cloudmanagement/zz_setup.go
@@ -9,7 +9,6 @@ import (
 	cmClient "github.com/sap/crossplane-provider-btp/internal/clients/cis"
 	smClient "github.com/sap/crossplane-provider-btp/internal/clients/servicemanager"
 	"github.com/sap/crossplane-provider-btp/internal/clients/tfclient"
-	"github.com/sap/crossplane-provider-btp/internal/di"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -27,10 +26,9 @@ func Setup(mgr ctrl.Manager, o internalopts.CrossplaneOptions) error {
 	recorder := event.NewAPIRecorder(mgr.GetEventRecorderFor(name)) //nolint:staticcheck // NewAPIRecorder requires the legacy event recorder type.
 	return providerconfig.DefaultSetupWithoutDefaultInitializer(mgr, o, &apisv1beta1.CloudManagement{}, apisv1beta1.CloudManagementKind, apisv1beta1.CloudManagementGroupVersionKind, func(kube client.Client, usage providerconfig.LegacyTracker, resourcetracker tracking.ReferenceResolverTracker) managed.ExternalConnector {
 		return &connector{
-			kube:                kube,
-			usage:               usage,
-			resourcetracker:     resourcetracker,
-			newPlanIdResolverFn: di.NewPlanIdResolverFn,
+			kube:            kube,
+			usage:           usage,
+			resourcetracker: resourcetracker,
 
 			newClientInitalizerFn: func() cmClient.ITfClientInitializer {
 				return cmClient.NewTfClient(

--- a/internal/controller/account/servicemanager/servicemanager.go
+++ b/internal/controller/account/servicemanager/servicemanager.go
@@ -26,23 +26,15 @@ import (
 const (
 	errNotServiceManager = "managed resource is not a ServiceManager custom resource"
 	errTrack             = "cannot track resource usage"
-	errInitialize        = "while initializing service plan ID"
 	errConnect           = "while connecting resources"
-	errGetPlanID         = "while getting plan ID initializer"
 	errUpdateStatus      = "while updating service manager status"
 	errCreate            = "while creating resources"
 	errUpdate            = "while updating resources"
 	errDelete            = "while deleting resources"
 	errSetStatus         = "while setting status"
-	errGetServicePlan    = "while getting service manager plan ID by name"
 
 	errExternalNameFormat = "crossplane.io/external-name is malformed; fix the annotation to resume reconciliation"
 )
-
-// ServiceManagerPlanIdInitializer is will provide implementation of service plan id lookup by name
-type ServiceManagerPlanIdInitializer interface {
-	ServiceManagerPlanIDByName(ctx context.Context, subaccountId string, servicePlanName string) (string, error)
-}
 
 // A connector is expected to produce an ExternalClient when its Connect method
 // is called.
@@ -51,8 +43,7 @@ type connector struct {
 	resourcetracker tracking.ReferenceResolverTracker
 	newServiceFn    func(cisSecretData []byte, serviceAccountSecretData []byte) (*btp.Client, error)
 
-	newPlanIdInitializerFn func(ctx context.Context, cr *apisv1beta1.ServiceManager) (ServiceManagerPlanIdInitializer, error)
-	newClientInitalizerFn  func() sm.ITfClientInitializer
+	newClientInitalizerFn func() sm.ITfClientInitializer
 
 	// newAdminLookuperFn builds a SemanticLookuper backed by the subaccount-admin
 	// SM binding (minted via the accounts-service), returning a cleanup func.
@@ -70,10 +61,6 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 		return nil, errors.Wrap(err, errTrack)
 	}
 
-	if err := c.InitializeServicePlanId(ctx, cr); err != nil {
-		return nil, errors.Wrap(err, errInitialize)
-	}
-
 	tfClientInit := c.newClientInitalizerFn()
 
 	tfClient, err := tfClientInit.ConnectResources(ctx, cr)
@@ -89,45 +76,6 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 		recorder:           c.recorder,
 		newAdminLookuperFn: c.newAdminLookuperFn,
 	}, nil
-}
-
-func (c *connector) IsInitialized(cr *apisv1beta1.ServiceManager) bool {
-	return cr.Spec.ForProvider.SubaccountGuid != "" && cr.Status.AtProvider.DataSourceLookup != nil
-}
-
-func (c *connector) InitializeServicePlanId(ctx context.Context, cr *apisv1beta1.ServiceManager) error {
-	if c.IsInitialized(cr) {
-		return nil
-	}
-
-	planIdInitializer, err := c.newPlanIdInitializerFn(ctx, cr)
-	if err != nil {
-		return errors.Wrap(err, errGetPlanID)
-	}
-
-	id, err := planIdInitializer.ServiceManagerPlanIDByName(ctx, cr.Spec.ForProvider.SubaccountGuid, c.ServicePlanName(cr))
-	if err != nil {
-		return errors.Wrap(err, errGetServicePlan)
-	}
-
-	return c.saveId(ctx, cr, id)
-}
-
-func (c *connector) ServicePlanName(cr *apisv1beta1.ServiceManager) string {
-	if cr.Spec.ForProvider.PlanName != "" {
-		return cr.Spec.ForProvider.PlanName
-	}
-	return apisv1beta1.DefaultPlanName
-}
-
-func (c *connector) saveId(ctx context.Context, cr *apisv1beta1.ServiceManager, id string) error {
-	cr.Status.AtProvider.DataSourceLookup = &apisv1beta1.DataSourceLookup{
-		ServiceManagerPlanID: id,
-	}
-	if err := c.kube.Status().Update(ctx, cr); err != nil {
-		return errors.Wrap(err, errUpdateStatus)
-	}
-	return nil
 }
 
 type external struct {
@@ -369,11 +317,11 @@ func (c *external) setStatus(ctx context.Context, status sm.ResourcesStatus, cr 
 	cr.Status.AtProvider.ServiceInstanceID = status.InstanceID
 	cr.Status.AtProvider.ServiceBindingID = status.BindingID
 
-	// Workaround for #941: self-heal a stale plan ID in status. An upgraded
-	// v1alpha1 SM lost dataSourceLookup and re-resolved the flipped default plan
-	// (#925) into status. Overwrite it with the observed live plan. For v1beta1
-	// these already match, so this is a no-op.
-	if cr.Status.AtProvider.DataSourceLookup != nil && status.ObservedPlanID != "" {
+	// Record the live plan ID so healExternalName can filter on it.
+	if status.ObservedPlanID != "" {
+		if cr.Status.AtProvider.DataSourceLookup == nil {
+			cr.Status.AtProvider.DataSourceLookup = &apisv1beta1.DataSourceLookup{}
+		}
 		cr.Status.AtProvider.DataSourceLookup.ServiceManagerPlanID = status.ObservedPlanID
 	}
 	// Unfortunately we need to update the CR status manually here, because the reconciler will drop the change otherwise

--- a/internal/controller/account/servicemanager/servicemanager_test.go
+++ b/internal/controller/account/servicemanager/servicemanager_test.go
@@ -30,9 +30,8 @@ var (
 
 func TestConnect_ResourceTracking(t *testing.T) {
 	type fields struct {
-		newPlanIdInitializerFn func(ctx context.Context, cr *apisv1beta1.ServiceManager) (ServiceManagerPlanIdInitializer, error)
-		newClientInitalizerFn  func() sm.ITfClientInitializer
-		resourcetracker        *testutils.ResourceTrackerMock
+		newClientInitalizerFn func() sm.ITfClientInitializer
+		resourcetracker       *testutils.ResourceTrackerMock
 	}
 	type args struct {
 		mg resource.Managed
@@ -53,9 +52,6 @@ func TestConnect_ResourceTracking(t *testing.T) {
 			reason: "should return an error if tracking fails",
 			fields: fields{
 				resourcetracker: testutils.NewResourceTrackerMockWithError(errTracking),
-				newPlanIdInitializerFn: func(ctx context.Context, cr *apisv1beta1.ServiceManager) (ServiceManagerPlanIdInitializer, error) {
-					return &PlanIdInitializerMock{}, nil
-				},
 				newClientInitalizerFn: func() sm.ITfClientInitializer {
 					return &TfClientInitializerMock{}
 				},
@@ -85,9 +81,6 @@ func TestConnect_ResourceTracking(t *testing.T) {
 			reason: "should call Track before initializer runs",
 			fields: fields{
 				resourcetracker: testutils.NewResourceTrackerMock(),
-				newPlanIdInitializerFn: func(ctx context.Context, cr *apisv1beta1.ServiceManager) (ServiceManagerPlanIdInitializer, error) {
-					return &PlanIdInitializerMock{}, nil
-				},
 				newClientInitalizerFn: func() sm.ITfClientInitializer {
 					return &TfClientInitializerMock{}
 				},
@@ -118,10 +111,9 @@ func TestConnect_ResourceTracking(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			c := connector{
-				kube:                   &test.MockClient{},
-				resourcetracker:        tc.fields.resourcetracker,
-				newPlanIdInitializerFn: tc.fields.newPlanIdInitializerFn,
-				newClientInitalizerFn:  tc.fields.newClientInitalizerFn,
+				kube:                  &test.MockClient{},
+				resourcetracker:       tc.fields.resourcetracker,
+				newClientInitalizerFn: tc.fields.newClientInitalizerFn,
 			}
 
 			_, err := c.Connect(context.Background(), tc.args.mg)
@@ -682,23 +674,6 @@ func (t *TfClientInitializerMock) ConnectResources(ctx context.Context, cr *apis
 	return &TfClientFake{}, nil
 }
 
-var _ ServiceManagerPlanIdInitializer = &PlanIdInitializerMock{}
-
-type PlanIdInitializerMock struct {
-	planID string
-	err    error
-}
-
-func (p *PlanIdInitializerMock) ServiceManagerPlanIDByName(ctx context.Context, subaccountId string, servicePlanName string) (string, error) {
-	if p.err != nil {
-		return "", p.err
-	}
-	if p.planID != "" {
-		return p.planID, nil
-	}
-	return "default-plan-id", nil
-}
-
 // ====================================================================================
 // Test Utilities
 // ====================================================================================
@@ -774,7 +749,6 @@ func (t *TfClientFake) DeleteResources(ctx context.Context, cr *apisv1beta1.Serv
 }
 
 func TestServicePlanName(t *testing.T) {
-	c := &connector{}
 	cases := map[string]struct {
 		planName string
 		want     string
@@ -792,9 +766,9 @@ func TestServicePlanName(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			cr := NewServiceManager("test")
 			cr.Spec.ForProvider.PlanName = tc.planName
-			got := c.ServicePlanName(cr)
+			got := sm.PlanNameOrDefault(cr)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
-				t.Errorf("ServicePlanName() mismatch (-want +got):\n%s", diff)
+				t.Errorf("PlanNameOrDefault() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/internal/controller/account/servicemanager/zz_setup.go
+++ b/internal/controller/account/servicemanager/zz_setup.go
@@ -38,16 +38,6 @@ func Setup(mgr ctrl.Manager, o internalopts.CrossplaneOptions) error {
 				newServiceFn:    btp.NewBTPClient,
 				resourcetracker: resourcetracker,
 
-				newPlanIdInitializerFn: func(ctx context.Context, cr *apisv1beta1.ServiceManager) (ServiceManagerPlanIdInitializer, error) {
-					btpclient, err := providerconfig.CreateClient(ctx, cr, mgr.GetClient(), usage, btp.NewBTPClient, resourcetracker)
-					if err != nil {
-						return nil, err
-					}
-
-					smInstanceClient := servicemanager.NewServiceManagerInstanceProxyClient(btpclient.AccountsServiceClient)
-					return smInstanceClient, nil
-				},
-
 				newClientInitalizerFn: func() servicemanager.ITfClientInitializer {
 					return servicemanager.NewServiceManagerTfClient(
 						tfclient.NewInternalTfConnector(mgr.GetClient(), "btp_subaccount_service_instance", apisv1alpha1.SubaccountServiceInstance_GroupVersionKind, false, nil),

--- a/test/upgrade/servicemanager_planname_upgrade_test.go
+++ b/test/upgrade/servicemanager_planname_upgrade_test.go
@@ -74,6 +74,11 @@ func Test_ServiceManager_PlanName_Upgrade(t *testing.T) {
 				}
 				assertServiceManagerV1beta1Healthy(t, smb, "before")
 
+				// Stash both pre-upgrade plan IDs; the post-upgrade hook asserts they
+				// are unchanged (the BTP service plan is immutable).
+				ctx = context.WithValue(ctx, preUpgradePlanIDKey(serviceManagerName), planIDOf(ctx, t, cfg, serviceManagerName))
+				ctx = context.WithValue(ctx, preUpgradePlanIDKey(serviceManagerV1beta1Name), planIDOf(ctx, t, cfg, serviceManagerV1beta1Name))
+
 				klog.V(4).Infof("Pre-upgrade ServiceManagers %q and %q are Synced and Ready", serviceManagerName, serviceManagerV1beta1Name)
 				return ctx
 			},
@@ -96,6 +101,7 @@ func Test_ServiceManager_PlanName_Upgrade(t *testing.T) {
 				// status.dataSourceLookup must hold the live instance plan. Read as
 				// v1beta1 (storage version) to see the full observation.
 				assertPlanMatchesLiveInstance(ctx, t, cfg, serviceManagerName)
+				assertPlanUnchanged(ctx, t, cfg, serviceManagerName)
 
 				// The v1beta1 SM must stay Synced+Ready and keep its explicit plan.
 				smb := &accountv1beta1.ServiceManager{}
@@ -104,6 +110,7 @@ func Test_ServiceManager_PlanName_Upgrade(t *testing.T) {
 				}
 				waitSyncedAndReady(ctx, t, cfg, smb, serviceManagerV1beta1Name, "v1beta1")
 				assertPlanMatchesLiveInstance(ctx, t, cfg, serviceManagerV1beta1Name)
+				assertPlanUnchanged(ctx, t, cfg, serviceManagerV1beta1Name)
 
 				klog.V(4).Infof("Post-upgrade: v1alpha1 %q and v1beta1 %q stayed Synced and Ready", serviceManagerName, serviceManagerV1beta1Name)
 				return ctx
@@ -159,6 +166,36 @@ func assertPlanMatchesLiveInstance(ctx context.Context, t *testing.T, cfg *envco
 	if sm.Status.AtProvider.Status != accountv1beta1.ServiceManagerBound {
 		t.Errorf("ServiceManager %q: status.atProvider.status = %q, want %q (should stay bound to its live instance)",
 			name, sm.Status.AtProvider.Status, accountv1beta1.ServiceManagerBound)
+	}
+}
+
+func preUpgradePlanIDKey(name string) string { return "preUpgradePlanID/" + name }
+
+// planIDOf returns the SM's persisted dataSourceLookup.serviceManagerPlanID, read
+// as v1beta1 (storage version). Fatal if absent.
+func planIDOf(ctx context.Context, t *testing.T, cfg *envconf.Config, name string) string {
+	t.Helper()
+	sm := &accountv1beta1.ServiceManager{}
+	if err := cfg.Client().Resources().Get(ctx, name, cfg.Namespace(), sm); err != nil {
+		t.Fatalf("Failed to read ServiceManager %q for plan-ID baseline: %v", name, err)
+	}
+	if sm.Status.AtProvider.DataSourceLookup == nil || sm.Status.AtProvider.DataSourceLookup.ServiceManagerPlanID == "" {
+		t.Fatalf("ServiceManager %q: no dataSourceLookup.serviceManagerPlanID before upgrade to baseline against", name)
+	}
+	return sm.Status.AtProvider.DataSourceLookup.ServiceManagerPlanID
+}
+
+// assertPlanUnchanged checks the plan ID survived the upgrade unchanged; the BTP
+// service plan is immutable, so a mismatch means the provider re-resolved and wrote
+// a different plan (#941 regression).
+func assertPlanUnchanged(ctx context.Context, t *testing.T, cfg *envconf.Config, name string) {
+	t.Helper()
+	before, ok := ctx.Value(preUpgradePlanIDKey(name)).(string)
+	if !ok || before == "" {
+		t.Fatalf("ServiceManager %q: no pre-upgrade plan ID stashed in ctx", name)
+	}
+	if after := planIDOf(ctx, t, cfg, name); after != before {
+		t.Errorf("ServiceManager %q: plan ID changed across upgrade (before %q, after %q)", name, before, after)
 	}
 }
 


### PR DESCRIPTION
Relates to #811. Supersedes the #941 workaround (#942).

## Why now

ServiceManager/ServiceInstance/ServiceBinding related E2E tests fail across all branches (including main). They time out when SM's `Connect` resolves the plan by minting a temporary admin binding via the accounts-service, which returns Code 20048 on a fresh subaccount. Connect fails before building the external client and writes no condition, so the SM stalls `Ready=Unknown`. Locally the connect retry succeeds after 4-6 attempts, so it seems to depend on the load.

Instead of making our custom service plan Id lookup work again, it was decided to utilize the now natively supported lookup using the TF resource.

## Implementation

`btp_subaccount_service_instance` takes `service_offering_name` + `serviceplan_name` directly since terraform-provider-btp v1.22.0 (see https://github.com/SAP/crossplane-provider-btp/discussions/647). `serviceInstanceCr` now forwards those instead of the self-resolved `serviceplan_id`.

## Removes the #941 regression at the root

#942 added two workarounds: a `resourcesUpToDate` guard reporting up-to-date on a plan-only diff, and a `setStatus` self-heal rewriting a stale plan ID. Both existed only because the SM re-resolved a plan and could land on the flipped #925 default after a v1alpha1 upgrade. No self-resolution means no wrong ID, so both are gone. `setStatus` still records the observed plan ID for `healExternalName`.

## Upgrade test

`Test_ServiceManager_PlanName_Upgrade` gated both API versions on Synced+Ready across v1.13.0 -> local, catching a plan flip BTP *rejects*. Added `assertPlanUnchanged`: stash each plan ID pre-upgrade, assert it is identical post-upgrade. The plan is immutable in BTP, so it must not change - this also catches a flip the provider *persists* without a rejected update, which the Synced gate alone misses.