### PR TITLE
test(e2e): provision servicemanager fixtures as v1beta1

### DIFF
--- a/test/e2e/testdata/crs/servicebinding/env/servicemanager.yaml
+++ b/test/e2e/testdata/crs/servicebinding/env/servicemanager.yaml
@@ -1,4 +1,4 @@
-apiVersion: account.btp.sap.crossplane.io/v1alpha1
+apiVersion: account.btp.sap.crossplane.io/v1beta1
 kind: ServiceManager
 metadata:
   name: e2e-sm-servicebinding

--- a/test/e2e/testdata/crs/servicebinding/rotation-env/servicemanager.yaml
+++ b/test/e2e/testdata/crs/servicebinding/rotation-env/servicemanager.yaml
@@ -1,4 +1,4 @@
-apiVersion: account.btp.sap.crossplane.io/v1alpha1
+apiVersion: account.btp.sap.crossplane.io/v1beta1
 kind: ServiceManager
 metadata:
   name: e2e-sm-servicebinding-rot

--- a/test/e2e/testdata/crs/servicebinding/secretformat-env/servicemanager.yaml
+++ b/test/e2e/testdata/crs/servicebinding/secretformat-env/servicemanager.yaml
@@ -1,4 +1,4 @@
-apiVersion: account.btp.sap.crossplane.io/v1alpha1
+apiVersion: account.btp.sap.crossplane.io/v1beta1
 kind: ServiceManager
 metadata:
   name: e2e-sm-servicebinding-fmt

--- a/test/e2e/testdata/crs/serviceinstance/servicemanager.yaml
+++ b/test/e2e/testdata/crs/serviceinstance/servicemanager.yaml
@@ -1,4 +1,4 @@
-apiVersion: account.btp.sap.crossplane.io/v1alpha1
+apiVersion: account.btp.sap.crossplane.io/v1beta1
 kind: ServiceManager
 metadata:
   name: e2e-sm-serviceinstance

--- a/test/e2e/testdata/crs/serviceinstance_import/servicemanager.yaml
+++ b/test/e2e/testdata/crs/serviceinstance_import/servicemanager.yaml
@@ -1,4 +1,4 @@
-apiVersion: account.btp.sap.crossplane.io/v1alpha1
+apiVersion: account.btp.sap.crossplane.io/v1beta1
 kind: ServiceManager
 metadata:
   name: e2e-sm-serviceinstance

--- a/test/e2e/testdata/crs/serviceinstance_paramupdate/servicemanager.yaml
+++ b/test/e2e/testdata/crs/serviceinstance_paramupdate/servicemanager.yaml
@@ -1,4 +1,4 @@
-apiVersion: account.btp.sap.crossplane.io/v1alpha1
+apiVersion: account.btp.sap.crossplane.io/v1beta1
 kind: ServiceManager
 metadata:
   name: e2e-sm-si-paramupdate

--- a/test/e2e/testdata/crs/servicemanager/create_flow/services.yaml
+++ b/test/e2e/testdata/crs/servicemanager/create_flow/services.yaml
@@ -1,4 +1,4 @@
-apiVersion: account.btp.sap.crossplane.io/v1alpha1
+apiVersion: account.btp.sap.crossplane.io/v1beta1
 kind: ServiceManager
 metadata:
   name: e2e-sm-servicemanager


### PR DESCRIPTION
## Problem

Six E2E tests time out with `ServiceManager` stuck at `Ready=Unknown`:
- `TestServiceManagerCreationFlow`
- `TestServiceInstance_CreationFlow`
- `TestServiceInstanceImportFlow`
- `TestServiceInstance_ParameterUpdate`
- `TestServiceBinding_CreationFlow`
- `TestServiceBinding_SecretFormatSAPKubernetes`

All six use a `v1alpha1` `ServiceManager`. Passing SM tests use `v1beta1`. It barely reproduces locally and only shows under CI's parallel load.

## Root cause

Every planId resolution mints a temporary admin binding (`POST /accounts/v1/subaccounts/{guid}/serviceManagementBinding`), a subaccount-scoped singleton, then deletes it. `ServiceManager` skips this once `IsInitialized` sees a resolved plan in status (`DataSourceLookup`). On `v1beta1` that flag persists, so the mint runs once. On `v1alpha1` it does not stick, so `Connect` re-mints every reconcile. Under CI's parallel load a re-mint collides with a still-open binding on the same subaccount, gets accounts-service Code 20048 ("binding already exists"), and stalls `Ready`.

The `v1beta1` flip removes the repeated mint, so the collision window closes. It does not remove the race itself. `ServiceInstance`, `ServiceBinding`, and `CloudManagement` reach the same singleton through `EnsureSemanticLookuper`. A `v1beta1` SM plus other resources in one subaccount can still collide, just far less often.

## What this PR does

Flip the seven affected e2e fixtures from `v1alpha1` to `v1beta1`. YAML only, no provider code.

This makes the collision unlikely enough to unblock CI. It is a workaround, not a fix for the underlying race.

## Follow-up

#976: Investigate why the plan flag does not persist on `v1alpha1` and decide required fix.
