### PR TITLE
[Backport release/v1_10_x] test(e2e): provision servicemanager fixtures as v1beta1

### DIFF
--- a/test/e2e/testdata/crs/servicebinding/env/servicemanager.yaml
+++ b/test/e2e/testdata/crs/servicebinding/env/servicemanager.yaml
@@ -1,4 +1,4 @@
-apiVersion: account.btp.sap.crossplane.io/v1alpha1
+apiVersion: account.btp.sap.crossplane.io/v1beta1
 kind: ServiceManager
 metadata:
   name: e2e-sm-servicebinding

--- a/test/e2e/testdata/crs/servicebinding/rotation-env/servicemanager.yaml
+++ b/test/e2e/testdata/crs/servicebinding/rotation-env/servicemanager.yaml
@@ -1,4 +1,4 @@
-apiVersion: account.btp.sap.crossplane.io/v1alpha1
+apiVersion: account.btp.sap.crossplane.io/v1beta1
 kind: ServiceManager
 metadata:
   name: e2e-sm-servicebinding-rot

--- a/test/e2e/testdata/crs/serviceinstance/servicemanager.yaml
+++ b/test/e2e/testdata/crs/serviceinstance/servicemanager.yaml
@@ -1,4 +1,4 @@
-apiVersion: account.btp.sap.crossplane.io/v1alpha1
+apiVersion: account.btp.sap.crossplane.io/v1beta1
 kind: ServiceManager
 metadata:
   name: e2e-sm-serviceinstance

--- a/test/e2e/testdata/crs/serviceinstance_import/servicemanager.yaml
+++ b/test/e2e/testdata/crs/serviceinstance_import/servicemanager.yaml
@@ -1,4 +1,4 @@
-apiVersion: account.btp.sap.crossplane.io/v1alpha1
+apiVersion: account.btp.sap.crossplane.io/v1beta1
 kind: ServiceManager
 metadata:
   name: e2e-sm-serviceinstance

--- a/test/e2e/testdata/crs/servicemanager/create_flow/services.yaml
+++ b/test/e2e/testdata/crs/servicemanager/create_flow/services.yaml
@@ -1,4 +1,4 @@
-apiVersion: account.btp.sap.crossplane.io/v1alpha1
+apiVersion: account.btp.sap.crossplane.io/v1beta1
 kind: ServiceManager
 metadata:
   name: e2e-sm-servicemanager


### PR DESCRIPTION
Backport of #973 to `release/v1_10_x`.

Bumps the `ServiceManager` e2e fixtures from `v1alpha1` to `v1beta1`. Applied to 5 of the 7 files in #973 - `servicebinding/secretformat-env/servicemanager.yaml` and `serviceinstance_paramupdate/servicemanager.yaml` don't exist on this branch (those test scenarios weren't backported), so they're skipped.