### PR TITLE
test(upgrade): change servicemanager fixture to v1beta1

### DIFF
--- a/test/upgrade/testdata/baseCRs/servicebinding/servicemanager.yaml
+++ b/test/upgrade/testdata/baseCRs/servicebinding/servicemanager.yaml
@@ -1,4 +1,4 @@
-apiVersion: account.btp.sap.crossplane.io/v1alpha1
+apiVersion: account.btp.sap.crossplane.io/v1beta1
 kind: ServiceManager
 metadata:
   name: upgrade-test-sb-sm


### PR DESCRIPTION
Change missing `ServiceManager` CR to `v1beta1` to fix failing upgrade tests ([run 34506859939](https://github.com/SAP/crossplane-provider-btp/actions/runs/34506859939)).

This one was missed in #973 and #980.