### PR TITLE
test(e2e): also use v1beta1 in Long E2E tests 

### DIFF
--- a/examples/kyma-on-steroids.yaml
+++ b/examples/kyma-on-steroids.yaml
@@ -1,4 +1,4 @@
-apiVersion: account.btp.sap.crossplane.io/v1alpha1
+apiVersion: account.btp.sap.crossplane.io/v1beta1
 kind: ServiceManager
 metadata:
   name: servicemanager-test

--- a/examples/kyma.yaml
+++ b/examples/kyma.yaml
@@ -11,7 +11,7 @@ spec:
     subaccountAdmins:
       - <EMAIL>
 ---
-apiVersion: account.btp.sap.crossplane.io/v1alpha1
+apiVersion: account.btp.sap.crossplane.io/v1beta1
 kind: ServiceManager
 metadata:
   name: servicemanager-test

--- a/test/e2e/testdata/crs/kyma_env/services.yaml
+++ b/test/e2e/testdata/crs/kyma_env/services.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: account.btp.sap.crossplane.io/v1alpha1
+apiVersion: account.btp.sap.crossplane.io/v1beta1
 kind: ServiceManager
 metadata:
   name: kyma-service-manager


### PR DESCRIPTION
Switch to v1beta1 was missed for Long E2E test `TestKymaEnvironment` in https://github.com/SAP/crossplane-provider-btp/pull/973.

Additionally I also bumped the kyma examples to use the v1beta1 version.