### PR TITLE
fix(servicebinding): patch metadata on create to avoid rotation deadlock

### DIFF
--- a/internal/controller/account/servicebinding/servicebinding.go
+++ b/internal/controller/account/servicebinding/servicebinding.go
@@ -243,11 +243,13 @@ func (e *external) Create(ctx context.Context, mg resource.Managed) (managed.Ext
 		return managed.ExternalCreation{}, errors.Wrap(err, errCreateBinding)
 	}
 
+	// Persist via a MergeFrom patch rather than Update: the patch can't 409 on a
+	// stale resourceVersion, which would otherwise fail Create() and deadlock the
+	// resource with "cannot determine creation result".
+	base := cr.DeepCopy()
 	meta.SetExternalName(cr, externalName)
 	meta.RemoveAnnotations(cr, servicebindingclient.ForceRotationKey)
-
-	// Call the kube client to update the external-name and force-rotation annotations
-	if err := e.kube.Update(ctx, cr); err != nil {
+	if err := e.kube.Patch(ctx, cr, kubeclient.MergeFrom(base)); err != nil {
 		return managed.ExternalCreation{}, errors.Wrap(err, errCreateBinding)
 	}
 

--- a/internal/controller/account/servicebinding/servicebinding_test.go
+++ b/internal/controller/account/servicebinding/servicebinding_test.go
@@ -1256,7 +1256,7 @@ func TestCreate(t *testing.T) {
 				},
 				keyRotator: &MockKeyRotator{},
 				kube: &test.MockClient{
-					MockUpdate: test.NewMockUpdateFn(nil),
+					MockPatch: test.NewMockPatchFn(nil),
 				},
 			},
 			args: args{
@@ -1331,6 +1331,64 @@ func TestCreate(t *testing.T) {
 						// Other fields remain as they were
 						cr.Status.AtProvider.CreatedDate = nil
 						cr.Status.AtProvider.LastModified = nil
+					},
+				),
+			},
+		},
+		"SuccessRemovesForceRotationAnnotation": {
+			// Regression test for the rotation create-deadlock: the metadata persist
+			// must set external-name and remove the force-rotation annotation.
+			reason: "should set external-name and remove the force-rotation annotation via patch",
+			fields: fields{
+				clientFactory: &MockServiceBindingClientFactory{
+					Client: &MockServiceBindingClient{
+						creation: managed.ExternalCreation{
+							ConnectionDetails: managed.ConnectionDetails{
+								"test-key": []byte("test-value"),
+							},
+						},
+					},
+				},
+				keyRotator: &MockKeyRotator{},
+				kube: &test.MockClient{
+					// The removal must serialize as an explicit null; a marshalled
+					// Update would drop the key and leave the annotation set.
+					MockPatch: func(_ context.Context, obj kubeclient.Object, p kubeclient.Patch, _ ...kubeclient.PatchOption) error {
+						data, err := p.Data(obj)
+						if err != nil {
+							t.Fatalf("patch data: %v", err)
+						}
+						if !strings.Contains(string(data), `"`+servicebindingclient.ForceRotationKey+`":null`) {
+							t.Errorf("patch must delete %q via null, got: %s", servicebindingclient.ForceRotationKey, data)
+						}
+						return nil
+					},
+				},
+			},
+			args: args{
+				mg: expectedServiceBinding(
+					withMetadata("", map[string]string{servicebindingclient.ForceRotationKey: "true"}),
+					func(cr *v1alpha1.ServiceBinding) {
+						cr.Spec.ForProvider.Name = "test-binding"
+						cr.Spec.Rotation = &v1alpha1.RotationParameters{
+							Frequency: &providerv1alpha1.Duration{Duration: time.Hour * 24},
+						}
+					},
+				),
+			},
+			want: want{
+				err: nil,
+				cr: expectedServiceBinding(
+					withMetadata("12345678-1234-5678-9abc-123456789012", map[string]string{
+						"crossplane.io/external-name": "12345678-1234-5678-9abc-123456789012",
+						// ForceRotationKey must be gone after the patch.
+					}),
+					withConditions(xpv1.Creating()),
+					func(cr *v1alpha1.ServiceBinding) {
+						cr.Spec.ForProvider.Name = "test-binding"
+						cr.Spec.Rotation = &v1alpha1.RotationParameters{
+							Frequency: &providerv1alpha1.Duration{Duration: time.Hour * 24},
+						}
 					},
 				),
 			},


### PR DESCRIPTION
## What

In `ServiceBinding`'s `Create()`, the persist of `external-name` + removal of the force-rotation annotation was a bare `e.kube.Update(ctx, cr)`. This changes it to a non-optimistic `MergeFrom` patch.

## Why

The external binding is already created in BTP by the time we persist metadata. The `Update` carries the CR's `resourceVersion` and fails with a 409 whenever the CR was modified concurrently — which is common under rotation, since rotation mutates the CR frequently. When that write fails, `Create()` returns an error, so crossplane-runtime never stamps `external-create-succeeded`. `external-create-pending` stays newest and the resource deadlocks with:

> cannot determine creation result - remove the crossplane.io/external-create-pending annotation if it is safe to proceed

A `MergeFrom` patch:
- **Cannot 409** — it's a server-side blind merge with no optimistic lock, eliminating the conflict class rather than retrying through it.
- **Correctly removes the annotation** — diffing from a `base` snapshot serializes the deletion as an explicit JSON `null`; a marshalled `Update` would omit the key, which a merge reads as "leave untouched".
- **Only touches the two-field diff**, so it won't clobber fields a concurrent writer changed.

## Testing

- Updated `SuccessWithoutRotation` to mock `Patch` instead of `Update`.
- Added `SuccessRemovesForceRotationAnnotation`: inspects the patch bytes and asserts the force-rotation annotation is deleted via `":null"`, and that `external-name` is set. This guards against a revert to `Update` (which wouldn't emit the null).
- `go vet` clean; all `TestCreate` cases pass.

## Notes for reviewers

- Recovery on a stuck resource in the field: `kubectl annotate servicebinding <name> crossplane.io/external-create-pending-` (do **not** delete/recreate the external binding — it's healthy).
